### PR TITLE
Add exception handler for remove_current_flows

### DIFF
--- a/models.py
+++ b/models.py
@@ -550,7 +550,11 @@ class EVCDeploy(EVCBase):
                  'cookie_mask': 18446744073709551615}
 
         for switch in switches:
-            self._send_flow_mods(switch, [match], 'delete')
+            try:
+                self._send_flow_mods(switch, [match], 'delete')
+            except FlowModException:
+                log.error(f'Error removing flows from switch {switch.id} for'
+                          f'EVC {self}')
 
         current_path.make_vlans_available()
         self.current_path = Path([])


### PR DESCRIPTION
Fixes #77 

### Description of the change

Added a exception handler for `remove_current_flows()`, which could raise a FlowModException if some of the switches in the current path lost connection or any other error from flow_manager.

### Release notes

N/A