### PR TITLE
Include flow priority

### DIFF
--- a/main.py
+++ b/main.py
@@ -210,7 +210,7 @@ class Main(KytosNApp):
             raise UnsupportedMediaType(result)
 
         try:
-            enable, path = \
+            enable, redeploy = \
                 evc.update(**self._evc_dict_with_instances(data))
         except ValueError as exception:
             log.error(exception)
@@ -221,7 +221,7 @@ class Main(KytosNApp):
             if enable is False:  # disable if active
                 with evc.lock:
                     evc.remove()
-            elif path is not None:  # redeploy if active
+            elif redeploy is not None:  # redeploy if active
                 with evc.lock:
                     evc.remove()
                     evc.deploy()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -25,6 +25,7 @@ class TestMain(TestCase):
         # Decorators have to be patched before the methods that are
         # decorated with them are imported.
         patch('kytos.core.helpers.run_on_thread', lambda x: x).start()
+        # pylint: disable=import-outside-toplevel
         from napps.kytos.mef_eline.main import Main
 
         self.addCleanup(patch.stopall)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -25,7 +25,6 @@ class TestMain(TestCase):
         # Decorators have to be patched before the methods that are
         # decorated with them are imported.
         patch('kytos.core.helpers.run_on_thread', lambda x: x).start()
-        # pylint: disable=import-outside-toplevel
         from napps.kytos.mef_eline.main import Main
 
         self.addCleanup(patch.stopall)


### PR DESCRIPTION
Fixes #28

Description of the change
=================

Priority was not being used in the flows. Now they
are used if defined, and the EVCs are redeployed if
the priority changes.

Main changes
---------------

- priority default value changed from 0 to -1 (allowing priority 0 to be used);
- if `priority > -1` then a priority field is included in the flow mod;
- if `priority == -1` then no priority is included in the flow mod and it will be the switch's default.
- if `priority` is updated, then the EVC is redeployed. 