### PR TITLE
Fix UI autocomplete result list width

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,12 +3,20 @@ Changelog
 #########
 All notable changes to the MEF_ELine NApp will be documented in this file.
 
+[2022.1.3] - 2022-02-11
+***********************
+
+Fixed
+=====
+-  Fix UI to display the scrollbar in the autocomplete results list
+
+
 [2022.1.2] - 2022-02-03
 ***********************
 
 Fixed
 =====
--  Fix to make tag fields optional and editable
+-  Fix UI to make tag fields optional and editable
 
 
 [2022.1.1] - 2022-02-03
@@ -16,7 +24,7 @@ Fixed
 
 Fixed
 =====
--  Fix list button not re-rendering the content
+-  Fix UI list button not re-rendering the content
 
 
 [2022.1.0] - 2022-01-31

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2022.1.2",
+  "version": "2022.1.3",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "kytos/storehouse", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ if "bdist_wheel" in sys.argv:
 BASE_ENV = Path(os.environ.get("VIRTUAL_ENV", "/"))
 
 NAPP_NAME = 'mef_eline'
-NAPP_VERSION = '2022.1.2'
+NAPP_VERSION = '2022.1.3'
 
 # Kytos var folder
 VAR_PATH = BASE_ENV / "var" / "lib" / "kytos"

--- a/ui/k-info-panel/show_circuit.kytos
+++ b/ui/k-info-panel/show_circuit.kytos
@@ -718,8 +718,11 @@ module.exports = {
     color: #ffc5c5;
     background: #be0000;
   }
-  .autocomplete-result-list {
+  #mef-unis .autocomplete-result-list {
     width: 110% !important;
+    outline: 0;
+    border: 1px #515151 solid;
+    border-radius: 3px;
   }
   .autocomplete-result-list li {
     white-space: nowrap;

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -228,8 +228,12 @@ module.exports = {
     height: 1.1em;
     padding-top: 0.4em;
   }
-  .autocomplete-result-list {
-    width: 110% !important;
+  #endpoint-a-input .autocomplete-result-list,
+  #endpoint-z-input .autocomplete-result-list {
+    width: 100% !important;
+    outline: 0;
+    border: 1px #515151 solid;
+    border-radius: 3px;
   }
   .autocomplete-result-list li {
     white-space: nowrap;


### PR DESCRIPTION
Fix #145
In the form to create EVC, the endpoint autocomplete displays the result list without the scrollbar.
This PR fixes the width issue that caused the issue with the scrollbar in the create form, making the autocomplete style more specific to avoid overriding from generic styles. 

![image](https://user-images.githubusercontent.com/10867136/152626003-a56c70cf-3cb3-4f91-9e78-0e190ffc1954.png)
