### PR TITLE
Fix list button not rerendering the content

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,14 @@ Changelog
 #########
 All notable changes to the MEF_ELine NApp will be documented in this file.
 
+[2022.1.1] - 2022-02-03
+***********************
+
+Fixed
+=====
+-  Fix list button not re-rendering the content
+
+
 [2022.1.0] - 2022-01-31
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2022.1.0",
+  "version": "2022.1.1",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "kytos/storehouse", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ if "bdist_wheel" in sys.argv:
 BASE_ENV = Path(os.environ.get("VIRTUAL_ENV", "/"))
 
 NAPP_NAME = 'mef_eline'
-NAPP_VERSION = '2022.1.0'
+NAPP_VERSION = '2022.1.1'
 
 # Kytos var folder
 VAR_PATH = BASE_ENV / "var" / "lib" / "kytos"

--- a/ui/k-info-panel/list_connections.kytos
+++ b/ui/k-info-panel/list_connections.kytos
@@ -52,8 +52,9 @@
       </div>
     </div>
     <div v-else>
-      <p class='empty-con-list'>No EVCs Installed.<br>
-      Close this info-panel and try again, please.</p>
+      <p class='empty-con-list' v-if="flag_loading">Loading EVCs. Please wait...</p>
+      <p class='empty-con-list' v-else>No EVCs Installed.<br>
+        Close this info-panel and try again, please.</p>
     </div>
 </template>
 
@@ -61,12 +62,13 @@
 module.exports = {
   data(){
     return {
+      flag_loading: false,
       component_key: 0,
-        data_header_id:  ['mef_dpid_id', 'mef_lst_name', 
-                        'mef_lst_sw_a', 'mef_lst_prt_a', 'mef_lst_int_a', 'mef_lst_tag_a',
-                        'mef_lst_sw_z', 'mef_lst_prt_z', 'mef_lst_int_z', 'mef_lst_tag_z', 
-                        'mef_lst_enabled',
-                        'mef_lst_active'],                         
+      data_header_id:  ['mef_dpid_id', 'mef_lst_name', 
+                      'mef_lst_sw_a', 'mef_lst_prt_a', 'mef_lst_int_a', 'mef_lst_tag_a',
+                      'mef_lst_sw_z', 'mef_lst_prt_z', 'mef_lst_int_z', 'mef_lst_tag_z', 
+                      'mef_lst_enabled',
+                      'mef_lst_active'],                         
       data_headers: ['id', 'Name', 'Switch A', 'Port A', 'Interf. A', 'Tag A', 
                       'Switch Z', 'Port Z', 'Interf. Z', 'Tag Z',
                       'Enabled', 'Active'],
@@ -189,6 +191,7 @@ module.exports = {
       /**
        * Call mef_eline REST endpoint to load EVC list.
        */
+      this.flag_loading = true;
       this.component_key = 0;
       var tableRows = [];
       var _this = this;
@@ -231,10 +234,12 @@ module.exports = {
 
         _this.data_rows = tableRows;
         _this.forceRerender(); 
+        _this.flag_loading = false;
       });
 
       request.fail(function( jqXHR, textStatus ) {
         alert( "Request failed: " + textStatus );
+        _this.flag_loading = false;
       });
       
       return tableRows;

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -68,7 +68,7 @@
 
          <k-accordion-item title="List EVCs">
             <k-button tooltip="List installed EVC" title="List installed EVC"
-                     icon="plug" :on_click="showInfoPanel">
+                     icon="plug" :on_click="viewPanel">
                      </k-button>
          </k-accordion-item>
       </k-accordion>
@@ -92,6 +92,18 @@ module.exports = {
     }
   },
   methods: {
+    viewPanel() {
+        var _this = this;
+        // Clear panel
+        this.hideInfoPanel();
+        // Wait 50ms to clear the panel.
+        setTimeout(function(){
+            _this.showInfoPanel();
+        }, 50);
+    },
+    hideInfoPanel() {
+        this.$kytos.$emit("hideInfoPanel");
+    },
     showInfoPanel() {
         let listConnections = {
             component: 'kytos-mef_eline-k-info-panel-list_connections',
@@ -99,7 +111,7 @@ module.exports = {
             icon: "desktop",
             title: "View Connections",
             subtitle: "by kytos/mef_eline"
-        }
+        };
         this.$kytos.$emit("showInfoPanel", listConnections);
     },
     set_default_values() {


### PR DESCRIPTION
Fix issue #138 
The "List installed EVC" button does not re-render the contents of the panel. The user must close the panel clicking the "X" button and click the "List installed EVC" button again.

This PR fixes this issue, forcing the panel that list the EVCs to be destroyed and the rendering of the content.
It needed a timeout between the calls because they are asynchronous.