### PR TITLE
[Feature] `service_level` and `sb_priority` attributes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,18 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [Unreleased]
 ************
 
+Added
+=====
+- Added ``service_level`` EVC attribute to set the service network convergence level, the higher the better
+
+Changed
+=======
+- ``priority`` has been renamed to ``sb_priority`` (southbound priority), ``./scripts/001_rename_priority.py`` can be used to update EVC documents accordingly
+
+Removed
+=======
+- ``priority`` is no longer supported in the API spec
+
 [2022.2.0] - 2022-08-12
 ***********************
 

--- a/db/models.py
+++ b/db/models.py
@@ -69,7 +69,7 @@ class EVCBaseDoc(DocumentBaseModel):
     dynamic_backup_path: bool
     creation_time: datetime
     owner: Optional[str]
-    priority: int
+    sb_priority: Optional[int]
     service_level: int = 0
     circuit_scheduler: List[CircuitScheduleDoc]
     archived: bool = False
@@ -93,7 +93,8 @@ class EVCBaseDoc(DocumentBaseModel):
             "current_path": 1,
             "failover_path": 1,
             "dynamic_backup_path": 1,
-            "priority": 1,
+            "sb_priority": {"$ifNull": ["$sb_priority", "$priority", None]},
+            "service_level": 1,
             "circuit_scheduler": 1,
             "archived": 1,
             "metadata": 1,

--- a/db/models.py
+++ b/db/models.py
@@ -70,6 +70,7 @@ class EVCBaseDoc(DocumentBaseModel):
     creation_time: datetime
     owner: Optional[str]
     priority: int
+    service_level: int = 0
     circuit_scheduler: List[CircuitScheduleDoc]
     archived: bool = False
     metadata: Optional[Dict] = None

--- a/models/evc.py
+++ b/models/evc.py
@@ -76,7 +76,8 @@ class EVCBase(GenericEntity):
                                archived; default is False.
             owner(str): The EVC owner. Default is None.
             priority(int): Service level provided in the request. Default is 0.
-            service_level(int): Service level provided in the request. Default is 0.
+            service_level(int): Service level provided. The higher the better.
+                                Default is 0.
 
         Raises:
             ValueError: raised when object attributes are invalid.

--- a/models/evc.py
+++ b/models/evc.py
@@ -36,7 +36,7 @@ class EVCBase(GenericEntity):
         "backup_path",
         "dynamic_backup_path",
         "queue_id",
-        "priority",
+        "sb_priority",
     ]
     required_attributes = ["name", "uni_a", "uni_z"]
 
@@ -75,7 +75,8 @@ class EVCBase(GenericEntity):
             archived(Boolean): indicate the EVC has been deleted and is
                                archived; default is False.
             owner(str): The EVC owner. Default is None.
-            priority(int): Service level provided in the request. Default is 0.
+            sb_priority(int): Service level provided in the request.
+                              Default is None.
             service_level(int): Service level provided. The higher the better.
                                 Default is 0.
 
@@ -107,7 +108,9 @@ class EVCBase(GenericEntity):
         self.dynamic_backup_path = kwargs.get("dynamic_backup_path", False)
         self.creation_time = get_time(kwargs.get("creation_time")) or now()
         self.owner = kwargs.get("owner", None)
-        self.priority = kwargs.get("priority", -1)
+        self.sb_priority = kwargs.get("sb_priority", None) or kwargs.get(
+            "priority", None
+        )
         self.service_level = kwargs.get("service_level", 0)
         self.circuit_scheduler = kwargs.get("circuit_scheduler", [])
 
@@ -282,7 +285,7 @@ class EVCBase(GenericEntity):
         evc_dict["active"] = self.is_active()
         evc_dict["enabled"] = self.is_enabled()
         evc_dict["archived"] = self.archived
-        evc_dict["priority"] = self.priority
+        evc_dict["sb_priority"] = self.sb_priority
         evc_dict["service_level"] = self.service_level
 
         return evc_dict
@@ -889,8 +892,8 @@ class EVCDeploy(EVCBase):
             "cookie": self.get_cookie(),
             "actions": default_actions,
         }
-        if self.priority > -1:
-            flow_mod["priority"] = self.priority
+        if self.sb_priority:
+            flow_mod["priority"] = self.sb_priority
 
         return flow_mod
 

--- a/models/evc.py
+++ b/models/evc.py
@@ -76,6 +76,7 @@ class EVCBase(GenericEntity):
                                archived; default is False.
             owner(str): The EVC owner. Default is None.
             priority(int): Service level provided in the request. Default is 0.
+            service_level(int): Service level provided in the request. Default is 0.
 
         Raises:
             ValueError: raised when object attributes are invalid.
@@ -106,6 +107,7 @@ class EVCBase(GenericEntity):
         self.creation_time = get_time(kwargs.get("creation_time")) or now()
         self.owner = kwargs.get("owner", None)
         self.priority = kwargs.get("priority", -1)
+        self.service_level = kwargs.get("service_level", 0)
         self.circuit_scheduler = kwargs.get("circuit_scheduler", [])
 
         self.current_links_cache = set()
@@ -264,13 +266,6 @@ class EVCBase(GenericEntity):
         evc_dict["dynamic_backup_path"] = self.dynamic_backup_path
         evc_dict["metadata"] = self.metadata
 
-        # if self._requested:
-        #     request_dict = self._requested.copy()
-        #     request_dict['uni_a'] = request_dict['uni_a'].as_dict()
-        #     request_dict['uni_z'] = request_dict['uni_z'].as_dict()
-        #     request_dict['circuit_scheduler'] = self.circuit_scheduler
-        #     evc_dict['_requested'] = request_dict
-
         evc_dict["request_time"] = self.request_time
         if isinstance(self.request_time, datetime):
             evc_dict["request_time"] = self.request_time.strftime(time_fmt)
@@ -287,6 +282,7 @@ class EVCBase(GenericEntity):
         evc_dict["enabled"] = self.is_enabled()
         evc_dict["archived"] = self.archived
         evc_dict["priority"] = self.priority
+        evc_dict["service_level"] = self.service_level
 
         return evc_dict
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -326,13 +326,16 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CircuitSchedule'
-        priority:
+        sb_priority:
           type: integer
-          format: int64
+          format: int32
+          description: "Southbound priority value"
+          minimum: 0
         service_level:
           type: integer
           format: int32
-          description: "Service level provided for network convergence. The higher the better."
+          description: "Service level provided for network convergence. The higher the better"
+          default: 0
           minimum: 0
           maximum: 7
         enabled:
@@ -458,13 +461,16 @@ components:
 
         owner:
           type: string
-        priority:
+        sb_priority:
           type: integer
           format: int32
+          description: "Southbound priority value"
+          minimum: 0
         service_level:
           type: integer
           format: int32
-          description: "Service level provided for network convergence. The higher the better."
+          description: "Service level provided for network convergence. The higher the better"
+          default: 0
           minimum: 0
           maximum: 7
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -329,6 +329,12 @@ components:
         priority:
           type: integer
           format: int64
+        service_level:
+          type: integer
+          format: int32
+          description: "Service level provided for network convergence. The higher the better."
+          minimum: 0
+          maximum: 7
         enabled:
           type: boolean
     NewLink:
@@ -455,6 +461,12 @@ components:
         priority:
           type: integer
           format: int32
+        service_level:
+          type: integer
+          format: int32
+          description: "Service level provided for network convergence. The higher the better."
+          minimum: 0
+          maximum: 7
 
         circuit_scheduler:
           type: array

--- a/scripts/001_rename_priority.py
+++ b/scripts/001_rename_priority.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from napps.kytos.mef_eline.controllers import ELineController
+
+
+def rename_evc_priority_to_sb_priority() -> int:
+    """Rename evcs priority to sb_priority."""
+    controller = ELineController()
+    db = controller.db
+    return db.evcs.update_many(
+        {}, {"$rename": {"priority": "sb_priority"}}
+    ).modified_count
+
+
+def main() -> None:
+    """Main function."""
+    count = rename_evc_priority_to_sb_priority()
+    print(f"Rename evc priority as sb_priority updated: {count}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/models/test_evc_base.py
+++ b/tests/unit/models/test_evc_base.py
@@ -214,7 +214,8 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
                 ),
             ],
             "enabled": True,
-            "priority": 2,
+            "sb_priority": 2,
+            "service_level": 7,
         }
         evc = EVC(**attributes)
 
@@ -248,7 +249,8 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
             ],
             "active": False,
             "enabled": True,
-            "priority": 2,
+            "sb_priority": 2,
+            "service_level": 7,
         }
         actual_dict = evc.as_dict()
         for name, value in expected_dict.items():

--- a/tests/unit/test_db_models.py
+++ b/tests/unit/test_db_models.py
@@ -38,6 +38,14 @@ class TestDBModels(TestCase):
 
         evc = EVCBaseDoc(**self.evc_dict)
         assert evc.name == "EVC 2"
+        assert evc.uni_a.interface_id == "00:00:00:00:00:00:00:04:1"
+        assert evc.uni_z.interface_id == "00:00:00:00:00:00:00:02:3"
+        assert evc.dynamic_backup_path
+        assert evc.priority == 81
+        assert evc.service_level == 0
+        assert not evc.active
+        assert not evc.enabled
+        assert not evc.circuit_scheduler
 
     def test_evcbasedoc_error(self):
         """Test failure EVCBaseDoc model creation"""

--- a/tests/unit/test_db_models.py
+++ b/tests/unit/test_db_models.py
@@ -27,7 +27,7 @@ class TestDBModels(TestCase):
             "name": "EVC 2",
             "dynamic_backup_path": True,
             "creation_time": "2022-04-06T21:34:10",
-            "priority": 81,
+            "sb_priority": 81,
             "active": False,
             "enabled": False,
             "circuit_scheduler": []
@@ -41,7 +41,7 @@ class TestDBModels(TestCase):
         assert evc.uni_a.interface_id == "00:00:00:00:00:00:00:04:1"
         assert evc.uni_z.interface_id == "00:00:00:00:00:00:00:02:3"
         assert evc.dynamic_backup_path
-        assert evc.priority == 81
+        assert evc.sb_priority == 81
         assert evc.service_level == 0
         assert not evc.active
         assert not evc.enabled

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1332,7 +1332,7 @@ class TestMain(TestCase):
                 ]
             },
             {
-                "priority": 3
+                "sb_priority": 3
             },
             {
                 # It works only with 'enable' and not with 'enabled'


### PR DESCRIPTION
Fixes issue #192

### Changelog 

- Added ``service_level`` EVC attribute to set the service network convergence level, the higher the better
- ``priority`` has been renamed to ``sb_priority`` (southbound priority), ``./scripts/001_rename_priority.py`` can be used to update EVC documents accordingly
- ``priority`` is no longer supported in the API spec

The `service_level` is only being set, it'll be used on issue #179 

### DB script

```
❯ python scripts/001_rename_priority.py
Rename evc priority as sb_priority updated: 1

❯ python scripts/001_rename_priority.py
Rename evc priority as sb_priority updated: 0
```

### Local tests

I've also explored it locally setting `service_level` and `sb_priority`:

```
{
    "3430a0de7e054b": {
        ...
        "id": "3430a0de7e054b",
        "metadata": {},
        "name": "epl",
        "owner": null,
        "primary_links": [],
        "primary_path": [],
        "queue_id": null,
        "request_time": "2022-09-29T19:40:55",
        "sb_priority": 2000,
        "service_level": 7,
      }
}
```

Validation on create also works as expected, validating `service_level` range values:

```
{
    "code": 400,
    "description": "The request body contains invalid API data. 70 is greater than the maximum of 7 for field service_level.",
    "name": "Bad Request"
}
```

```
~/repos/napps master*
❯ sudo ovs-ofctl -O OpenFlow13 dump-flows s1 --rsort=priority
 cookie=0x0, duration=93.935s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=ee:ee:ee:ee:ee:02 actions=CONTROLLER:65535
 cookie=0x0, duration=93.931s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=ee:ee:ee:ee:ee:03 actions=CONTROLLER:65535
 cookie=0xaa3430a0de7e054b, duration=16.743s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=2000,in_port="s1-eth1" actions=push_vlan:0x88a8,set_field:7763->vlan_vid,output:"s1-
eth3"
 cookie=0xaa3430a0de7e054b, duration=16.742s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=2000,in_port="s1-eth3",dl_vlan=3667 actions=pop_vlan,output:"s1-eth1"
 cookie=0xaa3430a0de7e054b, duration=16.611s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=2000,in_port="s1-eth2",dl_vlan=730 actions=pop_vlan,output:"s1-eth1"
 cookie=0xab00000000000001, duration=95.278s, table=0, n_packets=64, n_bytes=2688, send_flow_rem priority=1000,dl_vlan=3799,dl_type=0x88cc actions=CONTROLLER:65535

```