### PR TITLE
[Fix] GET `/v2/evc/<circuit_id>` 404

### DIFF
--- a/main.py
+++ b/main.py
@@ -135,7 +135,7 @@ class Main(KytosNApp):
         except KeyError:
             result = f"circuit_id {circuit_id} not found"
             log.debug("get_circuit result %s %s", result, 404)
-            raise BadRequest(result) from KeyError
+            raise NotFound(result) from KeyError
         status = 200
         log.debug("get_circuit result %s %s", result, status)
         return jsonify(result), status

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -860,7 +860,7 @@ class TestMain(TestCase):
 
         expected = "circuit_id blah not found"
         # Assert response not found
-        self.assertEqual(response.status_code, 400, response.data)
+        self.assertEqual(response.status_code, 404, response.data)
         self.assertEqual(expected, json.loads(response.data)["description"])
 
     def _uni_from_dict_side_effect(self, uni_dict):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1219,6 +1219,13 @@ class TestMain(TestCase):
         response = api.delete(url)
         self.assertEqual(response.status_code, 404)
 
+    def test_get_circuit_not_found(self):
+        """Test /v2/evc/<circuit_id> 404."""
+        api = self.get_app_test_client(self.napp)
+        url = f'{self.server_name_url}/v2/evc/1234'
+        response = api.get(url)
+        self.assertEqual(response.status_code, 404)
+
     @patch('requests.post')
     @patch('napps.kytos.mef_eline.scheduler.Scheduler.add')
     @patch('napps.kytos.mef_eline.storehouse.StoreHouse.save_evc')


### PR DESCRIPTION
Fixes #128 

### Release notes

- Fixed GET `/v2/evc/<circuit_id>` to return 404
