### PR TITLE
[Fix] `get_circuits` archived filter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,14 +11,20 @@ Added
 - Added ``service_level`` EVC attribute to set the service network convergence level, the higher the better
 - EVCs with higher service level priority will be handled first during network convergence, including when running ``sdntrace_cp`` consistency checks.
 - Added support for constrained paths for primary dynamic paths and failover paths, ``primary_constraints`` and ``secondary_constraints`` can be set via API.
+- Documented ``GET /v2/evc?archived`` query arg on openapi.yml
 
 Changed
 =======
 - ``priority`` has been renamed to ``sb_priority`` (southbound priority), ``./scripts/001_rename_priority.py`` can be used to update EVC documents accordingly
+- ``GET /v2/evc?archived=true`` will only return archived EVCs
 
 Removed
 =======
 - ``priority`` is no longer supported in the API spec
+
+Fixed
+=====
+- Fixed found but unloaded message log attempt for archived EVCs
 
 [2022.2.0] - 2022-08-12
 ***********************

--- a/main.py
+++ b/main.py
@@ -120,26 +120,16 @@ class Main(KytosNApp):
     def list_circuits(self):
         """Endpoint to return circuits stored.
 
-        If archived is set to True return all circuits, else only the ones
-        not archived.
+        archive query arg if defined (not null) will be filtered
+        accordingly, by default only non archived evcs will be listed
         """
         log.debug("list_circuits /v2/evc")
-        archived = request.args.get("archived", False)
-        circuits = self.mongo_controller.get_circuits()['circuits']
-        if not circuits:
-            return jsonify({}), 200
-        if archived:
-            return jsonify(circuits), 200
-        return (
-            jsonify(
-                {
-                    circuit_id: circuit
-                    for circuit_id, circuit in circuits.items()
-                    if not circuit.get("archived", False)
-                }
-            ),
-            200,
-        )
+        archived = request.args.get("archived", "false").lower()
+        archived_to_optional = {"null": None, "true": True, "false": False}
+        archived = archived_to_optional.get(archived, False)
+        circuits = self.mongo_controller.get_circuits(archived=archived)
+        circuits = circuits['circuits']
+        return jsonify(circuits), 200
 
     @rest("/v2/evc/<circuit_id>", methods=["GET"])
     def get_circuit(self, circuit_id):

--- a/openapi.yml
+++ b/openapi.yml
@@ -11,6 +11,13 @@ paths:
       summary: List all circuits stored.
       description: List all circuits stored.
       operationId: list_circuits
+      parameters:
+        - name: archived
+          in: query
+          schema:
+            type: string
+          description: "Filter for archived value, if not null. It's false by default"
+          required: false
       responses:
         '200':
           description: OK

--- a/tests/unit/test_controllers.py
+++ b/tests/unit/test_controllers.py
@@ -40,6 +40,7 @@ class TestControllers(TestCase):
         self.eline.bootstrap_indexes()
         expected_indexes = [
             ("evcs", [("circuit_scheduler", 1)]),
+            ("evcs", [("archived", 1)]),
         ]
         mock = self.eline.mongo.bootstrap_index
         assert mock.call_count == len(expected_indexes)

--- a/tests/unit/test_controllers.py
+++ b/tests/unit/test_controllers.py
@@ -51,6 +51,17 @@ class TestControllers(TestCase):
         assert "circuits" in self.eline.get_circuits()
         assert self.eline.db.evcs.aggregate.call_count == 1
 
+    def test_get_circuits_archived(self):
+        """Test get_circuits archived filter"""
+
+        self.eline.get_circuits(archived=None)
+        arg1 = self.eline.db.evcs.aggregate.call_args[0]
+        assert "$match" not in arg1[0][0]
+
+        self.eline.get_circuits(archived=True)
+        arg1 = self.eline.db.evcs.aggregate.call_args[0]
+        assert arg1[0][0]["$match"] == {'archived': True}
+
     def test_upsert_evc(self):
         """Test upsert_evc"""
 


### PR DESCRIPTION
Fixes #199 

This PR is on top of #198

### Chagelog

#### Added
- Documented ``GET /v2/evc?archived`` query arg on openapi.yml

#### Changed
- ``GET /v2/evc?archived=true`` will only return archived EVCs

#### Fixed
- Fixed found but unloaded message log attempt for archived EVCs


### Local tests

- Explored the three cases (default|false, true and null)

```
❯ http localhost:8181/api/kytos/mef_eline/v2/evc | jq -r | rg archived                                                                                                          
    "archived": false,

❯ http localhost:8181/api/kytos/mef_eline/v2/evc?archived=true | jq -r | rg archived
    "archived": true,
    "archived": true,
    "archived": true,

❯ http localhost:8181/api/kytos/mef_eline/v2/evc?archived=null | jq -r | rg archived
    "archived": true,
    "archived": false,
    "archived": true,
    "archived": true,
```