### PR TITLE
[Feature] Publish `available_tags` event when vlans are allocated or removed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,17 @@ Changelog
 #########
 All notable changes to the MEF_ELine NApp will be documented in this file.
 
-[2.6.0] - 2021-05-28
+[2.7.0] - 2022-01-19
+********************
+
+Added
+=====
+-  Added utils ``notify_link_available_tags``` function
+-  Publish ``kytos/mef_eline.link.available_tags`` event
+-  Hooked ``notify_link_available_tags`` when choosing or making vlans available
+
+
+[2.6.0] - 2021-11-30
 ********************
 
 Added

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,8 +3,8 @@ Changelog
 #########
 All notable changes to the MEF_ELine NApp will be documented in this file.
 
-[2.7.0] - 2022-01-19
-********************
+[2022.1.0] - 2022-01-31
+***********************
 
 Added
 =====

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2.7.0",
+  "version": "2022.1.0",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "kytos/storehouse", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "kytos/storehouse", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],

--- a/models/evc.py
+++ b/models/evc.py
@@ -14,7 +14,11 @@ from kytos.core.interface import UNI
 from napps.kytos.mef_eline import settings
 from napps.kytos.mef_eline.exceptions import FlowModException, InvalidPath
 from napps.kytos.mef_eline.storehouse import StoreHouse
-from napps.kytos.mef_eline.utils import compare_endpoint_trace, emit_event
+from napps.kytos.mef_eline.utils import (
+    compare_endpoint_trace,
+    emit_event,
+    notify_link_available_tags,
+)
 from .path import Path, DynamicPathManager
 
 
@@ -459,6 +463,8 @@ class EVCDeploy(EVCBase):
                 )
 
         current_path.make_vlans_available()
+        for link in current_path:
+            notify_link_available_tags(self._controller, link)
         self.current_path = Path([])
         self.deactivate()
         self.sync()
@@ -506,6 +512,8 @@ class EVCDeploy(EVCBase):
         if self.should_deploy(use_path):
             try:
                 use_path.choose_vlans()
+                for link in use_path:
+                    notify_link_available_tags(self._controller, link)
             except KytosNoTagAvailableError:
                 use_path = None
         else:
@@ -514,6 +522,8 @@ class EVCDeploy(EVCBase):
                     continue
                 try:
                     use_path.choose_vlans()
+                    for link in use_path:
+                        notify_link_available_tags(self._controller, link)
                     break
                 except KytosNoTagAvailableError:
                     pass

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ if "bdist_wheel" in sys.argv:
 BASE_ENV = Path(os.environ.get("VIRTUAL_ENV", "/"))
 
 NAPP_NAME = 'mef_eline'
-NAPP_VERSION = '2.7.0'
+NAPP_VERSION = '2022.1.0'
 
 # Kytos var folder
 VAR_PATH = BASE_ENV / "var" / "lib" / "kytos"

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ if "bdist_wheel" in sys.argv:
 BASE_ENV = Path(os.environ.get("VIRTUAL_ENV", "/"))
 
 NAPP_NAME = 'mef_eline'
-NAPP_VERSION = '2.6.1'
+NAPP_VERSION = '2.7.0'
 
 # Kytos var folder
 VAR_PATH = BASE_ENV / "var" / "lib" / "kytos"

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -777,8 +777,9 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         log_mock.info.assert_called_with(f"{evc} was deployed.")
         self.assertTrue(deployed)
 
+    @patch("napps.kytos.mef_eline.models.evc.notify_link_available_tags")
     @patch("napps.kytos.mef_eline.models.evc.EVC._send_flow_mods")
-    def test_remove_current_flows(self, send_flow_mods_mocked):
+    def test_remove_current_flows(self, send_flow_mods_mocked, notify_mock):
         """Test remove current flows."""
         uni_a = get_uni_mocked(
             interface_port=2,
@@ -830,6 +831,7 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
 
         evc.current_path = evc.primary_links
         evc.remove_current_flows()
+        notify_mock.assert_called()
 
         self.assertEqual(send_flow_mods_mocked.call_count, 5)
         self.assertFalse(evc.is_active())

--- a/tests/unit/models/test_link_protection.py
+++ b/tests/unit/models/test_link_protection.py
@@ -109,6 +109,7 @@ class TestLinkProtection(TestCase):  # pylint: disable=too-many-public-methods
         log_mocked.debug.assert_called_with(expected_msg)
         self.assertTrue(expected_deployed)
 
+    # pylint: disable=too-many-arguments
     @patch("napps.kytos.mef_eline.models.evc.notify_link_available_tags")
     @patch("requests.post")
     @patch("napps.kytos.mef_eline.storehouse.StoreHouse.save_evc")

--- a/tests/unit/models/test_link_protection.py
+++ b/tests/unit/models/test_link_protection.py
@@ -109,6 +109,7 @@ class TestLinkProtection(TestCase):  # pylint: disable=too-many-public-methods
         log_mocked.debug.assert_called_with(expected_msg)
         self.assertTrue(expected_deployed)
 
+    @patch("napps.kytos.mef_eline.models.evc.notify_link_available_tags")
     @patch("requests.post")
     @patch("napps.kytos.mef_eline.storehouse.StoreHouse.save_evc")
     @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.deploy")
@@ -122,6 +123,7 @@ class TestLinkProtection(TestCase):  # pylint: disable=too-many-public-methods
         deploy_mocked,
         _,
         requests_mock,
+        notify_mock
     ):
         """Test deploy with all links up."""
         deploy_mocked.return_value = True
@@ -147,6 +149,7 @@ class TestLinkProtection(TestCase):  # pylint: disable=too-many-public-methods
         install_uni_flows_mocked.assert_called_with(evc.primary_path)
         install_nni_flows_mocked.assert_called_with(evc.primary_path)
         self.assertTrue(deployed)
+        notify_mock.assert_called()
 
     @patch("requests.get", side_effect=get_mocked_requests)
     def test_deploy_to_case_3(self, requests_mocked):

--- a/utils.py
+++ b/utils.py
@@ -21,6 +21,11 @@ def emit_event(controller, name, **kwargs):
     controller.buffers.app.put(event)
 
 
+def notify_link_available_tags(controller, link):
+    """Notify link available tags."""
+    emit_event(controller, "link_available_tags", link=link)
+
+
 def compare_endpoint_trace(endpoint, vlan, trace):
     """Compare and endpoint with a trace step."""
     return (


### PR DESCRIPTION
### Description of the change

`mef_eline` manages and consumes tags when circuits are either provisioned or removed, and this resource `available_tags` needs to be stored and loaded when switches connect again or reboot, so I added a function to publish ``kytos/mef_eline.link.available_tags``  for `topology` to subscribe, which is being delivered [on this PR 46](https://github.com/kytos-ng/topology/pull/46)

### Release notes

version `[2.7.0] - 2022-01-19`

#### Added
-  Added utils ``notify_link_available_tags`` function
-  Publish ``kytos/mef_eline.link.available_tags`` event
-  Hooked ``notify_link_available_tags`` when choosing or making vlans available