### PR TITLE
[Feature] Add consistency check to remove alien flows

### DIFF
--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -1,8 +1,11 @@
 """Method to thest EVCDeploy class."""
 import sys
+from collections import OrderedDict
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock, patch
 
+from kytos.core.common import EntityStatus
+from kytos.core.exceptions import KytosNoTagAvailableError
 from kytos.core.interface import Interface
 from kytos.core.switch import Switch
 
@@ -20,7 +23,8 @@ from napps.kytos.mef_eline.tests.helpers import (
 )  # NOQA
 
 
-class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
+# pylint: disable=too-many-public-methods, too-many-lines
+class TestEVC(TestCase):
     """Tests to verify EVC class."""
 
     def setUp(self):
@@ -110,7 +114,7 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         requests_mock.post.return_value = response
 
         # pylint: disable=protected-access
-        EVC._send_flow_mods(switch, flow_mods)
+        EVC._send_flow_mods(switch.id, flow_mods)
 
         expected_endpoint = f"{MANAGER_URL}/flows/{switch.id}"
         expected_data = {"flows": flow_mods, "force": False}
@@ -129,7 +133,7 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         requests_mock.post.return_value = response
 
         # pylint: disable=protected-access
-        EVC._send_flow_mods(switch, flow_mods, command='delete', force=True)
+        EVC._send_flow_mods(switch.id, flow_mods, command='delete', force=True)
 
         expected_endpoint = f"{MANAGER_URL}/delete/{switch.id}"
         expected_data = {"flows": flow_mods, "force": True}
@@ -150,7 +154,7 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         # pylint: disable=protected-access
         with self.assertRaises(FlowModException):
             EVC._send_flow_mods(
-                switch,
+                switch.id,
                 flow_mods,
                 command='delete',
                 force=True
@@ -349,7 +353,7 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         ]
 
         send_flow_mods_mock.assert_any_call(
-            uni_a.interface.switch, expected_flow_mod_a
+            uni_a.interface.switch.id, expected_flow_mod_a
         )
 
         expected_flow_mod_z = [
@@ -396,8 +400,51 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         ]
 
         send_flow_mods_mock.assert_any_call(
-            uni_z.interface.switch, expected_flow_mod_z
+            uni_z.interface.switch.id, expected_flow_mod_z
         )
+
+    @staticmethod
+    def create_evc_inter_switch():
+        """Create inter-switch EVC with two links in the path"""
+        uni_a = get_uni_mocked(
+            interface_port=2,
+            tag_value=82,
+            switch_id=1,
+            switch_dpid=1,
+            is_valid=True,
+        )
+        uni_z = get_uni_mocked(
+            interface_port=3,
+            tag_value=83,
+            switch_id=3,
+            switch_dpid=3,
+            is_valid=True,
+        )
+
+        attributes = {
+            "controller": get_controller_mock(),
+            "name": "custom_name",
+            "id": "1",
+            "uni_a": uni_a,
+            "uni_z": uni_z,
+            "primary_links": [
+                get_link_mocked(
+                    switch_a=Switch(1),
+                    switch_b=Switch(2),
+                    endpoint_a_port=9,
+                    endpoint_b_port=10,
+                    metadata={"s_vlan": 5},
+                ),
+                get_link_mocked(
+                    switch_a=Switch(2),
+                    switch_b=Switch(3),
+                    endpoint_a_port=11,
+                    endpoint_b_port=12,
+                    metadata={"s_vlan": 6},
+                ),
+            ],
+        }
+        return EVC(**attributes)
 
     @staticmethod
     @patch("napps.kytos.mef_eline.models.evc.EVC._send_flow_mods")
@@ -406,41 +453,10 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
 
         This test will verify the flows send to the send_flow_mods method.
         """
-        uni_a = get_uni_mocked(
-            interface_port=2,
-            tag_value=82,
-            switch_id="switch_uni_a",
-            is_valid=True,
-        )
-        uni_z = get_uni_mocked(
-            interface_port=3,
-            tag_value=83,
-            switch_id="switch_uni_z",
-            is_valid=True,
-        )
-
-        attributes = {
-            "controller": get_controller_mock(),
-            "name": "custom_name",
-            "uni_a": uni_a,
-            "uni_z": uni_z,
-            "primary_links": [
-                get_link_mocked(
-                    endpoint_a_port=9,
-                    endpoint_b_port=10,
-                    metadata={"s_vlan": 5},
-                ),
-                get_link_mocked(
-                    endpoint_a_port=11,
-                    endpoint_b_port=12,
-                    metadata={"s_vlan": 6},
-                ),
-            ],
-        }
-        evc = EVC(**attributes)
+        evc = TestEVC.create_evc_inter_switch()
 
         # pylint: disable=protected-access
-        evc._install_nni_flows(attributes["primary_links"])
+        evc._install_nni_flows(evc.primary_links)
 
         in_vlan = evc.primary_links[0].get_metadata("s_vlan").value
         out_vlan = evc.primary_links[-1].get_metadata("s_vlan").value
@@ -467,8 +483,46 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
             },
         ]
 
-        switch = evc.primary_links[0].endpoint_b.switch
-        send_flow_mods_mock.assert_called_once_with(switch, expected_flow_mods)
+        dpid = evc.primary_links[0].endpoint_b.switch.id
+        send_flow_mods_mock.assert_called_once_with(dpid, expected_flow_mods)
+
+    def test_get_flows_match_evc_inter_switch(self):
+        """Test method get_flows_match with inter switch EVC."""
+        evc = self.create_evc_inter_switch()
+        evc.current_path = evc.primary_links
+        expected_flows = OrderedDict({
+            2: [
+                {
+                    'match': {'in_port': 10, 'dl_vlan': 5},
+                    'cookie': 0xaa00000000000001,
+                },
+                {
+                    'match': {'in_port': 11, 'dl_vlan': 6},
+                    'cookie': 0xaa00000000000001,
+                },
+            ],
+            1: [
+                {
+                    'match': {'in_port': 2, 'dl_vlan': 82},
+                    'cookie': 0xaa00000000000001,
+                },
+                {
+                    'match': {'in_port': 9, 'dl_vlan': 5},
+                    'cookie': 0xaa00000000000001,
+                },
+            ],
+            3: [
+                {
+                    'match': {'in_port': 3, 'dl_vlan': 83},
+                    'cookie': 0xaa00000000000001,
+                },
+                {
+                    'match': {'in_port': 12, 'dl_vlan': 6},
+                    'cookie': 0xaa00000000000001,
+                },
+            ],
+        })
+        self.assertEqual(evc.get_flows_match(), expected_flows)
 
     @patch("requests.post")
     @patch("napps.kytos.mef_eline.controllers.ELineController.upsert_evc")
@@ -476,6 +530,7 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
     @patch("napps.kytos.mef_eline.models.path.Path.choose_vlans")
     @patch("napps.kytos.mef_eline.models.evc.EVC._install_nni_flows")
     @patch("napps.kytos.mef_eline.models.evc.EVC._install_uni_flows")
+    @patch("napps.kytos.mef_eline.models.evc.EVC._install_direct_uni_flows")
     @patch("napps.kytos.mef_eline.models.evc.EVC.activate")
     @patch("napps.kytos.mef_eline.models.evc.EVC.should_deploy")
     def test_deploy_successfully(self, *args):
@@ -484,6 +539,7 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         (
             should_deploy_mock,
             activate_mock,
+            install_direct_uni_flows_mock,
             install_uni_flows_mock,
             install_nni_flows,
             chose_vlans_mock,
@@ -497,44 +553,8 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         requests_mock.return_value = response
 
         should_deploy_mock.return_value = True
-        uni_a = get_uni_mocked(
-            interface_port=2,
-            tag_value=82,
-            switch_id="switch_uni_a",
-            is_valid=True,
-        )
-        uni_z = get_uni_mocked(
-            interface_port=3,
-            tag_value=83,
-            switch_id="switch_uni_z",
-            is_valid=True,
-        )
-        primary_links = [
-            get_link_mocked(
-                endpoint_a_port=9, endpoint_b_port=10, metadata={"s_vlan": 5}
-            ),
-            get_link_mocked(
-                endpoint_a_port=11, endpoint_b_port=12, metadata={"s_vlan": 6}
-            ),
-        ]
-
-        attributes = {
-            "controller": get_controller_mock(),
-            "name": "custom_name",
-            "uni_a": uni_a,
-            "uni_z": uni_z,
-            "primary_links": primary_links,
-            "queue_id": 5,
-        }
-
-        # Setup path to deploy
-        path = Path()
-        path.append(primary_links[0])
-        path.append(primary_links[1])
-
-        evc = EVC(**attributes)
-
-        deployed = evc.deploy_to_path(path)
+        evc = self.create_evc_inter_switch()
+        deployed = evc.deploy_to_path(evc.primary_links)
 
         self.assertEqual(should_deploy_mock.call_count, 1)
         self.assertEqual(activate_mock.call_count, 1)
@@ -544,20 +564,22 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         log_mock.info.assert_called_with(f"{evc} was deployed.")
         self.assertTrue(deployed)
 
+        # intra switch EVC
+        evc = self.create_evc_intra_switch()
+        self.assertTrue(evc.deploy_to_path(evc.primary_links))
+        self.assertEqual(install_direct_uni_flows_mock.call_count, 1)
+        self.assertEqual(activate_mock.call_count, 2)
+        self.assertEqual(log_mock.info.call_count, 2)
+        log_mock.info.assert_called_with(f"{evc} was deployed.")
+
     @patch("requests.post")
     @patch("napps.kytos.mef_eline.models.evc.log")
-    @patch(
-        "napps.kytos.mef_eline.models.evc.EVC.discover_new_paths",
-        return_value=[],
-    )
+    @patch("napps.kytos.mef_eline.models.evc.EVC.discover_new_paths")
     @patch("napps.kytos.mef_eline.models.path.Path.choose_vlans")
     @patch("napps.kytos.mef_eline.models.evc.EVC._install_nni_flows")
     @patch("napps.kytos.mef_eline.models.evc.EVC._install_uni_flows")
     @patch("napps.kytos.mef_eline.models.evc.EVC.activate")
-    @patch(
-        "napps.kytos.mef_eline.models.evc.EVC.should_deploy",
-        return_value=False,
-    )
+    @patch("napps.kytos.mef_eline.models.evc.EVC.should_deploy")
     @patch("napps.kytos.mef_eline.models.EVC.sync")
     def test_deploy_fail(self, *args):
         """Test if all methods is ignored when the should_deploy is false."""
@@ -569,7 +591,7 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
             install_uni_flows_mock,
             install_nni_flows,
             choose_vlans_mock,
-            discover_new_paths,
+            discover_new_paths_mock,
             log_mock,
             requests_mock,
         ) = args
@@ -578,44 +600,12 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         response.status_code = 201
         requests_mock.return_value = response
 
-        uni_a = get_uni_mocked(
-            interface_port=2,
-            tag_value=82,
-            switch_id="switch_uni_a",
-            switch_dpid="switch_dpid_uni_a",
-            is_valid=True,
-        )
-        uni_z = get_uni_mocked(
-            interface_port=3,
-            tag_value=83,
-            switch_id="switch_uni_z",
-            switch_dpid="switch_dpid_uni_a",
-            is_valid=True,
-        )
-
-        attributes = {
-            "controller": get_controller_mock(),
-            "name": "custom_name",
-            "uni_a": uni_a,
-            "uni_z": uni_z,
-            "primary_links": [
-                get_link_mocked(
-                    endpoint_a_port=9,
-                    endpoint_b_port=10,
-                    metadata={"s_vlan": 5},
-                ),
-                get_link_mocked(
-                    endpoint_a_port=11,
-                    endpoint_b_port=12,
-                    metadata={"s_vlan": 6},
-                ),
-            ],
-        }
-
-        evc = EVC(**attributes)
+        evc = self.create_evc_inter_switch()
+        should_deploy_mock.return_value = False
+        discover_new_paths_mock.return_value = []
         deployed = evc.deploy_to_path()
 
-        self.assertEqual(discover_new_paths.call_count, 1)
+        self.assertEqual(discover_new_paths_mock.call_count, 1)
         self.assertEqual(should_deploy_mock.call_count, 1)
         self.assertEqual(activate_mock.call_count, 0)
         self.assertEqual(install_uni_flows_mock.call_count, 0)
@@ -624,6 +614,17 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         self.assertEqual(log_mock.info.call_count, 0)
         self.assertEqual(sync_mock.call_count, 1)
         self.assertFalse(deployed)
+
+        # NoTagAvailable on static path
+        should_deploy_mock.return_value = True
+        choose_vlans_mock.side_effect = KytosNoTagAvailableError("error")
+        self.assertFalse(evc.deploy_to_path(evc.primary_links))
+
+        # NoTagAvailable on dynamic path
+        should_deploy_mock.return_value = False
+        discover_new_paths_mock.return_value = [Path(['a', 'b'])]
+        choose_vlans_mock.side_effect = KytosNoTagAvailableError("error")
+        self.assertFalse(evc.deploy_to_path(evc.primary_links))
 
     @patch("napps.kytos.mef_eline.models.evc.log")
     @patch(
@@ -809,11 +810,55 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         log_mock.info.assert_called_with(f"{evc} was deployed.")
         self.assertTrue(deployed)
 
+    @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.deploy_to_primary_path")
+    @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.deploy_to_backup_path")
+    @patch("napps.kytos.mef_eline.models.evc.emit_event")
+    def test_deploy(self, *args):
+        """Test method deploy"""
+        (emit_event_mock, deploy_primary_mock, deploy_backup_mock) = args
+
+        # case 1: deploy to primary
+        self.evc_deploy.archived = False
+        deploy_primary_mock.return_value = True
+        self.assertTrue(self.evc_deploy.deploy())
+        self.assertEqual(emit_event_mock.call_count, 1)
+
+        # case 2: deploy to backup
+        deploy_primary_mock.return_value = False
+        deploy_backup_mock.return_value = True
+        self.assertTrue(self.evc_deploy.deploy())
+        self.assertEqual(emit_event_mock.call_count, 2)
+
+        # case 3: fail to deploy to primary and backup
+        deploy_backup_mock.return_value = False
+        self.assertFalse(self.evc_deploy.deploy())
+        self.assertEqual(emit_event_mock.call_count, 2)
+
+        # case 4: archived
+        self.evc_deploy.archived = True
+        self.assertFalse(self.evc_deploy.deploy())
+        self.assertEqual(emit_event_mock.call_count, 2)
+
+    @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.remove_current_flows")
+    @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.sync")
+    @patch("napps.kytos.mef_eline.models.evc.emit_event")
+    def test_remove(self, *args):
+        """Test method remove"""
+        (emit_event_mock, sync_mock, remove_flows_mock) = args
+        self.evc_deploy.remove()
+        remove_flows_mock.assert_called()
+        sync_mock.assert_called()
+        emit_event_mock.assert_called()
+        self.assertFalse(self.evc_deploy.is_enabled())
+
     @patch("napps.kytos.mef_eline.controllers.ELineController.upsert_evc")
     @patch("napps.kytos.mef_eline.models.evc.notify_link_available_tags")
     @patch("napps.kytos.mef_eline.models.evc.EVC._send_flow_mods")
-    def test_remove_current_flows(self, send_flow_mods_mocked, notify_mock, _):
+    @patch("napps.kytos.mef_eline.models.evc.log.error")
+    def test_remove_current_flows(self, *args):
         """Test remove current flows."""
+        # pylint: disable=too-many-locals
+        (log_error_mock, send_flow_mods_mocked, notify_mock, _) = args
         uni_a = get_uni_mocked(
             interface_port=2,
             tag_value=82,
@@ -869,18 +914,21 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         ]
         switch_1 = evc.primary_links[0].endpoint_a.switch
         switch_2 = evc.primary_links[0].endpoint_b.switch
-        send_flow_mods_mocked.assert_any_call(switch_1, flows, 'delete',
+        send_flow_mods_mocked.assert_any_call(switch_1.id, flows, 'delete',
                                               force=True)
-        send_flow_mods_mocked.assert_any_call(switch_2, flows, 'delete',
+        send_flow_mods_mocked.assert_any_call(switch_2.id, flows, 'delete',
                                               force=True)
+
+        send_flow_mods_mocked.side_effect = FlowModException("error")
+        evc.remove_current_flows()
+        log_error_mock.assert_called()
 
     @staticmethod
-    @patch("napps.kytos.mef_eline.models.evc.EVC._send_flow_mods")
-    def test_deploy_direct_uni_flows(send_flow_mods_mock):
-        """Test _install_direct_uni_flows."""
-
+    def create_evc_intra_switch():
+        """Create intra-switch EVC."""
         switch = Mock(spec=Switch)
         switch.dpid = 2
+        switch.id = switch.dpid
         interface_a = Interface("eth0", 1, switch)
         interface_z = Interface("eth1", 3, switch)
         uni_a = get_uni_mocked(
@@ -896,52 +944,136 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         attributes = {
             "controller": get_controller_mock(),
             "name": "custom_name",
+            "id": "1",
             "uni_a": uni_a,
             "uni_z": uni_z,
             "enabled": True,
-            "active": True,
         }
-        evc = EVC(**attributes)
+        return EVC(**attributes)
+
+    @staticmethod
+    @patch("napps.kytos.mef_eline.models.evc.EVC._send_flow_mods")
+    def test_deploy_direct_uni_flows(send_flow_mods_mock):
+        """Test _install_direct_uni_flows."""
+        evc = TestEVC.create_evc_intra_switch()
+
+        # Test 1: both UNIs with TAG
+        expected_dpid = evc.uni_a.interface.switch.id
+        expected_flows = [
+            {
+                "match": {"in_port": 1, "dl_vlan": 82},
+                "cookie": evc.get_cookie(),
+                "actions": [
+                    {"action_type": "set_vlan", "vlan_id": 84},
+                    {"action_type": "output", "port": 3},
+                ]
+            },
+            {
+                "match": {"in_port": 3, "dl_vlan": 84},
+                "cookie": evc.get_cookie(),
+                "actions": [
+                    {"action_type": "set_vlan", "vlan_id": 82},
+                    {"action_type": "output", "port": 1},
+                ]
+            }
+        ]
 
         # pylint: disable=protected-access
         evc._install_direct_uni_flows()
         send_flow_mods_mock.assert_called_once_with(
-            switch, [
+            expected_dpid, expected_flows
+        )
+
+        # Test2: no TAG in UNI_A
+        uni_a_tag = evc.uni_a.user_tag
+        evc.uni_a.user_tag = None
+        expected_flows_no_tag_a = [
+            {
+                "match": {"in_port": 1},
+                "cookie": evc.get_cookie(),
+                "actions": [
+                    {"action_type": "set_vlan", "vlan_id": 84},
+                    {"action_type": "output", "port": 3},
+                ]
+            },
+            {
+                "match": {"in_port": 3, "dl_vlan": 84},
+                "cookie": evc.get_cookie(),
+                "actions": [
+                    {"action_type": "pop_vlan"},
+                    {"action_type": "output", "port": 1},
+                ]
+            }
+        ]
+        evc._install_direct_uni_flows()
+        send_flow_mods_mock.assert_called_with(
+            expected_dpid, expected_flows_no_tag_a
+        )
+        evc.uni_a.user_tag = uni_a_tag
+
+        # Test3: no TAG in UNI_Z
+        uni_z_tag = evc.uni_z.user_tag
+        evc.uni_z.user_tag = None
+        expected_flows_no_tag_z = [
+            {
+                "match": {"in_port": 1, "dl_vlan": 82},
+                "cookie": evc.get_cookie(),
+                "actions": [
+                    {"action_type": "pop_vlan"},
+                    {"action_type": "output", "port": 3},
+                ]
+            },
+            {
+                "match": {"in_port": 3},
+                "cookie": evc.get_cookie(),
+                "actions": [
+                    {"action_type": "set_vlan", "vlan_id": 82},
+                    {"action_type": "output", "port": 1},
+                ]
+            }
+        ]
+        evc._install_direct_uni_flows()
+        send_flow_mods_mock.assert_called_with(
+            expected_dpid, expected_flows_no_tag_z
+        )
+        evc.uni_z.user_tag = uni_z_tag
+
+        # Test3: no TAG in both UNI_Z and UNI_Z
+        evc.uni_a.user_tag = None
+        evc.uni_z.user_tag = None
+        expected_flows_no_tag = [
+            {
+                "match": {"in_port": 1},
+                "cookie": evc.get_cookie(),
+                "actions": [{"action_type": "output", "port": 3}]
+            },
+            {
+                "match": {"in_port": 3},
+                "cookie": evc.get_cookie(),
+                "actions": [{"action_type": "output", "port": 1}]
+            }
+        ]
+        evc._install_direct_uni_flows()
+        send_flow_mods_mock.assert_called_with(
+            expected_dpid, expected_flows_no_tag
+        )
+
+    def test_get_flows_match_evc_intra_switch(self):
+        """Test method get_flows_match with intra-switch EVC."""
+        evc = self.create_evc_intra_switch()
+        expected_flows = OrderedDict({
+            2: [
                 {
-                    "match": {
-                        "in_port": 1,
-                        "dl_vlan": 82,
-                    },
-                    "cookie": evc.get_cookie(),
-                    "actions": [
-                        {
-                            "action_type": "set_vlan",
-                            "vlan_id": 84,
-                        },
-                        {
-                            "action_type": "output",
-                            "port": 3,
-                        },
-                    ]
+                    'match': {'in_port': 1, 'dl_vlan': 82},
+                    'cookie': 0xaa00000000000001,
                 },
                 {
-                    "match": {
-                        "in_port": 3,
-                        "dl_vlan": 84,
-                    },
-                    "cookie": evc.get_cookie(),
-                    "actions": [
-                        {
-                            "action_type": "set_vlan",
-                            "vlan_id": 82,
-                        },
-                        {
-                            "action_type": "output",
-                            "port": 1,
-                        },
-                    ]
-                }
-            ])
+                    'match': {'in_port': 3, 'dl_vlan': 84},
+                    'cookie': 0xaa00000000000001,
+                },
+            ],
+        })
+        self.assertEqual(evc.get_flows_match(), expected_flows)
 
     def test_is_affected_by_link(self):
         """Test is_affected_by_link method"""
@@ -977,3 +1109,27 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         self.evc_deploy.backup_path = Path([])
         self.evc_deploy.primary_path = Path([])
         self.assertFalse(self.evc_deploy.is_using_dynamic_path())
+
+    def test_get_path_status(self):
+        """Test get_path_status method"""
+        path = Path([])
+        self.assertEqual(
+            self.evc_deploy.get_path_status(path),
+            EntityStatus.DISABLED
+        )
+        path = Path([
+            get_link_mocked(status=EntityStatus.UP),
+            get_link_mocked(status=EntityStatus.DOWN)
+        ])
+        self.assertEqual(
+            self.evc_deploy.get_path_status(path),
+            EntityStatus.DOWN
+        )
+        path = Path([
+            get_link_mocked(status=EntityStatus.UP),
+            get_link_mocked(status=EntityStatus.UP)
+        ])
+        self.assertEqual(
+            self.evc_deploy.get_path_status(path),
+            EntityStatus.UP
+        )

--- a/utils.py
+++ b/utils.py
@@ -14,9 +14,9 @@ from kytos.core import log
 from kytos.core.events import KytosEvent
 
 
-def emit_event(controller, name, **kwargs):
+def emit_event(controller, name, context="kytos/mef_eline", **kwargs):
     """Send an event when something happens with an EVC."""
-    event_name = f"kytos/mef_eline.{name}"
+    event_name = f"{context}.{name}"
     event = KytosEvent(name=event_name, content=kwargs)
     controller.buffers.app.put(event)
 


### PR DESCRIPTION
Related to #156

### Description of the change

This pull request implements the removal of alien flows (e.g., from an old Path) as per [blueprint EP029](https://github.com/kytos-ng/kytos/blob/master/docs/blueprints/EP029.rst). More specifically, the following requirement will be delivered with this PR:

> The removal of forwarding flows from the old path should be handled as part of the consistency check routine, thus avoiding additional overhead as part of the link failure handling process. In the meantime, garbage/alien flows will be in the flow table. Those alien flows will be removed at the subsequent MEF E-Line consistency check execution. Therefore, new failover/protection paths should be established after the consistency check clears alien flows to avoid uncontrolled growth in the flow table size.

Contributions that can be listed from this PR:
- Extended MEF E-Line consistency check routing to check fo alien flows and request their removal
- Improved unit test coverage for `models/evc.py` from `xx%` to `91%` (overall cov from 88% to 91%)


### Release notes
