### PR TITLE
[Feature] pathfinder CSPF integration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Added
 =====
 - Added ``service_level`` EVC attribute to set the service network convergence level, the higher the better
 - EVCs with higher service level priority will be handled first during network convergence, including when running ``sdntrace_cp`` consistency checks.
+- Added support for constrained paths for primary dynamic paths and failover paths, ``primary_constraints`` and ``secondary_constraints`` can be set via API.
 
 Changed
 =======

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -1,7 +1,6 @@
 """ELineController."""
 # pylint: disable=unnecessary-lambda,invalid-name
 import os
-import re
 from datetime import datetime
 from typing import Dict, Optional
 

--- a/db/models.py
+++ b/db/models.py
@@ -126,7 +126,8 @@ class EVCBaseDoc(DocumentBaseModel):
             "owner": {"$ifNull": ["$owner", None]},
             "queue_id": {"$ifNull": ["$queue_id", None]},
             "primary_constraints": {"$ifNull": ["$primary_constraints", {}]},
-            "secondary_constraints": {"$ifNull": ["$secondary_constraints", {}]},
+            "secondary_constraints": {"$ifNull": ["$secondary_constraints",
+                                      {}]},
             "primary_links": {"$ifNull": ["$primary_links", []]},
             "backup_links": {"$ifNull": ["$backup_links", []]},
             "start_date": {"$dateToString": {

--- a/db/models.py
+++ b/db/models.py
@@ -51,7 +51,7 @@ class UNIDoc(BaseModel):
 class LinkConstraints(BaseModel):
     """LinkConstraints."""
     bandwidth: Optional[float]
-    ownership: Optional[dict[str, str]]
+    ownership: Optional[str]
     reliability: Optional[float]
     utilization: Optional[float]
     delay: Optional[float]
@@ -61,10 +61,12 @@ class LinkConstraints(BaseModel):
 class PathConstraints(BaseModel):
     """Pathfinder Constraints."""
     spf_attribute: Literal["hop", "delay", "priority"] = "hop"
-    spf_max_cost: Optional[float]
+    spf_max_path_cost: Optional[float]
     mandatory_metrics: Optional[LinkConstraints]
     flexible_metrics: Optional[LinkConstraints]
     minimul_flexible_hits: Optional[int]
+    desired_links: Optional[List[str]]
+    undesired_links: Optional[List[str]]
 
 
 class EVCBaseDoc(DocumentBaseModel):
@@ -123,6 +125,8 @@ class EVCBaseDoc(DocumentBaseModel):
             "enabled": 1,
             "owner": {"$ifNull": ["$owner", None]},
             "queue_id": {"$ifNull": ["$queue_id", None]},
+            "primary_constraints": {"$ifNull": ["$primary_constraints", {}]},
+            "secondary_constraints": {"$ifNull": ["$secondary_constraints", {}]},
             "primary_links": {"$ifNull": ["$primary_links", []]},
             "backup_links": {"$ifNull": ["$backup_links", []]},
             "start_date": {"$dateToString": {

--- a/db/models.py
+++ b/db/models.py
@@ -3,7 +3,7 @@
 # pylint: disable=no-self-argument,no-name-in-module
 
 from datetime import datetime
-from typing import Dict, List, Optional
+from typing import Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -48,6 +48,25 @@ class UNIDoc(BaseModel):
     interface_id: str
 
 
+class LinkConstraints(BaseModel):
+    """LinkConstraints."""
+    bandwidth: Optional[float]
+    ownership: Optional[dict[str, str]]
+    reliability: Optional[float]
+    utilization: Optional[float]
+    delay: Optional[float]
+    priority: Optional[int]
+
+
+class PathConstraints(BaseModel):
+    """Pathfinder Constraints."""
+    spf_attribute: Literal["hop", "delay", "priority"] = "hop"
+    spf_max_cost: Optional[float]
+    mandatory_metrics: Optional[LinkConstraints]
+    flexible_metrics: Optional[LinkConstraints]
+    minimul_flexible_hits: Optional[int]
+
+
 class EVCBaseDoc(DocumentBaseModel):
     """Base model for EVC documents"""
 
@@ -67,6 +86,8 @@ class EVCBaseDoc(DocumentBaseModel):
     backup_links: Optional[List]
     backup_links: Optional[List]
     dynamic_backup_path: bool
+    primary_constraints: Optional[PathConstraints]
+    secondary_constraints: Optional[PathConstraints]
     creation_time: datetime
     owner: Optional[str]
     priority: int

--- a/models/evc.py
+++ b/models/evc.py
@@ -289,6 +289,8 @@ class EVCBase(GenericEntity):
         evc_dict["archived"] = self.archived
         evc_dict["sb_priority"] = self.sb_priority
         evc_dict["service_level"] = self.service_level
+        evc_dict["primary_constraints"] = self.primary_constraints
+        evc_dict["secondary_constraints"] = self.secondary_constraints
 
         return evc_dict
 
@@ -311,7 +313,8 @@ class EVCDeploy(EVCBase):
 
     def discover_new_paths(self):
         """Discover new paths to satisfy this circuit and deploy it."""
-        return DynamicPathManager.get_best_paths(self)
+        return DynamicPathManager.get_best_paths(self,
+                                                 **self.primary_constraints)
 
     def get_failover_path_candidates(self):
         """Get failover paths to satisfy this EVC."""

--- a/models/evc.py
+++ b/models/evc.py
@@ -37,6 +37,8 @@ class EVCBase(GenericEntity):
         "dynamic_backup_path",
         "queue_id",
         "sb_priority",
+        "primary_constraints",
+        "secondary_constraints"
     ]
     required_attributes = ["name", "uni_a", "uni_z"]
 

--- a/models/evc.py
+++ b/models/evc.py
@@ -103,6 +103,8 @@ class EVCBase(GenericEntity):
         self.primary_path = Path(kwargs.get("primary_path", []))
         self.backup_path = Path(kwargs.get("backup_path", []))
         self.dynamic_backup_path = kwargs.get("dynamic_backup_path", False)
+        self.primary_constraints = kwargs.get("primary_constraints", {})
+        self.secondary_constraints = kwargs.get("secondary_constraints", {})
         self.creation_time = get_time(kwargs.get("creation_time")) or now()
         self.owner = kwargs.get("owner", None)
         self.priority = kwargs.get("priority", -1)

--- a/openapi.yml
+++ b/openapi.yml
@@ -320,6 +320,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/NewLink'
+        primary_constraints:
+          $ref: '#/components/schemas/PathConstraints'
+        secondary_constraints:
+          $ref: '#/components/schemas/PathConstraints'
         dynamic_backup_path:
           type: boolean
         circuit_scheduler:
@@ -399,7 +403,92 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Endpoint'
-
+    PathConstraints:
+      type: object
+      properties:
+        desired_links:
+          type: array
+          description: List of link IDs that should be in the path, included as a logical AND.
+          items:
+            type: string
+          example:
+            - '2bd01b0d-c875-4263-ad38-fec0b2999582'
+            - 'c41f6249-3ea6-4aba-a083-08049face1e2'
+        undesired_links:
+          type: array
+          description: List of link IDs that should not be in the path, excluded as a logical OR.
+          items:
+            type: string
+          example:
+            - "f13e8308-ecb2-49be-b507-3823af9cc409"
+            - "ee8d9017-1efd-49ac-9149-4cbeea86f751"
+        spf_attribute:
+          type: string
+          description: Link metadata attribute that will be used as link cost by SPF.
+          default: "hop"
+          enum: 
+            - "hop"
+            - "delay"
+            - "priority"
+        spf_max_path_cost:
+          type: number
+          description: Maximum accumulated path cost to be consireded. You should only set this value if you want to set an upper bound accumulated cost.
+          minimum: 1
+        mandatory_metrics:
+          description: Constraint in the form of a set that contains attributes. Paths will have every attribute specified in this set. Links metadata must be set for the metrics to be considered.
+          allOf:
+            - $ref: "#/components/schemas/Attributes"
+          example:
+            bandwidth: 100
+            ownership: "Bill"
+        flexible_metrics:
+          description: Constraint in the form of a set that contains attributes. Paths will have a user-specified minimum number of attributes specified in this set. Links metadata must be set for the metrics to be considered.
+          allOf:
+            - $ref: "#/components/schemas/Attributes"
+          example:
+            delay: 81
+            utilization: 100
+            reliability: 3
+        minimum_flexible_hits:
+          type: integer
+          description: Minimum number of attributes listed in flexible_metrics that a path will meet.
+          example: 2
+          minimum: 0
+          maximum: 6
+    Attributes:
+      type: object
+      properties:
+        bandwidth:
+          type: number
+          description: Minimum speed of the link in Gbps. It should be a positive float number.
+          example: 100
+          minimum: 0.1
+        utilization:
+          type: number
+          description: Maximum average percentage of utilization of the link. Utilization as 100 means the link does not have capacity left.
+          example: 70
+          minimum: 0
+          maximum: 100
+        priority:
+          type: number
+          description: Maximum priority of the link. The priority of the link could be set based on certain administrative traffic-engineering criteria. 
+          example: 1
+          minimum: 0
+        reliability:
+          type: number
+          description: Minimum percentage of the reliability of the link. Reliability as 0 means always down.
+          example: 95
+          minimum: 1
+          maximum: 100
+        delay:
+          type: number
+          description: Maximum propagation delay of the link in milliseconds. It should be a positive float number.
+          example: 200
+          minimum: 0.1
+        ownership:
+          type: string
+          description: The exact user who should have ownership or be authorized to use the link.
+          example: "Bill"
     Circuit: # Can be referenced via '#/components/schemas/Circuit'
       type: object
       required:
@@ -446,6 +535,10 @@ components:
           $ref: '#/components/schemas/Path'
         backup_path:
           $ref: '#/components/schemas/Path'
+        primary_constraints:
+          $ref: '#/components/schemas/PathConstraints'
+        secondary_constraints:
+          $ref: '#/components/schemas/PathConstraints'
 
         dynamic_backup_path:
           type: boolean

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 exclude = .eggs,ENV,build,docs/conf.py,venv
 
 [yala]
-pylint args = --disable=too-few-public-methods,too-many-instance-attributes,unnecessary-pass,missing-timeout --ignored-modules=napps.kytos.mef_eline
+pylint args = --disable=too-few-public-methods,too-many-instance-attributes,unnecessary-pass,missing-timeout,duplicate-code --ignored-modules=napps.kytos.mef_eline
 linters=pylint,pycodestyle,isort
 
 [pydocstyle]

--- a/tests/unit/models/test_evc_base.py
+++ b/tests/unit/models/test_evc_base.py
@@ -27,6 +27,31 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
             EVC(**attributes)
         self.assertEqual(str(handle_error.exception), error_message)
 
+    def test_expected_requiring_redeploy_attributes(self) -> None:
+        """Test expected attributes_requiring_redeploy."""
+        expected = [
+            "primary_path",
+            "backup_path",
+            "dynamic_backup_path",
+            "queue_id",
+            "sb_priority",
+            "primary_constraints",
+            "secondary_constraints"
+        ]
+        assert EVC.attributes_requiring_redeploy == expected
+
+    def test_expeted_read_only_attributes(self) -> None:
+        """Test expected read_only_attributes."""
+        expected = [
+            "creation_time",
+            "active",
+            "current_path",
+            "failover_path",
+            "_id",
+            "archived",
+        ]
+        assert EVC.read_only_attributes == expected
+
     def test_without_uni_a(self):
         """Test if the EVC raises and error with UNI A is required."""
         attributes = {

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -447,6 +447,17 @@ class TestMain(TestCase):
                 "tag": {"tag_type": 1, "value": 1},
             },
             "dynamic_backup_path": True,
+            "primary_constraints": {
+                "spf_max_path_cost": 8,
+                "mandatory_metrics": {
+                    "ownership": "red"
+                }
+            },
+            "secondary_constraints": {
+                "mandatory_metrics": {
+                    "ownership": "blue"
+                }
+            }
         }
 
         response = api.post(
@@ -471,6 +482,8 @@ class TestMain(TestCase):
             uni_a=uni1,
             uni_z=uni2,
             dynamic_backup_path=True,
+            primary_constraints=payload["primary_constraints"],
+            secondary_constraints=payload["secondary_constraints"],
         )
         # verify save method is called
         mongo_controller_upsert_mock.assert_called_once()


### PR DESCRIPTION
Fixes #136 

#### Changelog

- Added support for constrained paths for primary dynamic paths and failover paths, ``primary_constraints`` and ``secondary_constraints`` can be set via API.

### Notes

- I'll cover e2e tests on this issue https://github.com/amlight/kytos-end-to-end-tests/issues/165 

#### Local tests

- I explored locally with a ring topology, similar to the one documented in the blueprint. 

```
                                 100G, "blue"
               +------------------------------------------+
               |                 link a                   |
               |                                          |
               |                                          |
           +---+----+           +--------+           +----+---+
           |        | 100G,"red" |        | 100G,"red" |        |
           |  SW1   +-----------+  SW2   +-----------+  SW3   |
  H1-------+        |  link b   |        |  link c   |        +-----H2
           |        |           |        |           |        |
           +--------+           +--------+           +--------+


{
            "4523903085a1861c5dc2441c83e3499a9ff763c7794061de87ffc22e44f1a680": {
                "active": true,
                "enabled": true,
                "id": "4523903085a1861c5dc2441c83e3499a9ff763c7794061de87ffc22e44f1a680",
                "metadata": {
                    "bandwidth": 100,
                    "last_status_change": 1665089719.4232693,
                    "last_status_is_active": true,
                    "link_name": "link-S1-S3",
                    "ownership": {
                        "blue": {}
                    }
                }
            },
            "4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30": {
                "active": true,
                "enabled": true,
                "endpoint_b": ,
                "id": "4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30",
                "metadata": {
                    "bandwidth": 100,
                    "last_status_change": 1665089719.4425173,
                    "last_status_is_active": true,
                    "link_name": "link-S2-S3",
                    "ownership": {
                        "red": {}
                    }
                }
            },
            "cf0f4071be426b3f745027f5d22bc61f8312ae86293c9b28e7e66015607a9260": {
                "active": true,
                "enabled": true,
                "id": "cf0f4071be426b3f745027f5d22bc61f8312ae86293c9b28e7e66015607a9260",
                "metadata": {
                    "bandwidth": 100,
                    "last_status_change": 1665089719.4378483,
                    "last_status_is_active": true,
                    "link_name": "link-S1-S2",
                    "ownership": {
                        "red": {}
                    }
                }
            }
        }
```

Here's an example with `mandatory_metrics` constraints and `red` ownership in the dynamic primary path and `blue` in the failover path, the expected primary path should be constrained with `red` the longer path S1<->S2<->S3:

```
{
    "name": "epl",
    "service_level": 7,
    "dynamic_backup_path": true,
    "uni_a": {
        "interface_id": "00:00:00:00:00:00:00:01:1"
    },
    "uni_z": {
       "interface_id": "00:00:00:00:00:00:00:03:1"
    },
    "primary_constraints": {
        "mandatory_metrics": {
            "ownership": "red"
        }
    },
    "secondary_constraints": {
        "mandatory_metrics": {
            "ownership": "blue"
        }
    }
}
````



```
2022-10-06 18:43:05,677 - INFO [kytos.napps.kytos/mef_eline] [evc.py:624:deploy_to_path] (Thread-420) EVC(164bbee3e7524d, epl) was deployed.
2022-10-06 18:43:05,752 - INFO [kytos.napps.kytos/mef_eline] [evc.py:683:setup_failover_path] (thread_pool_app_5) Failover path for EVC(164bbee3e7524d, epl) was deployed.

{
    "164bbee3e7524d": {
        "active": true,
        "archived": false,
        "backup_links": [],
        "backup_path": [],
        "bandwidth": 0,
        "circuit_scheduler": [],
        "creation_time": "2022-10-06T21:43:05",
        "current_path": [
            {
                "active": true,
                "enabled": true,
                "endpoint_a": {
                    "active": true,
                    "enabled": true,
                    "id": "00:00:00:00:00:00:00:01:2",
                    "link": "cf0f4071be426b3f745027f5d22bc61f8312ae86293c9b28e7e66015607a9260",
                    "lldp": true,
                    "mac": "72:2d:dd:f0:9f:67",
                    "metadata": {},
                    "name": "s1-eth2",
                    "nni": true,
                    "port_number": 2,
                    "speed": 1250000000.0,
                    "switch": "00:00:00:00:00:00:00:01",
                    "type": "interface",
                    "uni": false
                },
                "endpoint_b": {
                    "active": true,
                    "enabled": true,
                    "id": "00:00:00:00:00:00:00:02:2",
                    "link": "cf0f4071be426b3f745027f5d22bc61f8312ae86293c9b28e7e66015607a9260",
                    "lldp": true,
                    "mac": "22:d2:76:bd:eb:4a",
                    "metadata": {},
                    "name": "s2-eth2",
                    "nni": true,
                    "port_number": 2,
                    "speed": 1250000000.0,
                    "switch": "00:00:00:00:00:00:00:02",
                    "type": "interface",
                    "uni": false
                },
                "id": "cf0f4071be426b3f745027f5d22bc61f8312ae86293c9b28e7e66015607a9260",
                "metadata": {
                    "s_vlan": {
                        "tag_type": 1,
                        "value": 18
                    }
                }
            },
            {
                "active": true,
                "enabled": true,
                "endpoint_a": {
                    "active": true,
                    "enabled": true,
                    "id": "00:00:00:00:00:00:00:02:3",
                    "link": "4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30",
                    "lldp": true,
                    "mac": "ea:28:d6:91:85:c8",
                    "metadata": {},
                    "name": "s2-eth3",
                    "nni": true,
                    "port_number": 3,
                    "speed": 1250000000.0,
                    "switch": "00:00:00:00:00:00:00:02",
                    "type": "interface",
                    "uni": false
                },
                "endpoint_b": {
                    "active": true,
                    "enabled": true,
                    "id": "00:00:00:00:00:00:00:03:2",
                    "link": "4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30",
                    "lldp": true,
                    "mac": "e6:03:6b:bf:da:ff",
                    "metadata": {},
                    "name": "s3-eth2",
                    "nni": true,
                    "port_number": 2,
                    "speed": 1250000000.0,
                    "switch": "00:00:00:00:00:00:00:03",
                    "type": "interface",
                    "uni": false
                },
                "id": "4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30",
                "metadata": {
                    "s_vlan": {
                        "tag_type": 1,
                        "value": 2271
                    }
                }
            }
        ],
        "dynamic_backup_path": true,
        "enabled": true,
        "end_date": null,
        "failover_path": [
            {
                "active": true,
                "enabled": true,
                "endpoint_a": {
                    "active": true,
                    "enabled": true,
                    "id": "00:00:00:00:00:00:00:01:3",
                    "link": "4523903085a1861c5dc2441c83e3499a9ff763c7794061de87ffc22e44f1a680",
                    "lldp": true,
                    "mac": "12:d5:f0:fa:34:c1",
                    "metadata": {},
                    "name": "s1-eth3",
                    "nni": true,
                    "port_number": 3,
                    "speed": 1250000000.0,
                    "switch": "00:00:00:00:00:00:00:01",
                    "type": "interface",
                    "uni": false
                },
                "endpoint_b": {
                    "active": true,
                    "enabled": true,
                    "id": "00:00:00:00:00:00:00:03:3",
                    "link": "4523903085a1861c5dc2441c83e3499a9ff763c7794061de87ffc22e44f1a680",
                    "lldp": true,
                    "mac": "62:3d:42:61:ef:6b",
                    "metadata": {},
                    "name": "s3-eth3",
                    "nni": true,
                    "port_number": 3,
                    "speed": 1250000000.0,
                    "switch": "00:00:00:00:00:00:00:03",
                    "type": "interface",
                    "uni": false
                },
                "id": "4523903085a1861c5dc2441c83e3499a9ff763c7794061de87ffc22e44f1a680",
                "metadata": {
                    "s_vlan": {
                        "tag_type": 1,
                        "value": 777
                    }
                }
            }
        ],
        "id": "164bbee3e7524d",
        "metadata": {},
        "name": "epl",
        "owner": null,
        "primary_constraints": {
            "mandatory_metrics": {
                "ownership": "red"
            },
            "spf_attribute": "hop"
        },
        "primary_links": [],
        "primary_path": [],
        "queue_id": null,
        "request_time": "2022-10-06T21:43:05",
        "sb_priority": null,
        "secondary_constraints": {
            "mandatory_metrics": {
                "ownership": "blue"
            },
            "spf_attribute": "hop"
        },
        "service_level": 7,
        "start_date": "2022-10-06T21:43:05",
        "uni_a": {
            "interface_id": "00:00:00:00:00:00:00:01:1"
        },
        "uni_z": {
            "interface_id": "00:00:00:00:00:00:00:03:1"
        }
    }
}
```

- Now if you update the circuit, changing the `primary_constraints` with `secondary_constraints` the paths should be current_path and failover_path should be the opposed of the prior example:

```
{
    "secondary_constraints": {
        "mandatory_metrics": {
            "ownership": "red"
        }
    },
    "primary_constraints": {
        "mandatory_metrics": {
            "ownership": "blue"
        }
    }
}
```

```
{
    "164bbee3e7524d": {
        "active": true,
        "archived": false,
        "backup_links": [],
        "backup_path": [],
        "bandwidth": 0,
        "circuit_scheduler": [],
        "creation_time": "2022-10-06T21:43:05",
        "current_path": [
            {
                "active": true,
                "enabled": true,
                "endpoint_a": {
                    "active": true,
                    "enabled": true,
                    "id": "00:00:00:00:00:00:00:01:3",
                    "link": "4523903085a1861c5dc2441c83e3499a9ff763c7794061de87ffc22e44f1a680",
                    "lldp": true,
                    "mac": "12:d5:f0:fa:34:c1",
                    "metadata": {},
                    "name": "s1-eth3",
                    "nni": true,
                    "port_number": 3,
                    "speed": 1250000000.0,
                    "switch": "00:00:00:00:00:00:00:01",
                    "type": "interface",
                    "uni": false
                },
                "endpoint_b": {
                    "active": true,
                    "enabled": true,
                    "id": "00:00:00:00:00:00:00:03:3",
                    "link": "4523903085a1861c5dc2441c83e3499a9ff763c7794061de87ffc22e44f1a680",
                    "lldp": true,
                    "mac": "62:3d:42:61:ef:6b",
                    "metadata": {},
                    "name": "s3-eth3",
                    "nni": true,
                    "port_number": 3,
                    "speed": 1250000000.0,
                    "switch": "00:00:00:00:00:00:00:03",
                    "type": "interface",
                    "uni": false
                },
                "id": "4523903085a1861c5dc2441c83e3499a9ff763c7794061de87ffc22e44f1a680",
                "metadata": {
                    "s_vlan": {
                        "tag_type": 1,
                        "value": 3026
                    }
                }
            }
        ],
        "dynamic_backup_path": true,
        "enabled": true,
        "end_date": null,
        "failover_path": [
            {
                "active": true,
                "enabled": true,
                "endpoint_a": {
                    "active": true,
                    "enabled": true,
                    "id": "00:00:00:00:00:00:00:01:3",
                    "link": "4523903085a1861c5dc2441c83e3499a9ff763c7794061de87ffc22e44f1a680",
                    "lldp": true,
                    "mac": "12:d5:f0:fa:34:c1",
                    "metadata": {},
                    "name": "s1-eth3",
                    "nni": true,
                    "port_number": 3,
                    "speed": 1250000000.0,
                    "switch": "00:00:00:00:00:00:00:01",
                    "type": "interface",
                    "uni": false
                },
                "endpoint_b": {
                    "active": true,
                    "enabled": true,
                    "id": "00:00:00:00:00:00:00:03:3",
                    "link": "4523903085a1861c5dc2441c83e3499a9ff763c7794061de87ffc22e44f1a680",
                    "lldp": true,
                    "mac": "62:3d:42:61:ef:6b",
                    "metadata": {},
                    "name": "s3-eth3",
                    "nni": true,
                    "port_number": 3,
                    "speed": 1250000000.0,
                    "switch": "00:00:00:00:00:00:00:03",
                    "type": "interface",
                    "uni": false
                },
                "id": "4523903085a1861c5dc2441c83e3499a9ff763c7794061de87ffc22e44f1a680",
                "metadata": {}
            }
        ],
        "id": "164bbee3e7524d",
        "metadata": {},
        "name": "epl",
        "owner": null,
        "primary_constraints": {
            "mandatory_metrics": {
                "ownership": "blue"
            }
        },
        "primary_links": [],
        "primary_path": [],
        "queue_id": null,
        "request_time": "2022-10-06T21:43:05",
        "sb_priority": null,
        "secondary_constraints": {
            "mandatory_metrics": {
                "ownership": "red"
            }
        },
        "service_level": 7,
        "start_date": "2022-10-06T21:43:05",
        "uni_a": {
            "interface_id": "00:00:00:00:00:00:00:01:1",
            "tag": null
        },
        "uni_z": {
            "interface_id": "00:00:00:00:00:00:00:03:1",
            "tag": null
        }
    }
}
```