### PR TITLE
[Fix] Differentiate `queue_id` zero from `None`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Removed
 Fixed
 =====
 - Removed failover flows when an EVC gets deleted
+- Validated ``queue_id`` on ``POST /v2/evc``
 
 [2022.2.0] - 2022-08-12
 ***********************

--- a/models/evc.py
+++ b/models/evc.py
@@ -937,7 +937,7 @@ class EVCDeploy(EVCBase):
         default_actions = [
             {"action_type": "output", "port": out_interface.port_number}
         ]
-        if queue_id:
+        if queue_id is not None:
             default_actions.append(
                 {"action_type": "set_queue", "queue_id": queue_id}
             )

--- a/openapi.yml
+++ b/openapi.yml
@@ -342,6 +342,12 @@ components:
           default: 0
           minimum: 0
           maximum: 7
+        queue_id:
+          type: integer
+          format: int32
+          description: "QoS Egress Queue ID"
+          minimum: 0
+          maximum: 7
         enabled:
           type: boolean
     NewLink:
@@ -564,6 +570,12 @@ components:
           format: int32
           description: "Service level provided for network convergence. The higher the better"
           default: 0
+          minimum: 0
+          maximum: 7
+        queue_id:
+          type: integer
+          format: int32
+          description: "QoS Egress Queue ID"
           minimum: 0
           maximum: 7
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -595,6 +595,34 @@ class TestMain(TestCase):
         )
         self.assertEqual(400, response.status_code, response.data)
 
+    def test_create_a_circuit_invalid_queue_id(self):
+        """Test create a new circuit with invalid queue_id."""
+        api = self.get_app_test_client(self.napp)
+        url = f"{self.server_name_url}/v2/evc/"
+
+        payload = {
+            "name": "my evc1",
+            "queue_id": 8,
+            "uni_a": {
+                "interface_id": "00:00:00:00:00:00:00:01:76",
+                "tag": {"tag_type": 1, "value": 80},
+            },
+            "uni_z": {
+                "interface_id": "00:00:00:00:00:00:00:02:2",
+                "tag": {"tag_type": 1, "value": 1},
+            },
+        }
+        response = api.post(
+            url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        current_data = json.loads(response.data)
+        expected_data = "8 is greater than the maximum of 7"
+
+        assert response.status_code == 400
+        assert expected_data in current_data["description"], expected_data
+
     @patch("napps.kytos.mef_eline.models.evc.EVC.deploy")
     @patch("napps.kytos.mef_eline.scheduler.Scheduler.add")
     @patch("napps.kytos.mef_eline.main.Main._uni_from_dict")


### PR DESCRIPTION
Fixes #210 

- Validated ``queue_id`` on ``POST /v2/evc`` and differentiated 0 from None.

### Local tests 

- Created EVC with this payload locally setting queue_id as 0:

```
{
    "name": "epl",
    "service_level": 7,
    "queue_id": 0,
    "sb_priority": 2000,
    "dynamic_backup_path": true,
    "uni_a": {
        "interface_id": "00:00:00:00:00:00:00:01:1"
    },
    "uni_z": {
       "interface_id": "00:00:00:00:00:00:00:03:1"
    }
}
```

```
❯ sudo ovs-ofctl -O OpenFlow13 dump-flows s1
 cookie=0x0, duration=41.244s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=ee:ee:ee:ee:ee:03 actions=CONTROLLER:65535
 cookie=0x0, duration=41.192s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=ee:ee:ee:ee:ee:02 actions=CONTROLLER:65535
 cookie=0xaa32e88ccd32804e, duration=28.814s, table=0, n_packets=1, n_bytes=98, send_flow_rem priority=2000,in_port="s1-eth1" actions=push_vlan:0x88a8,set_field:7435->vlan_vid,output:"s1
-eth4",set_queue:0
 cookie=0xaa32e88ccd32804e, duration=28.812s, table=0, n_packets=1, n_bytes=102, send_flow_rem priority=2000,in_port="s1-eth4",dl_vlan=3339 actions=pop_vlan,output:"s1-eth1",set_queue:0
 cookie=0xaa32e88ccd32804e, duration=28.654s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=2000,in_port="s1-eth3",dl_vlan=3250 actions=pop_vlan,output:"s1-eth1",set_queue:0
 cookie=0xab00000000000001, duration=42.034s, table=0, n_packets=3100, n_bytes=130200, send_flow_rem priority=1000,dl_vlan=3799,dl_type=0x88cc actions=CONTROLLER:65535
```

- Created EVC with this payload locally without setting any queue_id, confirmed that no `set_queue` were set on flows

```
{
    "name": "epl",
    "service_level": 7,
    "queue_id": 0,
    "sb_priority": 2000,
    "dynamic_backup_path": true,
    "uni_a": {
        "interface_id": "00:00:00:00:00:00:00:01:1"
    },
    "uni_z": {
       "interface_id": "00:00:00:00:00:00:00:03:1"
    }
}
```

```
❯ sudo ovs-ofctl -O OpenFlow13 dump-flows s1
 cookie=0x0, duration=65.157s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=ee:ee:ee:ee:ee:03 actions=CONTROLLER:65535
 cookie=0x0, duration=65.105s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=ee:ee:ee:ee:ee:02 actions=CONTROLLER:65535
 cookie=0xaa5aa055053ef644, duration=11.614s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=2000,in_port="s1-eth1" actions=push_vlan:0x88a8,set_field:6681->vlan_vid,output:"s1-
eth4"
 cookie=0xaa5aa055053ef644, duration=11.613s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=2000,in_port="s1-eth4",dl_vlan=2585 actions=pop_vlan,output:"s1-eth1"
 cookie=0xaa5aa055053ef644, duration=11.481s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=2000,in_port="s1-eth3",dl_vlan=1001 actions=pop_vlan,output:"s1-eth1"
 cookie=0xab00000000000001, duration=65.947s, table=0, n_packets=3116, n_bytes=130872, send_flow_rem priority=1000,dl_vlan=3799,dl_type=0x88cc actions=CONTROLLER:65535

```