### PR TITLE
Add red highlight for inactive circuits

### DIFF
--- a/ui/k-info-panel/list_connections.kytos
+++ b/ui/k-info-panel/list_connections.kytos
@@ -30,6 +30,7 @@
               </thead>
               <tbody>
                 <tr v-for="(row, rindex) in rowsOfPage"
+                  v-bind:class="{ inactive: !row['Active'] }"
                   @click="rowClicked(row['id'])">
                   <th scope="row" style="width: 45px">{{ rindex + 1 }}</th>
                   <template v-for="(column, cindex) in row"> 
@@ -302,6 +303,9 @@ module.exports = {
 .mef-table tbody tr:hover {
     color: #eee;
     background-color: #666;
+}
+.mef-table tbody tr.inactive {
+  background-color: #600000;
 }
 .mef-table-divisor {
   height: 190px;


### PR DESCRIPTION
fix #69 
For inactive circuits there must be something to call attention from the operator.
Added a red highlight for items that are marked as inactive circuit. 