### PR TITLE
[Fix] Removed failover flows when an EVC gets deleted

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,10 @@ Removed
 =======
 - ``priority`` is no longer supported in the API spec
 
+Fixed
+=====
+- Removed failover flows when an EVC gets deleted
+
 [2022.2.0] - 2022-08-12
 ***********************
 

--- a/main.py
+++ b/main.py
@@ -334,6 +334,7 @@ class Main(KytosNApp):
         log.info("Removing %s", evc)
         with evc.lock:
             evc.remove_current_flows()
+            evc.remove_failover_flows(sync=False)
             evc.deactivate()
             evc.disable()
             self.sched.remove(evc)

--- a/models/evc.py
+++ b/models/evc.py
@@ -499,7 +499,7 @@ class EVCDeploy(EVCBase):
                     [
                         {
                             "cookie": cookie,
-                            "cookie_mask": int(0xFFFFFFFFFFFFFFFF),
+                            "cookie_mask": int(0xffffffffffffffff),
                         }
                     ],
                     "delete",

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -923,6 +923,142 @@ class TestEVC(TestCase):
         evc.remove_current_flows()
         log_error_mock.assert_called()
 
+    @patch("napps.kytos.mef_eline.controllers.ELineController.upsert_evc")
+    @patch("napps.kytos.mef_eline.models.evc.notify_link_available_tags")
+    @patch("napps.kytos.mef_eline.models.evc.EVC._send_flow_mods")
+    @patch("napps.kytos.mef_eline.models.evc.log.error")
+    def test_remove_failover_flows_exclude_uni_switches(self, *args):
+        """Test remove failover flows excluding UNI switches."""
+        # pylint: disable=too-many-locals
+        (log_error_mock, send_flow_mods_mocked,
+         notify_mock, mock_upsert) = args
+        uni_a = get_uni_mocked(
+            interface_port=2,
+            tag_value=82,
+            switch_id="00:00:00:00:00:00:00:01",
+            is_valid=True,
+        )
+        uni_z = get_uni_mocked(
+            interface_port=3,
+            tag_value=83,
+            switch_id="00:00:00:00:00:00:00:03",
+            is_valid=True,
+        )
+
+        switch_a = Switch("00:00:00:00:00:00:00:01")
+        switch_b = Switch("00:00:00:00:00:00:00:02")
+        switch_c = Switch("00:00:00:00:00:00:00:03")
+
+        attributes = {
+            "controller": get_controller_mock(),
+            "name": "custom_name",
+            "uni_a": uni_a,
+            "uni_z": uni_z,
+            "active": True,
+            "enabled": True,
+            "failover_path": [
+                get_link_mocked(
+                    switch_a=switch_a,
+                    switch_b=switch_b,
+                    endpoint_a_port=9,
+                    endpoint_b_port=10,
+                    metadata={"s_vlan": 5},
+                ),
+                get_link_mocked(
+                    switch_a=switch_b,
+                    switch_b=switch_c,
+                    endpoint_a_port=11,
+                    endpoint_b_port=12,
+                    metadata={"s_vlan": 6},
+                ),
+            ],
+        }
+
+        evc = EVC(**attributes)
+        evc.remove_failover_flows(exclude_uni_switches=True, sync=True)
+        notify_mock.assert_called()
+
+        assert send_flow_mods_mocked.call_count == 1
+        flows = [
+            {"cookie": evc.get_cookie(),
+             "cookie_mask": int(0xffffffffffffffff)}
+        ]
+        send_flow_mods_mocked.assert_any_call(switch_b.id, flows, 'delete',
+                                              force=True)
+        assert mock_upsert.call_count == 1
+
+        send_flow_mods_mocked.side_effect = FlowModException("error")
+        evc.remove_current_flows()
+        log_error_mock.assert_called()
+
+    @patch("napps.kytos.mef_eline.controllers.ELineController.upsert_evc")
+    @patch("napps.kytos.mef_eline.models.evc.notify_link_available_tags")
+    @patch("napps.kytos.mef_eline.models.evc.EVC._send_flow_mods")
+    @patch("napps.kytos.mef_eline.models.evc.log.error")
+    def test_remove_failover_flows_include_all(self, *args):
+        """Test remove failover flows including UNI switches."""
+        # pylint: disable=too-many-locals
+        (log_error_mock, send_flow_mods_mocked,
+         notify_mock, mock_upsert) = args
+        uni_a = get_uni_mocked(
+            interface_port=2,
+            tag_value=82,
+            switch_id="00:00:00:00:00:00:00:01",
+            is_valid=True,
+        )
+        uni_z = get_uni_mocked(
+            interface_port=3,
+            tag_value=83,
+            switch_id="00:00:00:00:00:00:00:03",
+            is_valid=True,
+        )
+
+        switch_a = Switch("00:00:00:00:00:00:00:01")
+        switch_b = Switch("00:00:00:00:00:00:00:02")
+        switch_c = Switch("00:00:00:00:00:00:00:03")
+
+        attributes = {
+            "controller": get_controller_mock(),
+            "name": "custom_name",
+            "uni_a": uni_a,
+            "uni_z": uni_z,
+            "active": True,
+            "enabled": True,
+            "failover_path": [
+                get_link_mocked(
+                    switch_a=switch_a,
+                    switch_b=switch_b,
+                    endpoint_a_port=9,
+                    endpoint_b_port=10,
+                    metadata={"s_vlan": 5},
+                ),
+                get_link_mocked(
+                    switch_a=switch_b,
+                    switch_b=switch_c,
+                    endpoint_a_port=11,
+                    endpoint_b_port=12,
+                    metadata={"s_vlan": 6},
+                ),
+            ],
+        }
+
+        evc = EVC(**attributes)
+        evc.remove_failover_flows(exclude_uni_switches=False, sync=True)
+        notify_mock.assert_called()
+
+        assert send_flow_mods_mocked.call_count == 3
+        flows = [
+            {"cookie": evc.get_cookie(),
+             "cookie_mask": int(0xffffffffffffffff)}
+        ]
+        send_flow_mods_mocked.assert_any_call(switch_a.id, flows, 'delete',
+                                              force=True)
+        send_flow_mods_mocked.assert_any_call(switch_b.id, flows, 'delete',
+                                              force=True)
+        send_flow_mods_mocked.assert_any_call(switch_c.id, flows, 'delete',
+                                              force=True)
+        assert mock_upsert.call_count == 1
+
     @staticmethod
     def create_evc_intra_switch():
         """Create intra-switch EVC."""


### PR DESCRIPTION
Fixes #204 

- Removed failover flows when an EVC gets deleted

- I've also added a new method `remove_failover_flows` analogous to `remove_current_flows` but with options to also exclude UNI switches just so we minimize the number of FlowMods, since typically `remove_current_flows` is called first and UNI switches will already have this EVC cookie flows removed, so no need to send it again. In the future, I think we could also parametrize `remove_path_flows` to support such flexibility instead.
- I also took the opportunity to update some `cookie_mask` with their hex value as we've discussed before

## Local tests

Once the EVC is installed there are 8 flows in total, after removing it, there aren't any flows:

```
rs0 [direct: primary] napps> db.flows.aggregate([{"$match":{"flow.cookie": Decimal128(cookie), "state": "installed"}}, {"$count": "documents"}])
[ { documents: 8 } ]
rs0 [direct: primary] napps>

rs0 [direct: primary] napps> db.flows.aggregate([{"$match":{"flow.cookie": Decimal128(cookie), "state": "installed"}}, {"$count": "documents"}])

```

```
❯ sudo ovs-ofctl -O OpenFlow13 dump-flows s1
 cookie=0x0, duration=122.893s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=ee:ee:ee:ee:ee:03 actions=CONTROLLER:65535
 cookie=0x0, duration=122.821s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=ee:ee:ee:ee:ee:02 actions=CONTROLLER:65535
 cookie=0xab00000000000001, duration=124.187s, table=0, n_packets=82, n_bytes=3444, send_flow_rem priority=1000,dl_vlan=3799,dl_type=0x88cc actions=CONTROLLER:65535

❯ sudo ovs-ofctl -O OpenFlow13 dump-flows s2
 cookie=0x0, duration=123.885s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=ee:ee:ee:ee:ee:03 actions=CONTROLLER:65535
 cookie=0x0, duration=123.883s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=ee:ee:ee:ee:ee:01 actions=CONTROLLER:65535
 cookie=0xab00000000000002, duration=125.270s, table=0, n_packets=84, n_bytes=3528, send_flow_rem priority=1000,dl_vlan=3799,dl_type=0x88cc actions=CONTROLLER:65535

❯ sudo ovs-ofctl -O OpenFlow13 dump-flows s3
 cookie=0x0, duration=125.116s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=ee:ee:ee:ee:ee:02 actions=CONTROLLER:65535
 cookie=0x0, duration=125.039s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=ee:ee:ee:ee:ee:01 actions=CONTROLLER:65535
 cookie=0xab00000000000003, duration=126.415s, table=0, n_packets=84, n_bytes=3528, send_flow_rem priority=1000,dl_vlan=3799,dl_type=0x88cc actions=CONTROLLER:65535

```

UNI switches get excluded notice that a deletion was sent only once to every switch when removing both `current_path` and `failover_path`:

```
kytos $> 2022-10-13 16:28:14,205 - INFO [kytos.napps.kytos/mef_eline] [main.py:334:delete_circuit] (Thread-120) Removing EVC(04c451bcd90a4a, epl)
2022-10-13 16:28:14,209 - INFO [kytos.napps.kytos/flow_manager] [main.py:583:_send_flow_mods_from_request] (Thread-121) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command:
 delete, force: True, flows_dict: {'flows': [{'cookie': 12251132741694327370, 'cookie_mask': 18446744073709551615}], 'force': True}
2022-10-13 16:28:14,224 - INFO [werkzeug] [_internal.py:225:_log] (Thread-121) 127.0.0.1 - - [13/Oct/2022 16:28:14] "POST /api/kytos/flow_manager/v2/delete/00:00:00:00:00:00:00:01 HTTP/
1.1" 202 -
2022-10-13 16:28:14,237 - INFO [kytos.napps.kytos/flow_manager] [main.py:583:_send_flow_mods_from_request] (Thread-122) Send FlowMod from request dpid: 00:00:00:00:00:00:00:03, command:
 delete, force: True, flows_dict: {'flows': [{'cookie': 12251132741694327370, 'cookie_mask': 18446744073709551615}], 'force': True}
2022-10-13 16:28:14,246 - INFO [werkzeug] [_internal.py:225:_log] (Thread-122) 127.0.0.1 - - [13/Oct/2022 16:28:14] "POST /api/kytos/flow_manager/v2/delete/00:00:00:00:00:00:00:03 HTTP/
1.1" 202 -
2022-10-13 16:28:14,281 - INFO [kytos.napps.kytos/flow_manager] [main.py:583:_send_flow_mods_from_request] (Thread-123) Send FlowMod from request dpid: 00:00:00:00:00:00:00:02, command:
 delete, force: True, flows_dict: {'flows': [{'cookie': 12251132741694327370, 'cookie_mask': 18446744073709551615}], 'force': True}
2022-10-13 16:28:14,287 - INFO [werkzeug] [_internal.py:225:_log] (Thread-123) 127.0.0.1 - - [13/Oct/2022 16:28:14] "POST /api/kytos/flow_manager/v2/delete/00:00:00:00:00:00:00:02 HTTP/
1.1" 202 -
2022-10-13 16:28:14,319 - INFO [kytos.napps.kytos/mef_eline] [main.py:343:delete_circuit] (Thread-120) EVC removed. EVC(04c451bcd90a4a, epl)
2022-10-13 16:28:14,320 - INFO [werkzeug] [_internal.py:225:_log] (Thread-120) 127.0.0.1 - - [13/Oct/2022 16:28:14] "DELETE /api/kytos/mef_eline/v2/evc/04c451bcd90a4a HTTP/1.1" 200 -

```