### PR TITLE
[Fix]: When removing the flows for redeploy, reset failover path

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,7 @@ Removed
 
 Fixed
 =====
+- Removed the failover path after removing flows
 - Removed failover flows when an EVC gets deleted
 - Validated ``queue_id`` on ``POST /v2/evc``
 - Fixed found but unloaded message log attempt for archived EVCs

--- a/models/evc.py
+++ b/models/evc.py
@@ -465,7 +465,7 @@ class EVCDeploy(EVCBase):
     def remove(self):
         """Remove EVC path and disable it."""
         self.remove_current_flows()
-        self.remove_path_flows(self.failover_path)
+        self.remove_failover_flows()
         self.disable()
         self.sync()
         emit_event(self._controller, "undeployed", evc_id=self.id)


### PR DESCRIPTION
Fix #203

Before a redeploy, current flows and failover flows are removed from the switches, but the failover path was not reset to an empty making. When the `s-vlan` is marked as available, it is removed from the metadata, causing an error afterwards.
This PR uses the `remove_failover_flows` method, which also sets the path to an empty list.