### PR TITLE
[Feature] UI component `queue_id` on k-toolbar

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Added
 - Added support for constrained paths for primary dynamic paths and failover paths, ``primary_constraints`` and ``secondary_constraints`` can be set via API.
 - Added ``service_level`` UI component on ``k-toolbar`` and made it editable.
 - Added ``sb_priority`` UI component on ``k-toolbar``.
+- Added ``queue_id`` UI component on ``k-toolbar``.
 
 Changed
 =======

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -71,6 +71,9 @@
                     tooltip="Enter the southbound priority"
                     placeholder="southbound priority" icon="arrow-right"></k-input>
 
+           <k-dropdown icon="arrow-right" title="QoS Egress Queue" :options="get_queue_ids"
+            :value.sync="queue_id"></k-dropdown>
+
            <k-button tooltip="Request Circuit" title="Request Circuit"
                      icon="gear" :on_click="request_circuit">
                      </k-button>
@@ -99,9 +102,20 @@ module.exports = {
         tag_value_z: "",
         service_level: "",
         sb_priority: "",
+        queue_id: "",
         dpids: [""],
         hasAutoComplete:false
     }
+  },
+  computed: {
+    get_queue_ids(){
+      let values = Array(8).fill().map((_, i) => i)
+      var queue_ids = [{value: "", description: "none", selected: true}]
+      values.forEach(
+          x => queue_ids.push({value:x, description:String(x)})
+      )
+      return queue_ids;
+    },
   },
   methods: {
     viewPanel() {
@@ -138,6 +152,7 @@ module.exports = {
         this.tag_value_z = "";
         this.service_level = "";
         this.sb_priority = "";
+        this.queue_id = "";
     },
     post_success(data) {
         let notification = {
@@ -181,6 +196,9 @@ module.exports = {
         }
         if (this.sb_priority !== undefined && this.sb_priority !== "") {
             request.sb_priority = parseInt(this.sb_priority)
+        }
+        if (this.queue_id !== undefined && this.queue_id !== "") {
+            request.queue_id = parseInt(this.queue_id)
         }
         
         let circuit_request = $.ajax({


### PR DESCRIPTION
Fixes #182 

- Added ``queue_id`` UI component on ``k-toolbar``.

@rmotitsuki when you implement the UI vertical animations feel free to reorganize or move this component accordingly

### Local tests

- Created EVC with `queue_id: 0`:


![20221019_103247](https://user-images.githubusercontent.com/1010796/196707350-3e108d16-5da2-4c42-8019-af9d0ea13724.png)
![20221019_103306](https://user-images.githubusercontent.com/1010796/196707385-9cff71ef-5326-4d0b-9274-c9eb484c2777.png)

```
❯ sudo ovs-ofctl -O OpenFlow13 dump-flows s1 cookie=0xaa00000000000001/0xff00000000000000
 cookie=0xaa9b56e899c4bc4c, duration=87.027s, table=0, n_packets=1, n_bytes=70, send_flow_rem in_port="s1-eth1" actions=push_vlan:0x88a8,set_field:4428->vlan_vid,output:"s1-eth4",set_que
ue:0
 cookie=0xaa9b56e899c4bc4c, duration=87.025s, table=0, n_packets=1, n_bytes=74, send_flow_rem in_port="s1-eth4",dl_vlan=332 actions=pop_vlan,output:"s1-eth1",set_queue:0
 cookie=0xaa9b56e899c4bc4c, duration=86.902s, table=0, n_packets=0, n_bytes=0, send_flow_rem in_port="s1-eth3",dl_vlan=269 actions=pop_vlan,output:"s1-eth1",set_queue:0
```

- Created EVC without setting queue_id (none):

![20221019_103455](https://user-images.githubusercontent.com/1010796/196707819-b870046c-b3fa-415e-a642-695b582db539.png)
```
❯ sudo ovs-ofctl -O OpenFlow13 dump-flows s1 cookie=0xaa00000000000001/0xff00000000000000
 cookie=0xaa9aa27fb27c9742, duration=14.095s, table=0, n_packets=0, n_bytes=0, send_flow_rem in_port="s1-eth1" actions=push_vlan:0x88a8,set_field:6688->vlan_vid,output:"s1-eth4"
 cookie=0xaa9aa27fb27c9742, duration=14.094s, table=0, n_packets=0, n_bytes=0, send_flow_rem in_port="s1-eth4",dl_vlan=2592 actions=pop_vlan,output:"s1-eth1"
 cookie=0xaa9aa27fb27c9742, duration=13.973s, table=0, n_packets=0, n_bytes=0, send_flow_rem in_port="s1-eth3",dl_vlan=2604 actions=pop_vlan,output:"s1-eth1"

```

