### PR TITLE
Adding disjoint path as per EP029

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,16 @@ Added
 - ELineController and DB models
 - ``storehouse_to_mongo.py`` script to migrate data from storehouse to MongoDB
 - Retries to handle database ``AutoReconnect`` exception.
+- ``DynamicPathManager.get_disjoint_paths`` to calculates the maximum disjoint
+  paths from a given "unwanted_path" (typically the currently in use path) using
+  the approach described in blueprint EP029
+
+Changed
+=======
+
+- ``DynamicPathManager.get_paths`` to also supports ``max_paths`` parameter and
+  then request more paths from pathfinder (default to 2, which is also the
+  default on pathfinder)
 
 
 [2022.1.5] - 2022-02-11

--- a/models/path.py
+++ b/models/path.py
@@ -186,10 +186,10 @@ class DynamicPathManager:
             not provided or empty, we return an empty list.
         """
         unwanted_links = [
-            (l.endpoint_a.id, l.endpoint_b.id) for l in unwanted_path
+            (link.endpoint_a.id, link.endpoint_b.id) for link in unwanted_path
         ]
         if not unwanted_links:
-            return []
+            return None
 
         paths = cls.get_paths(circuit, max_paths=settings.DISJOINT_PATH_CUTOFF)
         for path in paths:
@@ -202,7 +202,7 @@ class DynamicPathManager:
                 ):
                     shared_edges += 1
             path["disjointness"] = 1 - shared_edges / len(unwanted_links)
-        paths = sorted(paths, key = lambda x: (-x['disjointness'], x['cost']))
+        paths = sorted(paths, key=lambda x: (-x['disjointness'], x['cost']))
         for path in paths:
             if path["disjointness"] == 0:
                 continue

--- a/models/path.py
+++ b/models/path.py
@@ -151,7 +151,9 @@ class DynamicPathManager:
             yield cls.create_path(path["hops"])
 
     @classmethod
-    def get_disjoint_paths(cls, circuit, unwanted_path):
+    def get_disjoint_paths(
+        cls, circuit, unwanted_path, cutoff=settings.DISJOINT_PATH_CUTOFF
+    ):
         """Computes the maximum disjoint paths from the unwanted_path for a EVC
 
         Maximum disjoint paths from the unwanted_path are the paths from the
@@ -179,6 +181,10 @@ class DynamicPathManager:
         unwanted_path : Path
             The Path which we want to avoid.
 
+        cutoff: int
+            Maximum number of paths to consider when calculating the disjoint
+            paths (number of paths to request from pathfinder)
+
         Returns:
         --------
         paths : generator
@@ -191,7 +197,7 @@ class DynamicPathManager:
         if not unwanted_links:
             return None
 
-        paths = cls.get_paths(circuit, max_paths=settings.DISJOINT_PATH_CUTOFF)
+        paths = cls.get_paths(circuit, max_paths=cutoff)
         for path in paths:
             head = path["hops"][:-1]
             tail = path["hops"][1:]

--- a/models/path.py
+++ b/models/path.py
@@ -207,6 +207,7 @@ class DynamicPathManager:
             if path["disjointness"] == 0:
                 continue
             yield cls.create_path(path["hops"])
+        return None
 
     @classmethod
     def create_path(cls, path):

--- a/models/path.py
+++ b/models/path.py
@@ -185,10 +185,10 @@ class DynamicPathManager:
             Generator of unwanted_path disjoint paths. If unwanted_path is
             not provided or empty, we return an empty list.
         """
-        undesired_links = [
+        unwanted_links = [
             (l.endpoint_a.id, l.endpoint_b.id) for l in unwanted_path
         ]
-        if not undesired_links:
+        if not unwanted_links:
             return []
 
         paths = cls.get_paths(circuit, max_paths=settings.DISJOINT_PATH_CUTOFF)
@@ -196,12 +196,12 @@ class DynamicPathManager:
             head = path["hops"][:-1]
             tail = path["hops"][1:]
             shared_edges = 0
-            for (endpoint_a, endpoint_b) in undesired_links:
+            for (endpoint_a, endpoint_b) in unwanted_links:
                 if ((endpoint_a, endpoint_b) in zip(head, tail)) or (
                     (endpoint_b, endpoint_a) in zip(head, tail)
                 ):
                     shared_edges += 1
-            path["disjointness"] = 1 - shared_edges / len(undesired_links)
+            path["disjointness"] = 1 - shared_edges / len(unwanted_links)
         paths = sorted(paths, key = lambda x: (-x['disjointness'], x['cost']))
         for path in paths:
             if path["disjointness"] == 0:

--- a/settings.py
+++ b/settings.py
@@ -22,3 +22,8 @@ WAIT_FOR_OLD_PATH = 5
 
 # Prefix this NApp has when using cookies
 COOKIE_PREFIX = 0xAA
+
+# Maximum number of paths to consider when calculating the disjoint paths
+# i.e., the number of paths that will be requested to pathfinder to calculate
+# the maximum disjoint paths from unwanted_path
+DISJOINT_PATH_CUTOFF = 10

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -7,6 +7,7 @@ from kytos.core.config import KytosConfig
 from kytos.core.interface import TAG, UNI, Interface
 from kytos.core.link import Link
 from kytos.core.switch import Switch
+from kytos.lib.helpers import get_interface_mock, get_switch_mock
 
 
 def get_controller_mock():
@@ -15,6 +16,15 @@ def get_controller_mock():
     controller = Controller(options)
     controller.log = Mock()
     return controller
+
+
+def id_to_interface_mock(interface_id):
+    """Create mocked interface/switch from id."""
+    switch_id = ":".join(interface_id.split(":")[:-1])
+    port_id = int(interface_id.split(":")[-1])
+    switch = get_switch_mock(switch_id, 0x04)
+    interface = get_interface_mock(port_id, port_id, switch)
+    return interface
 
 
 def get_link_mocked(**kwargs):


### PR DESCRIPTION
Related to #156 

### Description of the change

This pull request implements the `DynamicPathManager.get_disjoint_paths` as per [blueprint EP029](https://github.com/kytos-ng/kytos/blob/master/docs/blueprints/EP029.rst). Basically, the following contributions can be listed from this PR:
- Improved `DynamicPathManager.get_paths` to also supports `max_paths` parameter and then request more paths from pathfinder (default to 2, [which is also the default on pathfinder](https://github.com/kytos-ng/pathfinder/blob/61cfcde85b670a8bfe79722279aebab507801e2c/main.py#L113))
- Added `DynamicPathManager.get_disjoint_paths `, which calculates the maximum disjoint paths from a given "unwanted_path" (typically the currently in use path) using the approach described in blueprint EP029
- Improved unit test coverage for `models/path.py` from `73%` to `94%` (overall cov from 86% to 88%)

More information on the way the disjoint path is calculated can be found here: https://github.com/kytos-ng/kytos/blob/master/docs/blueprints/EP029.rst#path-disjointness


### Release notes

See Changelog