### PR TITLE
Add feature to delete EVC

### DIFF
--- a/ui/k-info-panel/show_circuit.kytos
+++ b/ui/k-info-panel/show_circuit.kytos
@@ -104,7 +104,7 @@
               </div>
               <div class="modal-body">
                 <slot name="body">
-                  Delete circuit? 
+                  Delete EVC? 
                 </slot>
               </div>
               <div class="modal-footer">


### PR DESCRIPTION
Related to issue #89 

### Description of the change
In the UI the user can only create and list the circuits.
The user has to be able to delete the circuit in the UI.
A new button was added in circuit detail window to delete the circuit.
![image](https://user-images.githubusercontent.com/10867136/143927551-ce086a90-342f-4ed2-85ea-b12c4886263f.png)
A modal window will open for the user to confirm the delete action.
![image](https://user-images.githubusercontent.com/10867136/143927615-1a035623-12e9-4028-b50f-091fb4979286.png)
Upon confirming, the UI will return to the list of circuits.

### Release notes
- Add feature to mef_eline UI to delete circuit/EVC. 
