### PR TITLE
Fix race condition when mef_eline consistency runs at the same time as creation of an evc

### DIFF
--- a/main.py
+++ b/main.py
@@ -58,7 +58,7 @@ class Main(KytosNApp):
         """Execute once when the napp is running."""
         for circuit in tuple(self.circuits.values()):
             if circuit.is_enabled() and not circuit.is_active():
-                with evc.lock:
+                with circuit.lock:
                     circuit.deploy()
 
     def shutdown(self):

--- a/main.py
+++ b/main.py
@@ -58,7 +58,8 @@ class Main(KytosNApp):
         """Execute once when the napp is running."""
         for circuit in tuple(self.circuits.values()):
             if circuit.is_enabled() and not circuit.is_active():
-                circuit.deploy()
+                with evc.lock:
+                    circuit.deploy()
 
     def shutdown(self):
         """Execute when your napp is unloaded.
@@ -162,7 +163,8 @@ class Main(KytosNApp):
 
         # Circuit has no schedule, deploy now
         if not evc.circuit_scheduler:
-            evc.deploy()
+            with evc.lock:
+                evc.deploy()
 
         # Notify users
         event = KytosEvent(name='kytos.mef_eline.created',
@@ -216,11 +218,13 @@ class Main(KytosNApp):
             if enable is False:  # disable if active
                 evc.remove()
             elif path is not None:  # redeploy if active
-                evc.remove()
-                evc.deploy()
+                with evc.lock:
+                    evc.remove()
+                    evc.deploy()
         else:
             if enable is True:  # enable if inactive
-                evc.deploy()
+                with evc.lock:
+                    evc.deploy()
         result = {evc.id: evc.as_dict()}
         status = 200
 

--- a/main.py
+++ b/main.py
@@ -216,7 +216,8 @@ class Main(KytosNApp):
 
         if evc.is_active():
             if enable is False:  # disable if active
-                evc.remove()
+                with evc.lock:
+                    evc.remove()
             elif path is not None:  # redeploy if active
                 with evc.lock:
                     evc.remove()


### PR DESCRIPTION
This PR fixes #22.

Description of the change
-----------------------------
A fix was implemented to prevent race conditions when mef_eline consistency check routine is run at the same time as the creation of an evc: both of them will call evc.deploy() and it may result in duplicated flows being created for the same evc. I've run the unit tests and all of them are passing after the change. I've also run the end-to-end tests, specially the one created to validate this behavior (as documented in #22) which was run 10 times, and they are all passing (except the ones not related to this PR).

Release notes
---------------
- Fix a race condition when mef_eline's consistency check runs at the same time of the creation of a evc.