### PR TITLE
Replace timer with rounds counter to decide when redeploy once sdntrace-cp fails

### DIFF
--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -92,6 +92,24 @@ class TestMain(TestCase):
         urls = self.get_napp_urls(self.napp)
         self.assertCountEqual(expected_urls, urls)
 
+    @patch('napps.kytos.mef_eline.main.settings')
+    def test_execute_wait_for(self, mock_settings):
+        """Test execute and wait for setting."""
+        evc1 = MagicMock()
+        evc1.is_enabled.return_value = True
+        evc1.is_active.return_value = False
+        evc1.lock.locked.return_value = False
+        evc1.check_traces.return_value = False
+        evc1.deploy.call_count = 0
+        self.napp.circuits = {'1': evc1}
+        self.napp.execution_rounds = 0
+        mock_settings.WAIT_FOR_OLD_PATH = 1
+
+        self.napp.execute()
+        self.assertEqual(evc1.deploy.call_count, 0)
+        self.napp.execute()
+        self.assertEqual(evc1.deploy.call_count, 1)
+
     @patch('napps.kytos.mef_eline.main.Main._uni_from_dict')
     @patch('napps.kytos.mef_eline.models.evc.EVCBase._validate')
     def test_evc_from_dict(self, _validate_mock, uni_from_dict_mock):


### PR DESCRIPTION
Fixes #100 

### Description of the change

THis PR is a simple replacement of the approach used by mef_eline to decide when re-deploy an EVC once the sdntrace-cp failed. The current approach is based on a timer. The proposed solution will use a execution cycles/rounds counter. By using the rounds counter instead of timers, we avoid that a longer execution at the beginning leads to the EVC being redeployed even in the first execution round (of course, assuming that sdntrace-cp will fail). In other words, by using timers we increase the possibility of "giving more opportunities to sdntrace detects when the EVC is actually running".

### Release Notes

N/A