### PR TITLE
Remove deprecated call for Link.use_tag

### DIFF
--- a/models.py
+++ b/models.py
@@ -45,7 +45,6 @@ class Path(list, GenericEntity):
         """Choose the VLANs to be used for the circuit."""
         for link in self:
             tag = link.get_next_available_tag()
-            link.use_tag(tag)
             link.add_metadata('s_vlan', tag)
 
     def make_vlans_available(self):


### PR DESCRIPTION
Fixes #79 

### Description of the change

This PR will remove the call for `Link.use_tag`, which is deprecated by Kytos core. mef_eline is also calling `Link.get_next_available_tag()`, which happens to do what `use_tag` was doing.


### Release notes

N/A