### PR TITLE
Add error handler for sdntrace-cp calls

### DIFF
--- a/models/evc.py
+++ b/models/evc.py
@@ -753,11 +753,11 @@ class EVCDeploy(EVCBase):
         """Check if current_path is deployed comparing with SDN traces."""
         trace_a = self.run_sdntrace(self.uni_a)
         if len(trace_a) != len(self.current_path) + 1:
-            log.warn("sdntrace-cp reported invalid path from uni_a: {trace_a}")
+            log.warn(f"Invalid trace from uni_a: {trace_a}")
             return False
         trace_z = self.run_sdntrace(self.uni_z)
         if len(trace_z) != len(self.current_path) + 1:
-            log.warn("sdntrace-cp reported invalid path from uni_z: {trace_z}")
+            log.warn(f"Invalid trace from uni_z: {trace_z}")
             return False
 
         for link, trace1, trace2 in zip(self.current_path,
@@ -766,10 +766,12 @@ class EVCDeploy(EVCBase):
             if compare_endpoint_trace(
                link.endpoint_a,
                glom(link.metadata, 's_vlan.value'), trace2) is False:
+                log.warn(f"Invalid trace from uni_a: {trace_a}")
                 return False
             if compare_endpoint_trace(
                link.endpoint_b,
                glom(link.metadata, 's_vlan.value'), trace1) is False:
+                log.warn(f"Invalid trace from uni_z: {trace_z}")
                 return False
 
         return True


### PR DESCRIPTION
Fixes #102 

### Description of the change

This PR adds some sort of error handler for sdntrace-cp calls. Any error returned by the sdntrace-cp API (`status_code >= 400`) will result in a log entry and a empty response (which preserves the behavior of caller method).

Additionally, the `EVC.check_traces()` was modified to add `log.warn` when a trace fails. Thus, the administrator can have records about trace failures.

### Release notes

N/A