### PR TITLE
Add Lock to prevent race conditions at storehouse get_stored_box method

### DIFF
--- a/storehouse.py
+++ b/storehouse.py
@@ -77,6 +77,8 @@ class StoreHouse:
                    'data': {}}
         name = 'kytos.storehouse.retrieve'
         event = KytosEvent(name=name, content=content)
+        self._lock.acquire()  # Lock to avoid race condition
+        log.debug(f'Lock {self._lock} acquired.')
         self.controller.buffers.app.put(event)
         log.debug(f'Retrieve box with {box_id} from {self.namespace}.')
 
@@ -86,6 +88,8 @@ class StoreHouse:
             log.error(f'Box {data.box_id} not found in {self.namespace}.')
 
         self.box = data
+        self._lock.release()
+        log.debug(f'Lock {self._lock} released.')
         log.debug(f'Box {self.box.box_id} was loaded from storehouse.')
 
     def save_evc(self, evc):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -918,6 +918,90 @@ class TestMain(TestCase):
                          response_json["action"])
         self.assertIsNotNone(response_json["id"])
 
+        # Case 2: there is no schedule
+        payload = {
+              "circuit_id": "cc:cc:cc",
+              "schedule": {
+                "frequency": "1 * * * *",
+                "action": "create"
+              }
+            }
+        response = api.post(url, data=json.dumps(payload),
+                            content_type='application/json')
+        self.assertEqual(response.status_code, 201)
+
+    def test_create_schedule_invalid_request(self):
+        """Test create schedule API with invalid request."""
+        evc1 = MagicMock()
+        self.napp.circuits = {'bb:bb:bb': evc1}
+        api = self.get_app_test_client(self.napp)
+        url = f'{self.server_name_url}/v2/evc/schedule/'
+
+        # case 1: empty post
+        response = api.post(url, data="")
+        self.assertEqual(response.status_code, 415)
+
+        # case 2: content-type not specified
+        payload = {
+            "circuit_id": "bb:bb:bb",
+            "schedule": {
+                "frequency": "1 * * * *",
+                "action": "create"
+            }
+        }
+        response = api.post(url, data=json.dumps(payload))
+        self.assertEqual(response.status_code, 415)
+
+        # case 3: not a dictionary
+        payload = []
+        response = api.post(url, data=json.dumps(payload),
+                            content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+
+        # case 4: missing circuit id
+        payload = {
+            "schedule": {
+                "frequency": "1 * * * *",
+                "action": "create"
+            }
+        }
+        response = api.post(url, data=json.dumps(payload),
+                            content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+
+        # case 5: missing schedule
+        payload = {
+            "circuit_id": "bb:bb:bb"
+        }
+        response = api.post(url, data=json.dumps(payload),
+                            content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+
+        # case 6: invalid circuit
+        payload = {
+            "circuit_id": "xx:xx:xx",
+            "schedule": {
+                "frequency": "1 * * * *",
+                "action": "create"
+            }
+        }
+        response = api.post(url, data=json.dumps(payload),
+                            content_type='application/json')
+        self.assertEqual(response.status_code, 404)
+
+        # case 7: archived or deleted evc
+        evc1.archived.return_value = True
+        payload = {
+            "circuit_id": "bb:bb:bb",
+            "schedule": {
+                "frequency": "1 * * * *",
+                "action": "create"
+            }
+        }
+        response = api.post(url, data=json.dumps(payload),
+                            content_type='application/json')
+        self.assertEqual(response.status_code, 403)
+
     @patch('apscheduler.schedulers.background.BackgroundScheduler.remove_job')
     @patch('napps.kytos.mef_eline.storehouse.StoreHouse.get_data')
     @patch('napps.kytos.mef_eline.scheduler.Scheduler.add')
@@ -1125,6 +1209,15 @@ class TestMain(TestCase):
         response = api.delete(url)
 
         self.assertEqual(response.status_code, 403, response.data)
+
+    @patch('napps.kytos.mef_eline.main.Main._find_evc_by_schedule_id')
+    def test_delete_schedule_not_found(self, mock_find_evc_by_sched):
+        """Test delete a circuit schedule - unexisting."""
+        mock_find_evc_by_sched.return_value = (None, False)
+        api = self.get_app_test_client(self.napp)
+        url = f'{self.server_name_url}/v2/evc/schedule/1'
+        response = api.delete(url)
+        self.assertEqual(response.status_code, 404)
 
     @patch('requests.post')
     @patch('napps.kytos.mef_eline.scheduler.Scheduler.add')


### PR DESCRIPTION
Fixes #108 

### Description of the change

Mef_eline's storehouse already leverages `threading.Lock` to protect its data against race conditions, more specifically during the update phase. This PR extends the Lock usage to also coverage the retrieve phase along with the `get_stored_box()` method. This was necessary because in some conditions the user may request to retrieve data right before storing new data. The retrieve process is executed asynchronously, and when the data is ready it can overrides the updated data (if they happen to run at the same time, or their threads get scheduled in parallel).

I've run the end-to-end tests with 200 repetitions and no further error was reported:
```
# cat run-test
( for i in $(seq 1 200); do echo $i $(date); python -m pytest tests/test_e2e_12_mef_eline.py::TestE2EMefEline::test_delete_schedule; done; date ) | tee log-mef-e2e-$(date +%Y%m%d%H%M%S)
# sh run-test
# egrep -o " (passed|failed) " log-mef-e2e-20211218021201 | sort | uniq -c
    200  passed
```

Before this PR, as reported in Issue #108, around 5% of the tests fail.

It is worthy mentioning that the used approach for Lock usage at `mef_eline/storehouse.py` is not the best (we are using `Lock.acquire()` and `Lock.release()` in different methods, instead of using the `with` statement which is more secure). However, due to the async way storehouse is used, the other option would be a busy wait. The busy wait would have the advantage of guarantee user data is persisted before return success to the user. However, it was not choose to be align with the current approach being used in Kytos (async calls). We may need to review this soon (or use a new backend).

I've also took the opportunity to work on unit tests and the coverage increased to 81%.