### PR TITLE
[Fix] UI create EVC - Clear fields if create EVC is a success

### DIFF
--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -95,6 +95,17 @@ module.exports = {
         }
         this.$kytos.$emit("showInfoPanel", listConnections);
     },
+    set_default_values() {
+        this.circuit_name = "";
+        this.endpoint_a = "";
+        this.endpoint_name_a = "Endpoint name:";
+        this.tag_type_a = "";
+        this.tag_value_a = "";
+        this.endpoint_z = "";
+        this.endpoint_name_z = "Endpoint name:";
+        this.tag_type_z = "";
+        this.tag_value_z = "";
+    },
     post_success(data) {
         let notification = {
             icon: 'gear',
@@ -103,6 +114,8 @@ module.exports = {
         }
     
         this.$kytos.$emit("setNotification" , notification);
+        // Clear fields if the POST is a success
+        this.set_default_values();
     },
     post_error(data) {
         let notification = {


### PR DESCRIPTION
Fix #118 
In the EVC create form all values remain in the fields after the user hit the "Request Circuit" button.
This can cause some confusion for the user because the success/failure message appears in the notifications panel.

This PR clears the form fields if the create action is successful.
If it fails for any reason, the values remain on the form.

![image](https://user-images.githubusercontent.com/10867136/148478778-5b838e83-8c3c-494b-b74f-a7331f7de927.png)
