### PR TITLE
Make tag field optional and editable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,14 @@ Changelog
 #########
 All notable changes to the MEF_ELine NApp will be documented in this file.
 
+[2022.1.2] - 2022-02-03
+***********************
+
+Fixed
+=====
+-  Fix to make tag fields optional and editable
+
+
 [2022.1.1] - 2022-02-03
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2022.1.1",
+  "version": "2022.1.2",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "kytos/storehouse", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ if "bdist_wheel" in sys.argv:
 BASE_ENV = Path(os.environ.get("VIRTUAL_ENV", "/"))
 
 NAPP_NAME = 'mef_eline'
-NAPP_VERSION = '2022.1.1'
+NAPP_VERSION = '2022.1.2'
 
 # Kytos var folder
 VAR_PATH = BASE_ENV / "var" / "lib" / "kytos"

--- a/ui/k-info-panel/show_circuit.kytos
+++ b/ui/k-info-panel/show_circuit.kytos
@@ -333,13 +333,13 @@ module.exports = {
       };
 
       // Tag is optional, but can be edited
-      let tag_a = {'value': "", 'editable':true, 'name':'tag_a'};
-      let tag_b = {'value': "", 'editable':true, 'name':'tag_b'};
-      if(this.circuit['uni_a']['tag']) {
-        tag_a['value'] = this.circuit['uni_a']['tag']['value'];
-        tag_b['value'] = this.circuit['uni_z']['tag']['value'];
-      }
-      this.endpoints_data['Tag Value'] = [tag_a, tag_b];
+      let tag_a = {'value': this.circuit['uni_a']['tag'] ? this.circuit['uni_a']['tag']['value'] : "", 
+                   'editable':true, 
+                   'name':'tag_a'};
+      let tag_z = {'value': this.circuit['uni_z']['tag'] ? this.circuit['uni_z']['tag']['value'] : "", 
+                   'editable':true, 
+                  'name':'tag_z'};
+      this.endpoints_data['Tag Value'] = [tag_a, tag_z];
 
       this.basics = {'ID': {'value': data['id'], 'editable':false},
                      'Name': {'value': data['name'], 'editable':true, 'name':'name'}

--- a/ui/k-info-panel/show_circuit.kytos
+++ b/ui/k-info-panel/show_circuit.kytos
@@ -194,7 +194,8 @@ module.exports = {
         paths: {}, // EVC paths data
         links: {}, // EVC links data
         circuit_scheduler: {}, // EVC scheduler data
-        showDelModal: false
+        showDelModal: false,
+        TAG_TYPE_VLAN: 1, // Tag type VLAN
     }
   },
   methods: {
@@ -330,11 +331,15 @@ module.exports = {
          {'value': uni_a_data['port_name']}, 
          {'value': uni_z_data['port_name']}]
       };
+
+      // Tag is optional, but can be edited
+      let tag_a = {'value': "", 'editable':true, 'name':'tag_a'};
+      let tag_b = {'value': "", 'editable':true, 'name':'tag_b'};
       if(this.circuit['uni_a']['tag']) {
-        let tag_a = {'value': this.circuit['uni_a']['tag']['value'], 'editable':true, 'name':'tag_a'};
-        let tag_b = {'value': this.circuit['uni_z']['tag']['value'], 'editable':true, 'name':'tag_b'};
-        this.endpoints_data['Tag Value'] = [tag_a, tag_b];
+        tag_a['value'] = this.circuit['uni_a']['tag']['value'];
+        tag_b['value'] = this.circuit['uni_z']['tag']['value'];
       }
+      this.endpoints_data['Tag Value'] = [tag_a, tag_b];
 
       this.basics = {'ID': {'value': data['id'], 'editable':false},
                      'Name': {'value': data['name'], 'editable':true, 'name':'name'}
@@ -498,19 +503,26 @@ module.exports = {
         queue_id: this.others["Queue"]["value"],
         uni_a: {
           interface_id: this.endpoints_data["DPID"][0]["value"],
-          tag: {
-            tag_type: this.circuit['uni_a']['tag']['tag_type'],
-            value: parseInt(this.endpoints_data["Tag Value"][1]["value"])
-          }
         },
         uni_z: {
           interface_id: this.endpoints_data["DPID"][1]["value"],
-          tag: {
-            tag_type: this.circuit['uni_z']['tag']['tag_type'],
-            value: parseInt(this.endpoints_data["Tag Value"][1]["value"])
-          }
         },
       };
+
+      // Tag is optional
+      if(this.endpoints_data["Tag Value"][0]["value"]) {
+        payload["uni_a"]["tag"] = {
+          tag_type: this.TAG_TYPE_VLAN,
+          value: parseInt(this.endpoints_data["Tag Value"][0]["value"])
+        };
+      }
+      if(this.endpoints_data["Tag Value"][1]["value"]) {
+        payload["uni_z"]["tag"] = {
+          tag_type: this.TAG_TYPE_VLAN,
+          value: parseInt(this.endpoints_data["Tag Value"][1]["value"])
+        };
+      }
+
       var request = $.ajax({
         url: this.$kytos_server_api + "kytos/mef_eline/v2/evc/" + id,
         type:"PATCH",


### PR DESCRIPTION
Fix #141 
If the EVC is created without the tag field, the EVC edit couldn´t handle it.
This PR makes the tag as an optional data, and render the input fields so the value can be inserted.