### PR TITLE
[Fix] Fixed EVC validation to catch nonexistent links interfaces

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ Fixed
 - Removed failover flows when an EVC gets deleted
 - Validated ``queue_id`` on ``POST /v2/evc``
 - Fixed found but unloaded message log attempt for archived EVCs
+- Fixed EVC validation to catch nonexistent links interfaces
 
 [2022.2.0] - 2022-08-12
 ***********************

--- a/main.py
+++ b/main.py
@@ -865,6 +865,12 @@ class Main(KytosNApp):
 
         endpoint_a = self.controller.get_interface_by_id(id_a)
         endpoint_b = self.controller.get_interface_by_id(id_b)
+        if not endpoint_a:
+            error_msg = f"Could not get interface endpoint_a id {id_a}"
+            raise ValueError(error_msg)
+        if not endpoint_b:
+            error_msg = f"Could not get interface endpoint_b id {id_b}"
+            raise ValueError(error_msg)
 
         link = Link(endpoint_a, endpoint_b)
         if "metadata" in link_dict:

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 exclude = .eggs,ENV,build,docs/conf.py,venv
 
 [yala]
-pylint args = --disable=too-few-public-methods,too-many-instance-attributes,unnecessary-pass,missing-timeout,duplicate-code --ignored-modules=napps.kytos.mef_eline
+pylint args = --disable=too-few-public-methods,too-many-instance-attributes,unnecessary-pass,missing-timeout,duplicate-code,protected-access --ignored-modules=napps.kytos.mef_eline
 linters=pylint,pycodestyle,isort
 
 [pydocstyle]

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1642,6 +1642,16 @@ class TestMain(TestCase):
         self.assertEqual(400, response.status_code)
         self.assertEqual(current_data["description"], expected_data)
 
+    def test_link_from_dict_non_existent_intf(self):
+        """Test _link_from_dict non existent intf."""
+        self.napp.controller.get_interface_by_id = MagicMock(return_value=None)
+        link_dict = {
+            "endpoint_a": {"id": "a"},
+            "endpoint_b": {"id": "b"}
+        }
+        with self.assertRaises(ValueError):
+            self.napp._uni_from_dict(link_dict)
+
     @patch("napps.kytos.mef_eline.models.evc.EVC.deploy")
     @patch("napps.kytos.mef_eline.scheduler.Scheduler.add")
     @patch("napps.kytos.mef_eline.main.Main._uni_from_dict")


### PR DESCRIPTION
Closes #231 

### Summary

- See changelog file

### Local Tests

I repeated the same local test that caught the original issue, when sending a POST it returns 400:

```
{
    "code": 400,
    "description": "Could not get interface endpoint_a id 00:00:00:00:00:00:00:01:3",
    "name": "Bad Request"
}
```