### PR TITLE
[Fix] Upgraded transitive deps from `requests` on `requirements/run.txt` 

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,7 +6,8 @@
 #
 -e git+https://github.com/kytos-ng/kytos.git#egg=kytos
     # via -r requirements/dev.in
--e . # via -r requirements/dev.in
+-e .
+    # via -r requirements/dev.in
 -e git+https://github.com/kytos-ng/python-openflow.git#egg=python-openflow
     # via
     #   -r requirements/dev.in
@@ -15,7 +16,7 @@ apscheduler==3.8.0
     # via kytos-mef-eline
 astroid==2.9.2
     # via pylint
-attrs==21.2.0
+attrs==21.4.0
     # via
     #   glom
     #   jsonschema
@@ -30,7 +31,7 @@ boltons==21.0.0
     #   face
     #   glom
     #   kytos-mef-eline
-certifi==2019.11.28
+certifi==2021.10.8
     # via
     #   kytos-mef-eline
     #   requests
@@ -38,7 +39,7 @@ charset-normalizer==2.0.10
     # via
     #   kytos-mef-eline
     #   requests
-click==7.1.1
+click==8.0.3
     # via
     #   flask
     #   kytos
@@ -58,7 +59,7 @@ distlib==0.3.4
     # via virtualenv
 docopt==0.6.2
     # via yala
-docutils==0.17.1
+docutils==0.18.1
     # via
     #   kytos
     #   python-daemon
@@ -81,12 +82,13 @@ flask-socketio==4.2.1
     # via kytos
 glom==20.11.0
     # via kytos-mef-eline
-idna==2.9
+idna==3.3
     # via
     #   kytos-mef-eline
     #   requests
-importlib-metadata==4.8.1
+importlib-metadata==4.8.3
     # via
+    #   click
     #   jsonschema
     #   kytos-mef-eline
     #   pep517
@@ -101,7 +103,7 @@ ipython-genutils==0.2.0
     # via
     #   kytos
     #   traitlets
-isodate==0.6.0
+isodate==0.6.1
     # via
     #   kytos-mef-eline
     #   openapi-core
@@ -129,7 +131,7 @@ jsonschema==3.2.0
     #   kytos-mef-eline
     #   openapi-schema-validator
     #   openapi-spec-validator
-lazy-object-proxy==1.6.0
+lazy-object-proxy==1.7.1
     # via
     #   astroid
     #   kytos-mef-eline
@@ -144,13 +146,13 @@ markupsafe==1.1.1
     #   kytos
 mccabe==0.6.1
     # via pylint
-more-itertools==8.10.0
+more-itertools==8.12.0
     # via
     #   kytos-mef-eline
     #   openapi-core
 openapi-core==0.14.2
     # via kytos-mef-eline
-openapi-schema-validator==0.1.5
+openapi-schema-validator==0.1.6
     # via
     #   kytos-mef-eline
     #   openapi-core
@@ -203,7 +205,7 @@ py==1.11.0
     # via tox
 pycodestyle==2.8.0
     # via yala
-pygments==2.10.0
+pygments==2.11.2
     # via
     #   ipython
     #   kytos
@@ -268,7 +270,7 @@ traitlets==4.3.3
     #   kytos
 typed-ast==1.5.1
     # via astroid
-typing-extensions==3.10.0.2
+typing-extensions==4.0.1
     # via
     #   astroid
     #   importlib-metadata
@@ -278,7 +280,7 @@ tzlocal==2.1
     # via
     #   apscheduler
     #   kytos-mef-eline
-urllib3==1.25.8
+urllib3==1.26.7
     # via
     #   kytos-mef-eline
     #   requests

--- a/requirements/run.txt
+++ b/requirements/run.txt
@@ -11,6 +11,7 @@ attrs==21.4.0
     #   glom
     #   jsonschema
     #   openapi-core
+    #   openapi-schema-validator
 boltons==21.0.0
     # via
     #   face
@@ -19,8 +20,6 @@ certifi==2021.10.8
     # via requests
 charset-normalizer==2.0.10
     # via requests
-dataclasses==0.8
-    # via werkzeug
 dictpath==0.1.3
     # via openapi-core
 face==20.1.1
@@ -32,9 +31,7 @@ idna==3.3
 importlib-metadata==4.8.3
     # via jsonschema
 isodate==0.6.1
-    # via
-    #   openapi-core
-    #   openapi-schema-validator
+    # via openapi-core
 jsonschema==3.2.0
     # via
     #   openapi-schema-validator
@@ -67,9 +64,7 @@ six==1.16.0
     # via
     #   apscheduler
     #   isodate
-    #   jsonschema
     #   openapi-core
-    #   openapi-schema-validator
     #   openapi-spec-validator
 typing-extensions==4.0.1
     # via importlib-metadata
@@ -77,7 +72,7 @@ tzlocal==2.1
     # via apscheduler
 urllib3==1.26.7
     # via requests
-werkzeug==2.0.2
+werkzeug==1.0.1
     # via openapi-core
 zipp==3.6.0
     # via importlib-metadata

--- a/requirements/run.txt
+++ b/requirements/run.txt
@@ -6,7 +6,7 @@
 #
 apscheduler==3.8.0
     # via -r requirements/run.in
-attrs==21.2.0
+attrs==21.4.0
     # via
     #   glom
     #   jsonschema
@@ -15,21 +15,23 @@ boltons==21.0.0
     # via
     #   face
     #   glom
-certifi==2019.11.28
+certifi==2021.10.8
     # via requests
 charset-normalizer==2.0.10
     # via requests
+dataclasses==0.8
+    # via werkzeug
 dictpath==0.1.3
     # via openapi-core
 face==20.1.1
     # via glom
 glom==20.11.0
     # via -r requirements/run.in
-idna==2.9
+idna==3.3
     # via requests
-importlib-metadata==4.8.1
+importlib-metadata==4.8.3
     # via jsonschema
-isodate==0.6.0
+isodate==0.6.1
     # via
     #   openapi-core
     #   openapi-schema-validator
@@ -37,13 +39,13 @@ jsonschema==3.2.0
     # via
     #   openapi-schema-validator
     #   openapi-spec-validator
-lazy-object-proxy==1.6.0
+lazy-object-proxy==1.7.1
     # via openapi-core
-more-itertools==8.10.0
+more-itertools==8.12.0
     # via openapi-core
 openapi-core==0.14.2
     # via -r requirements/run.in
-openapi-schema-validator==0.1.5
+openapi-schema-validator==0.1.6
     # via
     #   openapi-core
     #   openapi-spec-validator
@@ -69,13 +71,13 @@ six==1.16.0
     #   openapi-core
     #   openapi-schema-validator
     #   openapi-spec-validator
-typing-extensions==3.10.0.2
+typing-extensions==4.0.1
     # via importlib-metadata
 tzlocal==2.1
     # via apscheduler
-urllib3==1.25.8
+urllib3==1.26.7
     # via requests
-werkzeug==1.0.1
+werkzeug==2.0.2
     # via openapi-core
 zipp==3.6.0
     # via importlib-metadata


### PR DESCRIPTION
It turns out when [`requests` was pinned on version `2.27.0`](https://github.com/kytos-ng/mef_eline/blob/master/requirements/run.txt#L62) on this PR #115, I should've also `pip-compile` upgraded its transitive dependencies like `certifi`, `idna` and `urllib3`, otherwise they'd end up with prior pinned versions that would leave margin for conflicts, this is one of the trade off of having stricter transitive dependencies, but once they're all set it should be easier with documented guidelines how to keep this handled smoothly in the future as we need to roll out upgrades.

FYI, I've mapped an issue on this repo https://github.com/kytos-ng/kytos-ng.github.io/issues/14 to document some guidelines to have a deterministic and clear way on how to deal with upgrades and what to look for to make sure the docker build doesn't break, so later on I'll update there. 