### PR TITLE
[Feature] Parametrized flow_manager `force` option for flow deletions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,14 @@ Changelog
 #########
 All notable changes to the MEF_ELine NApp will be documented in this file.
 
+[2.6.0] - 2021-05-28
+********************
+
+Added
+=====
+- Parametrized ``force`` option as ``True`` when removing flows for reliability
+
+
 [2.5.1] - 2021-05-28
 ********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "kytos/storehouse", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if 'bdist_wheel' in sys.argv:
 BASE_ENV = Path(os.environ.get('VIRTUAL_ENV', '/'))
 
 NAPP_NAME = 'mef_eline'
-NAPP_VERSION = '2.5.1'
+NAPP_VERSION = '2.6.1'
 
 # Kytos var folder
 VAR_PATH = BASE_ENV / 'var' / 'lib' / 'kytos'

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -101,7 +101,7 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         EVC._send_flow_mods(switch, flow_mods)
 
         expected_endpoint = f"{MANAGER_URL}/flows/{switch.id}"
-        expected_data = {"flows": flow_mods}
+        expected_data = {"flows": flow_mods, "force": False}
         self.assertEqual(requests_mock.post.call_count, 1)
         requests_mock.post.assert_called_once_with(expected_endpoint,
                                                    json=expected_data)
@@ -116,10 +116,10 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         requests_mock.post.return_value = response
 
         # pylint: disable=protected-access
-        EVC._send_flow_mods(switch, flow_mods, command='delete')
+        EVC._send_flow_mods(switch, flow_mods, command='delete', force=True)
 
         expected_endpoint = f"{MANAGER_URL}/delete/{switch.id}"
-        expected_data = {"flows": flow_mods}
+        expected_data = {"flows": flow_mods, "force": True}
         self.assertEqual(requests_mock.post.call_count, 1)
         requests_mock.post.assert_called_once_with(expected_endpoint,
                                                    json=expected_data)
@@ -671,5 +671,7 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
                  'cookie_mask': 18446744073709551615}]
         switch_1 = evc.primary_links[0].endpoint_a.switch
         switch_2 = evc.primary_links[0].endpoint_b.switch
-        send_flow_mods_mocked.assert_any_call(switch_1, flows, 'delete')
-        send_flow_mods_mocked.assert_any_call(switch_2, flows, 'delete')
+        send_flow_mods_mocked.assert_any_call(switch_1, flows, 'delete',
+                                              force=True)
+        send_flow_mods_mocked.assert_any_call(switch_2, flows, 'delete',
+                                              force=True)


### PR DESCRIPTION
Fixes #88

This PR depends [on this `flow_manager` PR to land first](https://github.com/kytos-ng/flow_manager/pull/50)

### Description of the change

- Parametrized ``force`` option as ``True`` when removing flows for reliability

**Rationale:**

-  When removing flows for reliability when dealing with connection errors, it's simpler in terms of error handling to rely on `flow_manager's` `force` option, since the flows will need to eventually be removed and there's no other way around it. 

Related point:

When installing flows if the switch gets disconnected currently `mef_eline` handles the error but the circuit will be inactive, since the force still `False` since it's desirable to try to find other paths (based on our last conversion), currently, if there's a single path the circuit won't become active, so it might need some discussion regarding the desired behavior cc'ing @ajoaoff @italovalcy to collect feedback and to map an issue/requirement for this later on. 

