### PR TITLE
Fix boolean icons with swapped values

### DIFF
--- a/ui/k-info-panel/show_circuit.kytos
+++ b/ui/k-info-panel/show_circuit.kytos
@@ -18,8 +18,8 @@
             <template v-for="(column, cindex) in flags"> 
               <tr><th>{{cindex}}</th>
               <td>
-                <i class="material-icons" style="color:#c00000" v-if="column">close</i>
-                <i class="material-icons" style="color:green" v-else>done</i>
+                <i class="material-icons" style="color:green" v-if="column">done</i>
+                <i class="material-icons" style="color:#c00000" v-else>close</i>
               </td></tr>
             </template>
           </table>


### PR DESCRIPTION
Fix #70 
In circuit details, the flag icons are swapped (True are X, and False are Check).
Replaced the icons to the correct values.