### PR TITLE
Create a list of read only attributes of an EVC

### DIFF
--- a/models.py
+++ b/models.py
@@ -153,7 +153,11 @@ class DynamicPathManager:
 class EVCBase(GenericEntity):
     """Class to represent a circuit."""
 
-    unique_attributes = ['name', 'uni_a', 'uni_z']
+    read_only_attributes = [
+        'creation_time', 'active', 'current_path',
+        'name', 'uni_a', 'uni_z'
+    ]
+    required_attributes = ['name', 'uni_a', 'uni_z']
 
     def __init__(self, controller, **kwargs):
         """Create an EVC instance with the provided parameters.
@@ -267,8 +271,8 @@ class EVCBase(GenericEntity):
         """
         enable, redeploy = (None, None)
         for attribute, value in kwargs.items():
-            if attribute in self.unique_attributes:
-                raise ValueError(f'{attribute} can\'t be be updated.')
+            if attribute in self.read_only_attributes:
+                raise ValueError(f'{attribute} can\'t be updated.')
             if hasattr(self, attribute):
                 if attribute in ('enable', 'enabled'):
                     if value:
@@ -276,11 +280,6 @@ class EVCBase(GenericEntity):
                     else:
                         self.disable()
                     enable = value
-                elif attribute in ('active', 'activate'):
-                    if value:
-                        self.activate()
-                    else:
-                        self.deactivate()
                 else:
                     setattr(self, attribute, value)
                     if 'path' in attribute or 'priority' in attribute:
@@ -304,7 +303,7 @@ class EVCBase(GenericEntity):
             ValueError: message with error detail.
 
         """
-        for attribute in self.unique_attributes:
+        for attribute in self.required_attributes:
 
             if attribute not in kwargs:
                 raise ValueError(f'{attribute} is required.')

--- a/tests/unit/models/test_evc_base.py
+++ b/tests/unit/models/test_evc_base.py
@@ -70,56 +70,31 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
             EVC(**attributes)
         self.assertEqual(str(handle_error.exception), error_message)
 
-    def test_update_name(self):
-        """Test if raises and error when trying to update the name."""
+    def test_update_read_only(self):
+        """Test if raises an error when trying to update read only attr."""
         attributes = {
             "controller": get_controller_mock(),
             "name": "circuit_name",
             "uni_a": get_uni_mocked(is_valid=True),
             "uni_z": get_uni_mocked(is_valid=True)
         }
-        update_dict = {
-            "name": "circuit_name_2"
-        }
-        error_message = "name can't be be updated."
-        with self.assertRaises(ValueError) as handle_error:
-            evc = EVC(**attributes)
-            evc.update(**update_dict)
-        self.assertEqual(str(handle_error.exception), error_message)
+        update_attr = [
+            ("name", "circuit_name_2"),
+            ("uni_a", get_uni_mocked(is_valid=True)),
+            ("uni_z", get_uni_mocked(is_valid=True)),
+            ("active", True),
+            ("current_path", []),
+            ("creation_time", "date")
+        ]
 
-    def test_update_uni_a(self):
-        """Test if raises and error when trying to update the uni_a."""
-        attributes = {
-            "controller": get_controller_mock(),
-            "name": "circuit_name",
-            "uni_a": get_uni_mocked(is_valid=True),
-            "uni_z": get_uni_mocked(is_valid=True)
-        }
-        update_dict = {
-            "uni_a": get_uni_mocked(is_valid=True)
-        }
-        error_message = "uni_a can't be be updated."
-        with self.assertRaises(ValueError) as handle_error:
-            evc = EVC(**attributes)
-            evc.update(**update_dict)
-        self.assertEqual(str(handle_error.exception), error_message)
-
-    def test_update_uni_z(self):
-        """Test if raises and error when trying to update the uni_z."""
-        attributes = {
-            "controller": get_controller_mock(),
-            "name": "circuit_name",
-            "uni_a": get_uni_mocked(is_valid=True),
-            "uni_z": get_uni_mocked(is_valid=True)
-        }
-        update_dict = {
-            "uni_z": get_uni_mocked(is_valid=True)
-        }
-        error_message = "uni_z can't be be updated."
-        with self.assertRaises(ValueError) as handle_error:
-            evc = EVC(**attributes)
-            evc.update(**update_dict)
-        self.assertEqual(str(handle_error.exception), error_message)
+        for name, value in update_attr:
+            with self.subTest(name=name, value=value):
+                update_dict = {name: value}
+                error_message = f"{name} can't be updated."
+                with self.assertRaises(ValueError) as handle_error:
+                    evc = EVC(**attributes)
+                    evc.update(**update_dict)
+                self.assertEqual(str(handle_error.exception), error_message)
 
     @patch('napps.kytos.mef_eline.models.EVC.sync')
     def test_update_disable(self, _sync_mock):


### PR DESCRIPTION
The attributes on the list cannot be updated directly through the API.

Tests for the attributes that cannot be changed refactored using `unittest.subTest`.

Fixes #45, fixes #47