### PR TITLE
[Feature] Prioritized network convergence based on `service_level`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 Added
 =====
 - Added ``service_level`` EVC attribute to set the service network convergence level, the higher the better
+- EVCs with higher service level priority will be handled first during network convergence, including when running ``sdntrace_cp`` consistency checks.
 
 Changed
 =======

--- a/main.py
+++ b/main.py
@@ -60,6 +60,14 @@ class Main(KytosNApp):
 
         self.load_all_evcs()
 
+    def get_evcs_by_svc_level(self) -> list:
+        """Get circuits sorted by desc service level and asc creation_time.
+
+        In the future, as more ops are offloaded it should be get from the DB.
+        """
+        return sorted(self.circuits.values(),
+                      key=lambda x: (-x.service_level, x.creation_time))
+
     @staticmethod
     def get_eline_controller():
         """Return the ELineController instance."""
@@ -81,7 +89,7 @@ class Main(KytosNApp):
         """Execute consistency routine."""
         self.execution_rounds += 1
         stored_circuits = self.mongo_controller.get_circuits()['circuits']
-        for circuit in tuple(self.circuits.values()):
+        for circuit in self.get_evcs_by_svc_level():
             stored_circuits.pop(circuit.id, None)
             if (
                 circuit.is_enabled()
@@ -633,7 +641,7 @@ class Main(KytosNApp):
     def handle_link_up(self, event):
         """Change circuit when link is up or end_maintenance."""
         log.debug("Event handle_link_up %s", event)
-        for evc in self.circuits.copy().values():
+        for evc in self.get_evcs_by_svc_level():
             if evc.is_enabled() and not evc.archived:
                 with evc.lock:
                     evc.handle_link_up(event.content["link"])
@@ -651,7 +659,7 @@ class Main(KytosNApp):
         evcs_with_failover = []
         evcs_normal = []
         check_failover = []
-        for evc in self.circuits.copy().values():
+        for evc in self.get_evcs_by_svc_level():
             if evc.is_affected_by_link(link):
                 # if there is no failover path, handles link down the
                 # tradditional way


### PR DESCRIPTION
Fixes #179 

This PR is on top of PR #196 

### Changelog

- EVCs with higher service level priority will be handled first during network convergence, including when running ``sdntrace_cp`` consistency checks.

### Local tests

In addition to unit tests, I've also explored it with three EVCs (I've temporarily included some new logs), simulated link down and consistency checks:

```
2022-10-05 15:46:11,621 - INFO [kytos.napps.kytos/mef_eline] [main.py:658:handle_link_down] (thread_pool_app_1) Event handle_link_down Link(Interface('s1-eth3', 3, Switch('00:00:00:00:00
:00:00:01')), Interface('s3-eth3', 3, Switch('00:00:00:00:00:00:00:03')))
2022-10-05 15:46:11,622 - INFO [kytos.napps.kytos/mef_eline] [main.py:664:handle_link_down] (thread_pool_app_1) handle_link_down checking evc b3153652185742 name evpl1 service_level 7
2022-10-05 15:46:11,622 - INFO [kytos.napps.kytos/mef_eline] [main.py:664:handle_link_down] (thread_pool_app_1) handle_link_down checking evc 88761fe7908949 name evpl2 service_level 6
2022-10-05 15:46:11,622 - INFO [kytos.napps.kytos/mef_eline] [main.py:664:handle_link_down] (thread_pool_app_1) handle_link_down checking evc 0bb154c8652546 name evpl0 service_level 0

2022-10-05 15:46:12,138 - INFO [kytos.napps.kytos/mef_eline] [main.py:706:handle_link_down] (thread_pool_app_1) EVC(b3153652185742, evpl1) redeployed with failover due to link down 45239
03085a1861c5dc2441c83e3499a9ff763c7794061de87ffc22e44f1a680
2022-10-05 15:46:12,155 - INFO [kytos.napps.kytos/mef_eline] [main.py:706:handle_link_down] (thread_pool_app_1) EVC(88761fe7908949, evpl2) redeployed with failover due to link down 45239
03085a1861c5dc2441c83e3499a9ff763c7794061de87ffc22e44f1a680
2022-10-05 15:46:12,174 - INFO [kytos.napps.kytos/mef_eline] [main.py:706:handle_link_down] (thread_pool_app_1) EVC(0bb154c8652546, evpl0) redeployed with failover due to link down 45239
03085a1861c5dc2441c83e3499a9ff763c7794061de87ffc22e44f1a680

```

```
kytos $> 2022-10-05 15:47:55,581 - INFO [kytos.napps.kytos/mef_eline] [main.py:99:execute_consistency] (mef_eline) Executing consistency for evc b3153652185742 service_level 7
2022-10-05 15:47:55,584 - INFO [werkzeug] [_internal.py:225:_log] (Thread-123) 127.0.0.1 - - [05/Oct/2022 15:47:55] "PUT /api/amlight/sdntrace_cp/trace HTTP/1.1" 200 -
2022-10-05 15:47:55,588 - INFO [werkzeug] [_internal.py:225:_log] (Thread-124) 127.0.0.1 - - [05/Oct/2022 15:47:55] "PUT /api/amlight/sdntrace_cp/trace HTTP/1.1" 200 -
2022-10-05 15:47:55,590 - INFO [kytos.napps.kytos/mef_eline] [main.py:101:execute_consistency] (mef_eline) EVC(b3153652185742, evpl1) enabled but inactive - activating
2022-10-05 15:47:55,595 - INFO [kytos.napps.kytos/mef_eline] [main.py:99:execute_consistency] (mef_eline) Executing consistency for evc 88761fe7908949 service_level 6
2022-10-05 15:47:55,599 - INFO [werkzeug] [_internal.py:225:_log] (Thread-125) 127.0.0.1 - - [05/Oct/2022 15:47:55] "PUT /api/amlight/sdntrace_cp/trace HTTP/1.1" 200 -
2022-10-05 15:47:55,603 - INFO [werkzeug] [_internal.py:225:_log] (Thread-126) 127.0.0.1 - - [05/Oct/2022 15:47:55] "PUT /api/amlight/sdntrace_cp/trace HTTP/1.1" 200 -
2022-10-05 15:47:55,604 - INFO [kytos.napps.kytos/mef_eline] [main.py:101:execute_consistency] (mef_eline) EVC(88761fe7908949, evpl2) enabled but inactive - activating
2022-10-05 15:47:55,609 - INFO [kytos.napps.kytos/mef_eline] [main.py:99:execute_consistency] (mef_eline) Executing consistency for evc 0bb154c8652546 service_level 0
2022-10-05 15:47:55,612 - INFO [werkzeug] [_internal.py:225:_log] (Thread-127) 127.0.0.1 - - [05/Oct/2022 15:47:55] "PUT /api/amlight/sdntrace_cp/trace HTTP/1.1" 200 -
2022-10-05 15:47:55,617 - INFO [kytos.napps.kytos/mef_eline] [main.py:101:execute_consistency] (mef_eline) EVC(0bb154c8652546, evpl0) enabled but inactive - activating
2022-10-05 15:47:55,616 - INFO [werkzeug] [_internal.py:225:_log] (Thread-128) 127.0.0.1 - - [05/Oct/2022 15:47:55] "PUT /api/amlight/sdntrace_cp/trace HTTP/1.1" 200 -
```