### PR TITLE
Update for blueprint032

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,12 +15,14 @@ Added
 - Added ``sb_priority`` UI component on ``k-toolbar``.
 - Added ``queue_id`` UI component on ``k-toolbar``.
 - Documented ``GET /v2/evc?archived`` query arg on openapi.yml
+- Function ``get_circuits_by_update_date`` for filtering for EVC where is less than or equal to a given datetime given the "updated_at" parameter.
 
 Changed
 =======
 - ``priority`` has been renamed to ``sb_priority`` (southbound priority), ``./scripts/001_rename_priority.py`` can be used to update EVC documents accordingly
 - ``GET /v2/evc?archived=true`` will only return archived EVCs
 - k-toolbar UI component won't expose UNI tag type anymore, if a tag value is set, it'll assume it's tag type vlan.
+- Consistency check uses the new ``PUT /traces`` endpoint from `sdntrace_cp` in ``check_traces`` function for bulk requests.
 
 Removed
 =======

--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,7 @@ Subscribed
 - ``kytos/topology.link_up``
 - ``kytos/topology.link_down``
 - ``kytos/flow_manager.flow.error``
+- ``kytos/flow_manager.flow.removed``
 
 Published
 ---------

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -86,4 +86,14 @@ class ELineController:
             return_document=ReturnDocument.AFTER,
             upsert=True,
         )
+        if updated is not None:
+            return utc_now
         return updated
+
+    def get_circuits_by_update_date(self, dt: datetime) -> Optional[Dict]:
+        """Filter for EVCs where updated_at is lte to a given datetime"""
+        return self.db.evcs.find(
+            {
+                "updated_at": {"$lte": dt}
+            }
+        )

--- a/db/models.py
+++ b/db/models.py
@@ -145,4 +145,9 @@ class EVCBaseDoc(DocumentBaseModel):
                     "$ifNull": ["$end_date", None]
                 }
             }},
+            "updated_at": {"$dateToString": {
+                "format": time_fmt, "date": {
+                    "$ifNull": ["$updated_at", "$inserted_at"]
+                }
+            }},
         }

--- a/main.py
+++ b/main.py
@@ -112,11 +112,11 @@ class Main(KytosNApp):
             self._load_evc(stored_circuits[circuit_id])
 
     @listen_to('kytos/flow_manager.flow.removed')
-    def on_flow_mod_delete(self, event):
+    def on_flow_delete(self, event):
         """Capture delete messages to keep track when flows got removed."""
-        self.handle_flow_mod_delete(event)
+        self.handle_flow_delete(event)
 
-    def handle_flow_mod_delete(self, event):
+    def handle_flow_delete(self, event):
         """Keep track when the EVC got flows removed by deriving its cookie."""
         flow = event.content["flow"]
         evc = self.circuits.get(EVC.get_id_from_cookie(flow.cookie))

--- a/models/evc.py
+++ b/models/evc.py
@@ -536,10 +536,6 @@ class EVCDeploy(EVCBase):
         if sync:
             self.sync()
 
-    def removed_flow(self):
-        """Records the deletion of flows"""
-        self.sync()
-
     def remove_current_flows(self, current_path=None, force=True):
         """Remove all flows from current path."""
         switches = set()

--- a/settings.py
+++ b/settings.py
@@ -41,3 +41,7 @@ BATCH_SIZE = 50
 # is not set in a request
 EVPL_SB_PRIORITY = 20000
 EPL_SB_PRIORITY = 10000
+
+# Time interval to check if flows have been recently modified
+# in the consistency routine
+CONSISTENCY_MIN_VERDICT_INTERVAL = 60 * 2

--- a/tests/unit/models/test_evc_base.py
+++ b/tests/unit/models/test_evc_base.py
@@ -36,7 +36,8 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
             "queue_id",
             "sb_priority",
             "primary_constraints",
-            "secondary_constraints"
+            "secondary_constraints",
+            "updated_at"
         ]
         assert EVC.attributes_requiring_redeploy == expected
 

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -1378,6 +1378,32 @@ class TestEVC(TestCase):
         result = evc.run_sdntrace(evc.uni_a)
         self.assertEqual(result, [])
 
+    @patch("requests.put")
+    def test_run_sdntraces(self, put_mock):
+        """Test run_sdntraces method for bulh request."""
+        evc = self.create_evc_inter_switch()
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"result": "ok"}
+        put_mock.return_value = response
+
+        expected_endpoint = f"{SDN_TRACE_CP_URL}/traces"
+        expected_payload = [
+                            {
+                                'trace': {
+                                    'switch': {'dpid': 1, 'in_port': 2},
+                                    'eth': {'dl_type': 0x8100, 'dl_vlan': 82}
+                                }
+                            }
+                        ]
+        result = evc.run_sdntraces([evc.uni_a])
+        put_mock.assert_called_with(expected_endpoint, json=expected_payload)
+        self.assertEqual(result['result'], "ok")
+
+        response.status_code = 400
+        result = evc.run_sdntraces([evc.uni_a])
+        self.assertEqual(result, [])
+
     @patch("napps.kytos.mef_eline.models.evc.log")
     @patch("napps.kytos.mef_eline.models.evc.EVC.run_sdntraces")
     def test_check_traces(self, run_sdntraces_mock, _):

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -1379,8 +1379,8 @@ class TestEVC(TestCase):
         self.assertEqual(result, [])
 
     @patch("napps.kytos.mef_eline.models.evc.log")
-    @patch("napps.kytos.mef_eline.models.evc.EVC.run_sdntrace")
-    def test_check_traces(self, run_sdntrace_mock, _):
+    @patch("napps.kytos.mef_eline.models.evc.EVC.run_sdntraces")
+    def test_check_traces(self, run_sdntraces_mock, _):
         """Test check_traces method."""
         evc = self.create_evc_inter_switch()
         for link in evc.primary_links:
@@ -1397,27 +1397,42 @@ class TestEVC(TestCase):
             {"dpid": 2, "port": 11, "time": "t2", "type": "trace", "vlan": 6},
             {"dpid": 1, "port": 9, "time": "t3", "type": "trace", "vlan": 5},
         ]
-        run_sdntrace_mock.side_effect = [trace_a, trace_z]
+        run_sdntraces_mock.return_value = {
+                                                1: [trace_a],
+                                                3: [trace_z]
+                                        }
 
         self.assertTrue(evc.check_traces())
 
         # case2: fail incomplete trace from uni_a
-        run_sdntrace_mock.side_effect = [trace_a[:2], trace_z]
+        run_sdntraces_mock.return_value = {
+                                            1: [trace_a[:2]],
+                                            3: [trace_z]
+                                        }
         self.assertFalse(evc.check_traces())
 
         # case3: fail incomplete trace from uni_z
-        run_sdntrace_mock.side_effect = [trace_a, trace_z[:2]]
+        run_sdntraces_mock.return_value = {
+                                            1: [trace_a],
+                                            3: [trace_z[:2]]
+                                        }
         self.assertFalse(evc.check_traces())
 
         # case4: fail wrong vlan id in trace from uni_a
         trace_a[1]["vlan"] = 5
         trace_z[1]["vlan"] = 99
-        run_sdntrace_mock.side_effect = [trace_a, trace_z]
+        run_sdntraces_mock.return_value = {
+                                            1: [trace_a],
+                                            3: [trace_z]
+                                        }
         self.assertFalse(evc.check_traces())
 
         # case5: fail wrong vlan id in trace from uni_z
         trace_a[1]["vlan"] = 99
-        run_sdntrace_mock.side_effect = [trace_a, trace_z]
+        run_sdntraces_mock.return_value = {
+                                            1: [trace_a],
+                                            3: [trace_z]
+                                        }
         self.assertFalse(evc.check_traces())
 
     @patch(

--- a/tests/unit/test_controllers.py
+++ b/tests/unit/test_controllers.py
@@ -32,7 +32,8 @@ class TestControllers(TestCase):
             "priority": 100,
             "active": False,
             "enabled": True,
-            "circuit_scheduler": []
+            "circuit_scheduler": [],
+            "updated_at": 1
         }
 
     def test_bootstrap_indexes(self):
@@ -67,3 +68,8 @@ class TestControllers(TestCase):
 
         self.eline.upsert_evc(self.evc_dict)
         assert self.eline.db.evcs.find_one_and_update.call_count == 1
+
+    def test_get_circuits_by_update_date(self):
+        """Test get_circuits_by_update_date"""
+        self.eline.get_circuits_by_update_date(1)
+        assert self.eline.db.evcs.find.call_count == 1

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -145,11 +145,13 @@ class TestMain(TestCase):
         evc1.is_enabled.return_value = True
         evc1.is_active.return_value = False
         evc1.lock.locked.return_value = False
+        evc1.recent_updated.return_value = False
         evc1.check_traces.return_value = True
         evc2 = MagicMock(id=2, service_level=7, creation_time=1)
         evc2.is_enabled.return_value = True
         evc2.is_active.return_value = False
         evc2.lock.locked.return_value = False
+        evc2.recent_updated.return_value = False
         evc2.check_traces.return_value = False
         self.napp.circuits = {'1': evc1, '2': evc2}
         assert self.napp.get_evcs_by_svc_level() == [evc2, evc1]
@@ -166,6 +168,7 @@ class TestMain(TestCase):
         evc1.is_enabled.return_value = True
         evc1.is_active.return_value = False
         evc1.lock.locked.return_value = False
+        evc1.recent_updated.return_value = False
         evc1.check_traces.return_value = False
         evc1.deploy.call_count = 0
         self.napp.circuits = {'1': evc1}

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -161,6 +161,17 @@ class TestMain(TestCase):
         self.assertEqual(evc2.deploy.call_count, 1)
         mock_load_evc.assert_called_with(stored_circuits['3'])
 
+    def test_handle_flow_delete(self):
+        """Test the tracking of flows removed."""
+        flow = MagicMock()
+        flow.cookie = 0xaa00000000000011
+        event = MagicMock()
+        event.content = {'flow': flow}
+        evc = create_autospec(EVC)
+        self.napp.circuits = {"00000000000011": evc}
+        self.napp.handle_flow_delete(event)
+        evc.sync.assert_called_once()
+
     @patch('napps.kytos.mef_eline.main.settings')
     def test_execute_consistency_wait_for(self, mock_settings):
         """Test execute and wait for setting."""


### PR DESCRIPTION
This is related to blueprint032.

- Added ``function on_flow_mod_delete`` for `kytos/flow_manager.flow.removed` that keeps track when EVC flows are removed. 
What it does is update the EVC `update_at` parameter with the ``sync`` function see this [link](https://github.com/kytos-ng/mef_eline/blob/54899c4bd8d5c1a09a86f2abf7c6b1e13be132ab/main.py#L114-L124).
I wonder whether it is enough or whether it is necessary to have a new parameter that is unique to identify when a flow is deleted.

- Added ``get_circuits_by_update_date`` function to filter EVCs with update time less than or equal to a given datetime. Returns all evcs that meet the condition. Then, the function [``recent_updated``](https://github.com/kytos-ng/mef_eline/blob/54899c4bd8d5c1a09a86f2abf7c6b1e13be132ab/models/evc.py#L157-L166) uses the first function to get the evcs and iterates through the list to check if the evc has been recently updated. Note that if a flow has been removed in the specified interval it is counted as an update.
I wonder whether this behavior is expected or whether it is better to check if the `updated_at` parameter of the evc is within the specified interval.

- Consistency check uses the new ``PUT /traces``  in ``check_traces`` see [link](https://github.com/kytos-ng/mef_eline/blob/54899c4bd8d5c1a09a86f2abf7c6b1e13be132ab/models/evc.py#L1116).