### PR TITLE
Do not always redeploy EVCs on startup

### DIFF
--- a/kytos.json
+++ b/kytos.json
@@ -4,7 +4,7 @@
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
   "version": "2.5.1",
-  "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "kytos/storehouse"],
+  "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "kytos/storehouse", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],
   "url": "https://github.com/kytos/mef_eline.git"

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@
 
 NApp to provision circuits from user request.
 """
+import time
 from threading import Lock
 
 from flask import jsonify, request
@@ -54,14 +55,20 @@ class Main(KytosNApp):
         self._lock = Lock()
 
         self.execute_as_loop(settings.DEPLOY_EVCS_INTERVAL)
+        self.load_time = time.time()
         self.load_all_evcs()
 
     def execute(self):
         """Execute once when the napp is running."""
         for circuit in tuple(self.circuits.values()):
             if circuit.is_enabled() and not circuit.is_active():
-                with circuit.lock:
-                    circuit.deploy()
+                if circuit.check_traces():
+                    circuit.activate()
+                    circuit.sync()
+                else:
+                    running_for = time.time() - self.load_time
+                    if running_for > settings.WAIT_FOR_OLD_PATH:
+                        circuit.deploy()
 
     def shutdown(self):
         """Execute when your napp is unloaded.
@@ -592,7 +599,6 @@ class Main(KytosNApp):
         if evc.archived:
             return None
         evc.deactivate()
-        evc.current_path = Path([])
         evc.sync()
         self.circuits.setdefault(evc.id, evc)
         self.sched.add(evc)

--- a/models.py
+++ b/models.py
@@ -12,7 +12,6 @@ from kytos.core.exceptions import KytosNoTagAvailableError
 from kytos.core.helpers import get_time, now
 from kytos.core.interface import UNI
 from kytos.core.link import Link
-
 from napps.kytos.mef_eline import settings
 from napps.kytos.mef_eline.exceptions import FlowModException
 from napps.kytos.mef_eline.storehouse import StoreHouse

--- a/models.py
+++ b/models.py
@@ -12,6 +12,7 @@ from kytos.core.exceptions import KytosNoTagAvailableError
 from kytos.core.helpers import get_time, now
 from kytos.core.interface import UNI
 from kytos.core.link import Link
+
 from napps.kytos.mef_eline import settings
 from napps.kytos.mef_eline.exceptions import FlowModException
 from napps.kytos.mef_eline.storehouse import StoreHouse

--- a/requirements/run.in
+++ b/requirements/run.in
@@ -1,2 +1,3 @@
 apscheduler
 requests
+glom

--- a/settings.py
+++ b/settings.py
@@ -15,5 +15,8 @@ SDN_TRACE_CP_URL = 'http://localhost:8181/api/amlight/sdntrace_cp'
 # EVC consistency interval
 DEPLOY_EVCS_INTERVAL = 60
 
+# Time to wait for old path to become available
+WAIT_FOR_OLD_PATH = 5 * DEPLOY_EVCS_INTERVAL
+
 # Prefix this NApp has when using cookies
 COOKIE_PREFIX = 0xaa

--- a/settings.py
+++ b/settings.py
@@ -9,6 +9,9 @@ MANAGER_URL = 'http://localhost:8181/api/kytos/flow_manager/v2'
 # Base URL of the Pathfinder endpoint
 TOPOLOGY_URL = 'http://localhost:8181/api/kytos/topology/v3'
 
+# Base URL of SDN trace CP
+SDN_TRACE_CP_URL = 'http://localhost:8181/api/amlight/sdntrace_cp'
+
 # EVC consistency interval
 DEPLOY_EVCS_INTERVAL = 60
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ add-ignore = D105
 
 [isort]
 # The first party was necessary to fix travis build.
-known_first_party = kytos.core,tests
+known_first_party = kytos.core,tests,napps
 known_third_party = pyof
 # Ignoring tests because is adding napps path
 skip=tests

--- a/tests/unit/models/test_link_protection.py
+++ b/tests/unit/models/test_link_protection.py
@@ -196,6 +196,7 @@ class TestLinkProtection(TestCase):  # pylint: disable=too-many-public-methods
         evc = EVC(**attributes)
 
         evc.current_path = evc.primary_path
+        evc.activate()
         current_handle_link_down = evc.handle_link_down()
         self.assertEqual(deploy_mocked.call_count, 0)
         deploy_to_mocked.assert_called_once()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,36 @@
+"""Module to test the utls.py file."""
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from napps.kytos.mef_eline.utils import compare_endpoint_trace
+
+
+# pylint: disable=too-many-public-methods, too-many-lines
+class TestUtils(TestCase):
+    """Test utility functions."""
+
+    def test_compare_endpoint_trace(self):
+        """Test method compare_endpoint_trace"""
+
+        trace = {
+            "dpid": "1234",
+            "port": 2,
+            "vlan": 123
+        }
+
+        switch1 = MagicMock()
+        switch1.dpid = "1234"
+        switch2 = MagicMock()
+        switch2.dpid = "2345"
+
+        endpoint = MagicMock()
+        endpoint.port_number = 2
+        vlan = 123
+
+        for switch, expected in ((switch1, True), (switch2, False)):
+            with self.subTest(switch=switch, expected=expected):
+                endpoint.switch = switch
+                self.assertEqual(
+                    compare_endpoint_trace(endpoint, vlan, trace),
+                    expected
+                )

--- a/utils.py
+++ b/utils.py
@@ -7,3 +7,10 @@ def emit_event(controller, name, **kwargs):
     event_name = f'kytos/mef_eline.{name}'
     event = KytosEvent(name=event_name, content=kwargs)
     controller.buffers.app.put(event)
+
+
+def compare_endpoint_trace(endpoint, vlan, trace):
+    """Compare and endpoint with a trace step."""
+    return endpoint.switch.dpid == trace['dpid']\
+        and endpoint.port_number == trace['port']\
+        and vlan == trace['vlan']


### PR DESCRIPTION
Fixes #33 

Existing EVCs are loaded on Kytos startup, and were always redeployed, leading to some problems as described in the linked issue. Now, before trying to redeploy, it is checked if the old path the EVC used is still working. If it is, the EVC is marked as active and no further action is taken. If after a specific amount of time (configurable) the old path is not working, then the EVC is redeployed.