### PR TITLE
On update, try to redeploy if EVC is enabled.

### DIFF
--- a/main.py
+++ b/main.py
@@ -235,7 +235,7 @@ class Main(KytosNApp):
                     evc.remove()
                     evc.deploy()
         else:
-            if enable is True:  # enable if inactive
+            if evc.is_enabled():  # enable if inactive
                 with evc.lock:
                     evc.deploy()
         result = {evc.id: evc.as_dict()}


### PR DESCRIPTION
Fixes #38

When EVC is `inactive`, it was redeployed on update only if the update is enabling it.
If the EVC was inactive due to an invalid primary path, an update on that path would not trigger redeploy
Now, redeploy is always called if the EVC is enabled.