### PR TITLE
Redeploy EVC when queue_id is updated

### DIFF
--- a/main.py
+++ b/main.py
@@ -226,7 +226,6 @@ class Main(KytosNApp):
             log.debug('update result %s %s', exception, 400)
             raise BadRequest(str(exception))
 
-        log.info(f'enable: {enable}, redeploy: {redeploy}')
         if evc.is_active():
             if enable is False:  # disable if active
                 with evc.lock:

--- a/main.py
+++ b/main.py
@@ -226,6 +226,7 @@ class Main(KytosNApp):
             log.debug('update result %s %s', exception, 400)
             raise BadRequest(str(exception))
 
+        log.info(f'enable: {enable}, redeploy: {redeploy}')
         if evc.is_active():
             if enable is False:  # disable if active
                 with evc.lock:

--- a/models.py
+++ b/models.py
@@ -157,6 +157,10 @@ class EVCBase(GenericEntity):
         'creation_time', 'active', 'current_path',
         '_id', 'archived'
     ]
+    attributes_requiring_redeploy = [
+        'primary_path', 'backup_path', 'dynamic_backup_path', 'queue_id',
+        'priority'
+    ]
     required_attributes = ['name', 'uni_a', 'uni_z']
 
     def __init__(self, controller, **kwargs):
@@ -282,7 +286,7 @@ class EVCBase(GenericEntity):
                     enable = value
                 else:
                     setattr(self, attribute, value)
-                    if 'path' in attribute or 'priority' in attribute:
+                    if attribute in self.attributes_requiring_redeploy:
                         redeploy = value
             else:
                 raise ValueError(f'The attribute "{attribute}" is invalid.')

--- a/tests/unit/models/test_evc_base.py
+++ b/tests/unit/models/test_evc_base.py
@@ -112,6 +112,23 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         evc.update(**update_dict)
         self.assertIs(evc.is_enabled(), False)
 
+    @patch('napps.kytos.mef_eline.models.EVC.sync')
+    def test_update_queue(self, _sync_mock):
+        """Test if evc is set to redeploy."""
+        attributes = {
+            "controller": get_controller_mock(),
+            "name": "circuit_name",
+            "enable": True,
+            "uni_a": get_uni_mocked(is_valid=True),
+            "uni_z": get_uni_mocked(is_valid=True)
+        }
+        update_dict = {
+            "queue_id": 3
+        }
+        evc = EVC(**attributes)
+        _, redeploy = evc.update(**update_dict)
+        self.assertTrue(redeploy)
+
     def test_circuit_representation(self):
         """Test the method __repr__."""
         attributes = {


### PR DESCRIPTION
Fixes #37

When `queue_id` was updated, the EVC was not being
redeployed, so the queue was not been reflected in
the flows.

A list of EVC attributes requiring redeploy when updated
was created to make it easier to redeploy.
