### PR TITLE
Roolback deployment when flow_manager fails.

### DIFF
--- a/exceptions.py
+++ b/exceptions.py
@@ -11,3 +11,7 @@ class EVCException(MEFELineException):
 
 class ValidationException(EVCException):
     """Exception for validation errors."""
+
+
+class FlowModException(MEFELineException):
+    """Exception for FlowMod errors."""

--- a/tests/unit/models/test_link_protection.py
+++ b/tests/unit/models/test_link_protection.py
@@ -1,7 +1,7 @@
 """Module to test the LinkProtection class."""
 import sys
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from unittest.mock import Mock
 
 from kytos.core.common import EntityStatus
@@ -96,9 +96,12 @@ class TestLinkProtection(TestCase):  # pylint: disable=too-many-public-methods
     @patch('napps.kytos.mef_eline.models.Path.status', EntityStatus.UP)
     def test_deploy_to_case_2(self, install_uni_flows_mocked,
                               install_nni_flows_mocked,
-                              deploy_mocked, *_):
+                              deploy_mocked, _, requests_mock):
         """Test deploy with all links up."""
         deploy_mocked.return_value = True
+        response = MagicMock()
+        response.status_code = 201
+        requests_mock.return_value = response
 
         primary_path = [
                  get_link_mocked(status=EntityStatus.UP),

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1161,7 +1161,11 @@ class TestMain(TestCase):
     @patch('napps.kytos.mef_eline.main.EVC.as_dict')
     def test_update_circuit(self, *args):
         """Test update a circuit circuit."""
-        (evc_as_dict_mock, uni_from_dict_mock, evc_deploy, *mocks) = args
+        (evc_as_dict_mock, uni_from_dict_mock, evc_deploy,
+         *mocks, requests_mock) = args
+        response = MagicMock()
+        response.status_code = 201
+        requests_mock.return_value = response
 
         for mock in mocks:
             mock.return_value = True


### PR DESCRIPTION
Fixes #26 

Description of the change
----------------------------

If flow_manager returns an error code, stop the deployment and uninstall already installed flows, keeping the EVC inactive.

Tests
-----

New unit tests were created for this new behavior and old tests needed to be slightly modified.