### PR TITLE
[Feature/UI] sb_priority component on k-toolbar

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Added
 - EVCs with higher service level priority will be handled first during network convergence, including when running ``sdntrace_cp`` consistency checks.
 - Added support for constrained paths for primary dynamic paths and failover paths, ``primary_constraints`` and ``secondary_constraints`` can be set via API.
 - Added ``service_level`` UI component on ``k-toolbar`` and made it editable.
+- Added ``sb_priority`` UI component on ``k-toolbar``.
 
 Changed
 =======

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -66,6 +66,11 @@
                     tooltip="Enter the service level (0-7)"
                     placeholder="service level value" icon="arrow-right"></k-input>
 
+            <k-input id="sb-priority-input" :value.sync="sb_priority"
+                    title="Southbound priority:"
+                    tooltip="Enter the southbound priority"
+                    placeholder="southbound priority" icon="arrow-right"></k-input>
+
            <k-button tooltip="Request Circuit" title="Request Circuit"
                      icon="gear" :on_click="request_circuit">
                      </k-button>
@@ -93,6 +98,7 @@ module.exports = {
         tag_type_z: "",
         tag_value_z: "",
         service_level: "",
+        sb_priority: "",
         dpids: [""],
         hasAutoComplete:false
     }
@@ -131,6 +137,7 @@ module.exports = {
         this.tag_type_z = "";
         this.tag_value_z = "";
         this.service_level = "";
+        this.sb_priority = "";
     },
     post_success(data) {
         let notification = {
@@ -171,6 +178,9 @@ module.exports = {
         }
         if (this.service_level !== undefined && this.service_level !== "") {
             request.service_level = parseInt(this.service_level)
+        }
+        if (this.sb_priority !== undefined && this.sb_priority !== "") {
+            request.sb_priority = parseInt(this.sb_priority)
         }
         
         let circuit_request = $.ajax({


### PR DESCRIPTION
Fixes #181, this on top of PR #208

- Added ``sb_priority`` UI component on ``k-toolbar``. (editing was already supported)

### Local exploratory tests

- Created an EVC with priority different than default:

![20221017_142143](https://user-images.githubusercontent.com/1010796/196242658-ade96e56-9d37-4cba-b675-8bde5d466339.png)

![20221017_142157](https://user-images.githubusercontent.com/1010796/196242710-f4d7c83e-9b81-4234-87e4-13e8f86fab41.png)

```
❯ sudo ovs-ofctl -O OpenFlow13 dump-flows s1
 cookie=0x0, duration=89.555s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=ee:ee:ee:ee:ee:03 actions=CONTROLLER:65535
 cookie=0x0, duration=89.541s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=ee:ee:ee:ee:ee:02 actions=CONTROLLER:65535
 cookie=0xaa72d3a029b7254e, duration=25.358s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=33333,in_port="s1-eth1" actions=push_vlan:0x88a8,set_field:6203->vlan_vid,output:"s1
-eth4"
 cookie=0xaa72d3a029b7254e, duration=25.355s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=33333,in_port="s1-eth4",dl_vlan=2107 actions=pop_vlan,output:"s1-eth1"
 cookie=0xaa72d3a029b7254e, duration=25.234s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=33333,in_port="s1-eth3",dl_vlan=130 actions=pop_vlan,output:"s1-eth1"
 cookie=0xab00000000000001, duration=91.149s, table=0, n_packets=244, n_bytes=10248, send_flow_rem priority=1000,dl_vlan=3799,dl_type=0x88cc actions=CONTROLLER:65535
```

- Created an EVC without setting priority (sb_priority null on EVC, but on-wire uses the default SB value):

![20221017_142255](https://user-images.githubusercontent.com/1010796/196242813-a89a3ecd-cc6f-4db5-a55f-28532441b297.png)

```
❯ sudo ovs-ofctl -O OpenFlow13 dump-flows s1
 cookie=0x0, duration=139.683s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=ee:ee:ee:ee:ee:03 actions=CONTROLLER:65535
 cookie=0x0, duration=139.669s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=ee:ee:ee:ee:ee:02 actions=CONTROLLER:65535
 cookie=0xaa366376261a0f44, duration=31.041s, table=0, n_packets=0, n_bytes=0, send_flow_rem in_port="s1-eth1" actions=push_vlan:0x88a8,set_field:6997->vlan_vid,output:"s1-eth4"
 cookie=0xaa366376261a0f44, duration=31.037s, table=0, n_packets=0, n_bytes=0, send_flow_rem in_port="s1-eth4",dl_vlan=2901 actions=pop_vlan,output:"s1-eth1"
 cookie=0xaa366376261a0f44, duration=30.914s, table=0, n_packets=0, n_bytes=0, send_flow_rem in_port="s1-eth3",dl_vlan=526 actions=pop_vlan,output:"s1-eth1"
 cookie=0xab00000000000001, duration=141.277s, table=0, n_packets=278, n_bytes=11676, send_flow_rem priority=1000,dl_vlan=3799,dl_type=0x88cc actions=CONTROLLER:65535

```