### PR TITLE
[fix] Updated GH actions to run py3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Closes #227 

### Summary

Updated GH actions to run py3.9 like scrutinizer

### Local Tests

N/A