### PR TITLE
[fix] update `primary_path` or `backup_path` empty

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,7 @@ Fixed
 - Validated ``queue_id`` on ``POST /v2/evc``
 - Fixed found but unloaded message log attempt for archived EVCs
 - Fixed EVC validation to catch nonexistent links interfaces
+- Allowed ``primary_path`` to be empty on update when ``dynamic_backup_path`` is true and ``backup_path`` to be empty too
 
 [2022.2.0] - 2022-08-12
 ***********************

--- a/main.py
+++ b/main.py
@@ -208,14 +208,10 @@ class Main(KytosNApp):
             log.debug("create_circuit result %s %s", result, 409)
             raise Conflict(result)
 
-        if (
-            not evc.primary_path
-            and evc.dynamic_backup_path is False
-            and evc.uni_a.interface.switch != evc.uni_z.interface.switch
-        ):
-            result = "The EVC must have a primary path or allow dynamic paths."
-            log.debug("create_circuit result %s %s", result, 400)
-            raise BadRequest(result)
+        try:
+            evc._validate_has_primary_or_dynamic()
+        except ValueError as exception:
+            raise BadRequest(str(exception)) from exception
 
         # store circuit in dictionary
         self.circuits[evc.id] = evc

--- a/models/path.py
+++ b/models/path.py
@@ -46,6 +46,8 @@ class Path(list, GenericEntity):
 
     def is_valid(self, switch_a, switch_z, is_scheduled=False):
         """Check if this is a valid path."""
+        if not self:
+            return True
         previous = switch_a
         for link in self:
             if link.endpoint_a.switch != previous:

--- a/tests/unit/models/test_path.py
+++ b/tests/unit/models/test_path.py
@@ -195,6 +195,11 @@ class TestPath(TestCase):
         expected_dict = [{"id": 3}, {"id": 2}]
         self.assertEqual(expected_dict, current_path.as_dict())
 
+    def test_empty_is_valid(self) -> None:
+        """Test empty path is valid."""
+        path = Path([])
+        self.assertEqual(path.is_valid(MagicMock(), MagicMock(), False), True)
+
     def test_is_valid(self):
         """Test is_valid method."""
         switch1 = Switch("00:00:00:00:00:00:00:01")


### PR DESCRIPTION
Closes #230 

This PR is on top of PR #232 

### Summary

- See changelog file

### Local Tests

I also explored locally based on some cases that @italovalcy [highlighted](https://github.com/kytos-ng/mef_eline/issues/230#issuecomment-1358261774):

1 - With a ring topology, I created an EVC non dynamic path with `primary_path` between s1 and s3:

```
{
    "name": "epl",
    "dynamic_backup_path": false,
    "uni_a": {
        "interface_id": "00:00:00:00:00:00:00:01:1"
    },
    "uni_z": {
        "interface_id": "00:00:00:00:00:00:00:03:1"
    },
    "primary_path": [
        {
            "endpoint_a": {
                "id": "00:00:00:00:00:00:00:01:4"
            },
            "endpoint_b": {
                "id": "00:00:00:00:00:00:00:03:3"
            }
        }
    ]
}
```

1.1 - I tried to set an empty `primary_path`, since `dynamic_backup_path` is `false` by default it resulted in 400:


```
{
    "primary_path": []
}
```

```
{
    "code": 400,
    "description": "The EVC must have a primary path or allow dynamic paths.",
    "name": "Bad Request"
}
```

1.2 - Then I set an empty `primary_path` but this time with `dynamic_backup_path: true`, simulating a case where the network operator no longer wants to use a static `primary_path`.

```
{
    "dynamic_backup_path": true,
    "primary_path": []
}
```

```
{
    "12a724a1f5914e": {
        "active": true,
        "archived": false,
        "backup_links": [],
        "backup_path": [],
        "bandwidth": 0,
        "circuit_scheduler": [],
        "creation_time": "2022-12-20T17:42:13",
        "current_path": [
            {
                "active": true,
                "enabled": true,
                "endpoint_a": {
                    "active": true,
                    "enabled": true,
                    "id": "00:00:00:00:00:00:00:01:4",
                    "link": "c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07",
                    "lldp": true,
                    "mac": "56:51:f6:ea:07:e0",
                    "metadata": {},
                    "name": "s1-eth4",
                    "nni": true,
                    "port_number": 4,
                    "speed": 1250000000.0,
                    "switch": "00:00:00:00:00:00:00:01",
                    "type": "interface",
                    "uni": false
                },
                "endpoint_b": {
                    "active": true,
                    "enabled": true,
                    "id": "00:00:00:00:00:00:00:03:3",
                    "link": "c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07",
                    "lldp": true,
                    "mac": "e2:f8:58:62:dc:29",
                    "metadata": {},
                    "name": "s3-eth3",
                    "nni": true,
                    "port_number": 3,
                    "speed": 1250000000.0,
                    "switch": "00:00:00:00:00:00:00:03",
                    "type": "interface",
                    "uni": false
                },
                "id": "c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07",
                "metadata": {
                    "s_vlan": {
                        "tag_type": 1,
                        "value": 3
                    }
                }
            }
        ],
        "dynamic_backup_path": true,
        "enabled": true,
        "end_date": null,
        "failover_path": [],
        "id": "12a724a1f5914e",
        "metadata": {},
        "name": "epl",
        "owner": null,
        "primary_constraints": {},
        "primary_links": [],
        "primary_path": [],
        "queue_id": null,
        "request_time": "2022-12-20T17:42:13",
        "sb_priority": null,
        "secondary_constraints": {},
        "service_level": 0,
        "start_date": "2022-12-20T17:42:13",
        "uni_a": {
            "interface_id": "00:00:00:00:00:00:00:01:1",
            "tag": null
        },
        "uni_z": {
            "interface_id": "00:00:00:00:00:00:00:03:1",
            "tag": null
        }
    }
}
```

2 - Finally I created an EPL intra-switch with `primary_path` empty:

```
{
    "name": "epl",
    "service_level": 7,
    "primary_path": [],
    "uni_a": {
        "interface_id": "00:00:00:00:00:00:00:01:1"
    },
    "uni_z": {
       "interface_id": "00:00:00:00:00:00:00:01:2"
    }
}
```

```
{
    "active": true,
    "archived": false,
    "backup_links": [],
    "backup_path": [],
    "bandwidth": 0,
    "circuit_scheduler": [],
    "creation_time": "2022-12-20T17:47:39",
    "current_path": [],
    "dynamic_backup_path": false,
    "enabled": true,
    "end_date": null,
    "failover_path": [],
    "id": "623b9c7ea8244e",
    "metadata": {},
    "name": "epl",
    "owner": null,
    "primary_constraints": {
        "spf_attribute": "hop"
    },
    "primary_links": [],
    "primary_path": [],
    "queue_id": null,
    "request_time": "2022-12-20T17:47:39",
    "sb_priority": null,
    "secondary_constraints": {
        "spf_attribute": "hop"
    },
    "service_level": 7,
    "start_date": "2022-12-20T17:47:39",
    "uni_a": {
        "interface_id": "00:00:00:00:00:00:00:01:1"
    },
    "uni_z": {
        "interface_id": "00:00:00:00:00:00:00:01:2"
    }
}
```

