### PR TITLE
fix: Change client vlan on first switch

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,15 @@ Changelog
 #########
 All notable changes to the MEF_ELine NApp will be documented in this file.
 
+[Unreleased]
+************
+
+Added
+=====
+
+- Reintroduced Q-in-Q when creating the flows for an EVC.
+  
+
 [2022.1.5] - 2022-02-11
 ***********************
 

--- a/models/evc.py
+++ b/models/evc.py
@@ -755,14 +755,14 @@ class EVCDeploy(EVCBase):
             out_interface(str): Interface output.
             in_vlan(str): Vlan input.
             out_vlan(str): Vlan output.
-            new_in_vlan(str): Interface input.
+            new_c_vlan(str): New client vlan.
 
         Return:
             dict: An python dictionary representing a FlowMod
 
         """
         # assign all arguments
-        in_interface, out_interface, in_vlan, out_vlan , new_in_vlan = args
+        in_interface, out_interface, in_vlan, out_vlan , new_c_vlan = args
 
         flow_mod = self._prepare_flow_mod(
             in_interface, out_interface, queue_id
@@ -778,9 +778,9 @@ class EVCDeploy(EVCBase):
         if in_vlan:
             # if in_vlan is set, it must be included in the match
             flow_mod["match"]["dl_vlan"] = in_vlan
-        if new_in_vlan:
+        if new_c_vlan:
             # new_in_vlan is set, so an action to set it is necessary
-            new_action = {"action_type": "set_vlan", "vlan_id": new_in_vlan}
+            new_action = {"action_type": "set_vlan", "vlan_id": new_c_vlan}
             flow_mod["actions"].insert(0, new_action)
             if not in_vlan:
                 # new_in_vlan is set, but in_vlan is not, so there was no

--- a/models/evc.py
+++ b/models/evc.py
@@ -645,6 +645,7 @@ class EVCDeploy(EVCBase):
             path[0].endpoint_a,
             in_vlan_a,
             out_vlan_a,
+            in_vlan_z,
             queue_id=self.queue_id,
         )
         flows_a.append(push_flow)
@@ -653,7 +654,6 @@ class EVCDeploy(EVCBase):
         pop_flow = self._prepare_pop_flow(
             path[0].endpoint_a,
             self.uni_a.interface,
-            in_vlan_a,
             out_vlan_a,
             queue_id=self.queue_id,
         )
@@ -670,6 +670,7 @@ class EVCDeploy(EVCBase):
             path[-1].endpoint_b,
             in_vlan_z,
             out_vlan_z,
+            in_vlan_a,
             queue_id=self.queue_id,
         )
         flows_z.append(push_flow)
@@ -678,7 +679,6 @@ class EVCDeploy(EVCBase):
         pop_flow = self._prepare_pop_flow(
             path[-1].endpoint_b,
             self.uni_z.interface,
-            in_vlan_z,
             out_vlan_z,
             queue_id=self.queue_id,
         )
@@ -755,13 +755,14 @@ class EVCDeploy(EVCBase):
             out_interface(str): Interface output.
             in_vlan(str): Vlan input.
             out_vlan(str): Vlan output.
+            new_in_vlan(str): Interface input.
 
         Return:
             dict: An python dictionary representing a FlowMod
 
         """
         # assign all arguments
-        in_interface, out_interface, in_vlan, out_vlan = args
+        in_interface, out_interface, in_vlan, out_vlan , new_in_vlan = args
 
         flow_mod = self._prepare_flow_mod(
             in_interface, out_interface, queue_id
@@ -777,12 +778,24 @@ class EVCDeploy(EVCBase):
         if in_vlan:
             # if in_vlan is set, it must be included in the match
             flow_mod["match"]["dl_vlan"] = in_vlan
+        if new_in_vlan:
+            # new_in_vlan is set, so an action to set it is necessary
+            new_action = {"action_type": "set_vlan", "vlan_id": new_in_vlan}
+            flow_mod["actions"].insert(0, new_action)
+            if not in_vlan:
+                # new_in_vlan is set, but in_vlan is not, so there was no
+                # vlan set; then it is set now
+                new_action = {"action_type": "push_vlan", "tag_type": "c"}
+                flow_mod["actions"].insert(0, new_action)
+        elif in_vlan:
+            # in_vlan is set, but new_in_vlan is not, so the existing vlan
+            # must be removed
             new_action = {"action_type": "pop_vlan"}
             flow_mod["actions"].insert(0, new_action)
         return flow_mod
 
     def _prepare_pop_flow(
-        self, in_interface, out_interface, in_vlan, out_vlan, queue_id=None
+        self, in_interface, out_interface, out_vlan, queue_id=None
     ):
         # pylint: disable=too-many-arguments
         """Prepare pop flow."""
@@ -790,11 +803,6 @@ class EVCDeploy(EVCBase):
             in_interface, out_interface, queue_id
         )
         flow_mod["match"]["dl_vlan"] = out_vlan
-        if in_vlan:
-            new_action = {"action_type": "set_vlan", "vlan_id": in_vlan}
-            flow_mod["actions"].insert(0, new_action)
-            new_action = {"action_type": "push_vlan", "tag_type": "c"}
-            flow_mod["actions"].insert(0, new_action)
         new_action = {"action_type": "pop_vlan"}
         flow_mod["actions"].insert(0, new_action)
         return flow_mod

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -170,7 +170,7 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
 
         # pylint: disable=protected-access
         flow_mod = evc._prepare_pop_flow(
-            interface_a, interface_z, None, in_vlan
+            interface_a, interface_z, in_vlan
         )
 
         expected_flow_mod = {
@@ -197,30 +197,43 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         out_vlan_a = 20
 
         for in_vlan_a in (10, None):
-            with self.subTest(in_vlan_a=in_vlan_a):
-                # pylint: disable=protected-access
-                flow_mod = evc._prepare_push_flow(
-                    interface_a, interface_z, in_vlan_a, out_vlan_a
-                )
+            for in_vlan_z in (3, None):
+                with self.subTest(in_vlan_a=in_vlan_a, in_vlan_z=in_vlan_z):
+                    # pylint: disable=protected-access
+                    flow_mod = evc._prepare_push_flow(interface_a, interface_z,
+                                                      in_vlan_a, out_vlan_a,
+                                                      in_vlan_z)
 
-                expected_flow_mod = {
-                    "match": {"in_port": interface_a.port_number},
-                    "cookie": evc.get_cookie(),
-                    "actions": [
-                        {"action_type": "push_vlan", "tag_type": "s"},
-                        {"action_type": "set_vlan", "vlan_id": out_vlan_a},
-                        {
-                            "action_type": "output",
-                            "port": interface_z.port_number,
-                        },
-                    ],
-                }
-                if in_vlan_a:
-                    expected_flow_mod["match"]["dl_vlan"] = in_vlan_a
-                    expected_flow_mod["actions"].insert(
-                        0, {"action_type": "pop_vlan"}
-                    )
-                self.assertEqual(expected_flow_mod, flow_mod)
+                    expected_flow_mod = {
+                        'match': {'in_port': interface_a.port_number},
+                        'cookie': evc.get_cookie(),
+                        'actions': [
+                            {'action_type': 'push_vlan', 'tag_type': 's'},
+                            {'action_type': 'set_vlan', 'vlan_id': out_vlan_a},
+                            {
+                                'action_type': 'output',
+                                'port': interface_z.port_number
+                            }
+                        ]
+                    }
+                    if in_vlan_a and in_vlan_z:
+                        expected_flow_mod['match']['dl_vlan'] = in_vlan_a
+                        expected_flow_mod['actions'].insert(0, {
+                            'action_type': 'set_vlan', 'vlan_id': in_vlan_z
+                        })
+                    elif in_vlan_a:
+                        expected_flow_mod['match']['dl_vlan'] = in_vlan_a
+                        expected_flow_mod['actions'].insert(0, {
+                            'action_type': 'pop_vlan'
+                        })
+                    elif in_vlan_z:
+                        expected_flow_mod['actions'].insert(0, {
+                            'action_type': 'set_vlan', 'vlan_id': in_vlan_z
+                        })
+                        expected_flow_mod['actions'].insert(0, {
+                            'action_type': 'push_vlan', 'tag_type': 'c'
+                        })
+                    self.assertEqual(expected_flow_mod, flow_mod)
 
     @staticmethod
     @patch("napps.kytos.mef_eline.models.evc.EVC._send_flow_mods")
@@ -273,7 +286,10 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
                 },
                 "cookie": evc.get_cookie(),
                 "actions": [
-                    {"action_type": "pop_vlan"},
+                    {
+                        "action_type": "set_vlan",
+                        "vlan_id": uni_z.user_tag.value
+                    },
                     {"action_type": "push_vlan", "tag_type": "s"},
                     {
                         "action_type": "set_vlan",
@@ -297,11 +313,6 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
                 "cookie": evc.get_cookie(),
                 "actions": [
                     {"action_type": "pop_vlan"},
-                    {"action_type": "push_vlan", "tag_type": "c"},
-                    {
-                        "action_type": "set_vlan",
-                        "vlan_id": uni_a.user_tag.value,
-                    },
                     {
                         "action_type": "output",
                         "port": uni_a.interface.port_number,
@@ -322,7 +333,10 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
                 },
                 "cookie": evc.get_cookie(),
                 "actions": [
-                    {"action_type": "pop_vlan"},
+                    {
+                        "action_type": "set_vlan",
+                        "vlan_id": uni_a.user_tag.value
+                    },
                     {"action_type": "push_vlan", "tag_type": "s"},
                     {
                         "action_type": "set_vlan",
@@ -346,11 +360,6 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
                 "cookie": evc.get_cookie(),
                 "actions": [
                     {"action_type": "pop_vlan"},
-                    {"action_type": "push_vlan", "tag_type": "c"},
-                    {
-                        "action_type": "set_vlan",
-                        "vlan_id": uni_z.user_tag.value,
-                    },
                     {
                         "action_type": "output",
                         "port": uni_z.interface.port_number,


### PR DESCRIPTION
Q-in-Q had been removed because of issues with Noviflow. Now the issue is solved, so again we can have Q-in-Q, with the cliente VLAN being changed in the first switch.

Fix #154