### PR TITLE
Add lock to prevent race conditions when removing the EVC

### DIFF
--- a/main.py
+++ b/main.py
@@ -318,12 +318,13 @@ class Main(KytosNApp):
             raise NotFound(result) from NotFound
 
         log.info("Removing %s", evc)
-        evc.remove_current_flows()
-        evc.deactivate()
-        evc.disable()
-        self.sched.remove(evc)
-        evc.archive()
-        evc.sync()
+        with evc.lock:
+            evc.remove_current_flows()
+            evc.deactivate()
+            evc.disable()
+            self.sched.remove(evc)
+            evc.archive()
+            evc.sync()
         log.info("EVC removed. %s", evc)
         result = {"response": f"Circuit {circuit_id} removed"}
         status = 200


### PR DESCRIPTION
Fixes #131 

### Description of the change

This PR leverage the `EVC.Lock` mechanism to also protect against race conditions during the removal of an EVC. Without this protect it might happen that mef_eline leaves some alien flows in flow_manager when the removal of an EVC happens at the exact same time when the EVC is being processed by the consistency check routine (such as the example shown on issue #131).

All the unit tests were executed and no surprises were noticed.

I've also repeated 20 times the end-to-end test that revealed this issue and no more error was reported:
```
export TESTS=tests/test_e2e_10_mef_eline.py::TestE2EMefEline::test_080_create_and_remove_ten_circuits_ten_times
( for i in $(seq 1 20); do python -m pytest $TESTS; done ) 2>&1 | tee log-mef_eline_test_080.log
# grep -c "passed" log-mef_eline_test_080.log
20
# grep -c "failed" log-mef_eline_test_080.log
0
```

### Release Notes

- Added EVC.Lock mechanism to protect the EVC against race conditions on the EVC removal