### PR TITLE
[Fix] `get_id_from_cookie` leading zeros issue

### DIFF
--- a/models/evc.py
+++ b/models/evc.py
@@ -702,7 +702,7 @@ class EVCDeploy(EVCBase):
     def get_id_from_cookie(cookie):
         """Return the evc id given a cookie value."""
         evc_id = cookie - (settings.COOKIE_PREFIX << 56)
-        return f"{evc_id:14x}"
+        return f"{evc_id:x}".zfill(14)
 
     def _prepare_flow_mod(self, in_interface, out_interface, queue_id=None):
         """Prepare a common flow mod."""

--- a/tests/unit/models/test_evc_base.py
+++ b/tests/unit/models/test_evc_base.py
@@ -253,3 +253,19 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         evc_id = evc.id
         assert evc_id
         assert evc.get_id_from_cookie(evc.get_cookie()) == evc_id
+
+    @staticmethod
+    def test_get_id_from_cookie_with_leading_zeros():
+        """Test get_id_from_cookie with leading zeros."""
+
+        attributes = {
+            "controller": get_controller_mock(),
+            "name": "circuit_name",
+            "enable": True,
+            "uni_a": get_uni_mocked(is_valid=True),
+            "uni_z": get_uni_mocked(is_valid=True)
+        }
+        evc = EVC(**attributes)
+        evc_id = "0a2d672d99ff41"
+        evc._id = evc_id
+        assert EVC.get_id_from_cookie(evc.get_cookie()) == evc_id

--- a/tests/unit/models/test_evc_base.py
+++ b/tests/unit/models/test_evc_base.py
@@ -267,5 +267,7 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         }
         evc = EVC(**attributes)
         evc_id = "0a2d672d99ff41"
+        # pylint: disable=protected-access
         evc._id = evc_id
+        # pylint: enable=protected-access
         assert EVC.get_id_from_cookie(evc.get_cookie()) == evc_id


### PR DESCRIPTION
Fixes #124 that @italovalcy has reported (thanks for mapping and double checking the error there)

### Release notes

- Fixed `get_id_from_cookie` leading zeros issue

I was going to bump a version, but since the release hasn't happened yet, it didn't set a new version