### PR TITLE
Add UI primary and secondary constraints

### DIFF
--- a/ui/k-info-panel/list_connections.kytos
+++ b/ui/k-info-panel/list_connections.kytos
@@ -357,15 +357,15 @@ module.exports = {
 .mef-table tbody tr:nth-child(even) {
   background: #313131;
 }
-.mef-table tbody tr:hover {
-    color: #eee;
-    background-color: #666;
-}
 .mef-table tbody tr.inactive {
   background-color: #600000;
 }
 .mef-table-divisor {
   height: 190px;
+}
+.mef-table-list-circuit tbody tr:hover {
+    color: #eee;
+    background-color: #666;
 }
 #mef_lst_prt_a_search,
 #mef_lst_prt_z_search,

--- a/ui/k-info-panel/show_circuit.kytos
+++ b/ui/k-info-panel/show_circuit.kytos
@@ -150,8 +150,8 @@
                     </tr>
                     <tr>
                     <td>
-                      <k-select :options="get_desired_link_options(p_constraint_index)"
-                      :value.sync=form_constraints[p_constraint_index].desired_links>
+                      <k-select :options="get_link_options()"
+                      :value.sync=p_constraint.desired_links>
                       </k-select>
                     </td>
                     </tr>
@@ -162,8 +162,8 @@
                     <tr><th>{{constraint_labels['undesired_links']}}</th></tr>
                     <tr>
                     <td>
-                      <k-select :options="get_undesired_link_options(p_constraint_index)"
-                      :value.sync=form_constraints[p_constraint_index].undesired_links>
+                      <k-select :options="get_link_options()"
+                      :value.sync=p_constraint.undesired_links>
                       </k-select>
                     </td>
                     </tr>
@@ -176,7 +176,7 @@
                         <th>{{constraint_labels['spf_attribute']}}</th>
                         <td> 
                           <k-dropdown :options="get_spf_attribute_options(p_constraint_index)" 
-                           :value.sync=form_constraints[p_constraint_index].spf_attribute></k-dropdown>
+                           :value.sync=p_constraint.spf_attribute></k-dropdown>
                         </td>
                       </tr>
                       <tr>
@@ -335,54 +335,18 @@ module.exports = {
       ];
       return _result;
     },
-    get_link_options: function(selecteds){
+    get_link_options: function(){
       /**
        * Build option items for constraint (desired/undesired) link.
        */
       let _this = this;
       let _result = [];
       $.each(this.link_options, function(key, item){
-        let _selected = false;
-        if(selecteds) {
-          selecteds.every( s => {
-            if(s == item.value) {
-              _selected = true;
-              return false;
-            }
-            return true;
-          });
-        }
         let _item = {};
         _item.value = item.value;
         _item.description = item.description;
-        _item.selected = _selected;
-
         _result.push(_item);
       });
-      return _result;
-    },
-    get_desired_link_options: function(type) {
-      /**
-       * Method to build option items for constraint desired_links.
-       * @parameter type primary_constraints or secondary_constraints
-       */
-      let _links = this.form_constraints[type].desired_links;
-      if (this.form_constraints[type].desired_links == []) {
-        _links = this.constraints[type].desired_links;
-      }
-      let _result = this.get_link_options(_links);
-      return _result;
-    },
-    get_undesired_link_options: function(type) {
-      /**
-       * Method to build option items for constraint undesired_links.
-       * @parameter type primary_constraints or secondary_constraints
-       */
-      let _links = this.form_constraints[type].undesired_links;
-      if (this.form_constraints[type].undesired_links == []) {
-        _links = this.constraints[type].undesired_links;
-      }
-      let _result = this.get_link_options(_links);
       return _result;
     },
     showInfoPanel: function() {
@@ -816,14 +780,20 @@ module.exports = {
       ['primary_constraints', 'secondary_constraints'].forEach(_type => {
         payload[_type] = {};
         // Dropdown forms
-        if(this.form_constraints[_type].desired_links.length > 0) {
-          payload[_type].desired_links = this.form_constraints[_type].desired_links.filter(item => typeof(item) == "string");
+        payload[_type].desired_links = [];
+        if(this.constraints[_type].desired_links && this.constraints[_type].desired_links.length > 0) {
+          payload[_type].desired_links = [].concat(
+            this.constraints[_type].desired_links.filter(item => typeof(item) == "string")
+          );
         }
-        if(this.form_constraints[_type].desired_links.length > 0) {
-          payload[_type].undesired_links = this.form_constraints[_type].undesired_links.filter(item => typeof(item) == "string");
+        payload[_type].undesired_links = [];
+        if(this.constraints[_type].undesired_links && this.constraints[_type].undesired_links.length > 0) {
+          payload[_type].undesired_links = [].concat(
+            this.constraints[_type].undesired_links.filter(item => typeof(item) == "string")
+          );
         }
-        if(this.form_constraints[_type].spf_attribute !== "") {
-          payload[_type].spf_attribute = this.form_constraints[_type].spf_attribute;
+        if(this.constraints[_type].spf_attribute !== "") {
+          payload[_type].spf_attribute = this.constraints[_type].spf_attribute;
         }
 
         // Input forms

--- a/ui/k-info-panel/show_circuit.kytos
+++ b/ui/k-info-panel/show_circuit.kytos
@@ -138,7 +138,121 @@
             </table>
           </div>
         </template>
+        <template  v-for="(p_constraint, p_constraint_index) in constraints">
+          <div class="mef-circuit-table mef-circuit-table-constraints">
+            <table class="table">
+              <tbody>
+              <tr><th>{{constraint_labels[p_constraint_index]}}</th></tr>
+              <tr><td>
+                <div id="mef-constraints-desired-links">
+                  <table class="table">
+                    <tr><th>{{constraint_labels['desired_links']}}</th>
+                    </tr>
+                    <tr>
+                    <td>
+                      <k-select :options="get_desired_link_options(p_constraint_index)"
+                      :value.sync=form_constraints[p_constraint_index].desired_links>
+                      </k-select>
+                    </td>
+                    </tr>
+                  </table>
+                </div>
+                <div id="mef-constraints-undesired-links">
+                  <table class="table">
+                    <tr><th>{{constraint_labels['undesired_links']}}</th></tr>
+                    <tr>
+                    <td>
+                      <k-select :options="get_undesired_link_options(p_constraint_index)"
+                      :value.sync=form_constraints[p_constraint_index].undesired_links>
+                      </k-select>
+                    </td>
+                    </tr>
+                  </table>
+                </div>
+
+                  <div>
+                    <table class="table" id="mef-constraints-spf">
+                      <tr>
+                        <th>{{constraint_labels['spf_attribute']}}</th>
+                        <td> 
+                          <k-dropdown :options="get_spf_attribute_options(p_constraint_index)" 
+                           :value.sync=form_constraints[p_constraint_index].spf_attribute></k-dropdown>
+                        </td>
+                      </tr>
+                      <tr>
+                        <th>{{constraint_labels['spf_max_path_cost']}}</th>
+                        <td>
+                          <k-input :value.sync=p_constraint.spf_max_path_cost></k-input>
+                        </td>
+                      </tr>
+                      <tr>
+                        <th>
+                          <span :title=constraint_descriptions.minimum_flexible_hits>
+                            {{constraint_labels['minimum_flexible_hits']}}
+                          </span>
+                        </th>
+                        <td>
+                          <k-input :value.sync=p_constraint.minimum_flexible_hits></k-input>
+                        </td>
+                      </tr>
+                    </table>
+                  </div>
+                  <div style="
+                      float: left;
+                      width: 250px;">
+                    <table class="table">
+                      <tr><th>{{constraint_labels['mandatory_metrics']}}</th>
+                      </tr>
+                      <tr>
+                        <td>
+                          <div>
+                            <table class="table" style="">
+                              <template v-for="(metric_attr, metric_index) in p_constraint.mandatory_metrics">
+                                <tr>
+                                  <th>{{constraint_labels["flexible_metrics."+metric_index]}}</th>
+                                  <td style="padding:0 5px;">
+                                    <k-input :value.sync="p_constraint.mandatory_metrics[metric_index]"></k-input>
+                                  </td>
+                                </tr>
+                              </template>
+                            </table>
+                          </div>
+                        </td>
+                      </tr>
+                    </table>
+                  </div>
+                  <div style="
+                      float: left;
+                      margin-left: 10px;
+                      width: 250px;">
+                    <table class="table">
+                      <tr>
+                        <th>{{constraint_labels['flexible_metrics']}}</th>
+                      </tr>
+                      <tr>
+                        <td>
+                          <div>
+                            <template v-for="(metric_attr, metric_index) in p_constraint.flexible_metrics">
+                              <tr>
+                                <th>{{constraint_labels["flexible_metrics."+metric_index]}}</th>
+                                <td style="padding:0 5px;">
+                                  <k-input :value.sync="p_constraint.flexible_metrics[metric_index]"></k-input>
+                                </td>
+                              </tr>
+                            </template>
+                          </div>
+                        </td>
+                      </tr>
+                    </table>
+                  </div>
+              </td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+        </template>
       </div>
+
       <div class="mef-back-button">
         <k-button tooltip="List installed EVCs" title="< Back to list" :on_click="showInfoPanel">
         </k-button>
@@ -196,9 +310,81 @@ module.exports = {
         circuit_scheduler: {}, // EVC scheduler data
         showDelModal: false,
         TAG_TYPE_VLAN: 1, // Tag type VLAN
+
+        constraints: {}, // constraint data
+        constraint_labels: {}, // constraint labels
+        constraint_descriptions: {}, // constraint mouse over description
+        link_options: [], // constraint link dropdown options
+        form_constraints: {}, // constraint data vue object synchronization
     }
   },
   methods: {
+    get_spf_attribute_options: function(type) {
+      /**
+       * Method to build option items for spf attribute.
+       * @parameter type primary_constraints or secondary_constraints
+       */
+      let _spf = this.form_constraints[type].spf_attribute;
+      if(this.form_constraints[type].spf_attribute == '') {
+        _spf = this.constraints[type].spf_attribute;
+      }
+      let _result = [
+        {value: "hop", description: "hop", selected: (_spf == 'hop')},
+        {value: "delay", description: "delay", selected: (_spf == 'delay')},
+        {value: "priority", description: "priority", selected: (_spf == 'priority')},
+      ];
+      return _result;
+    },
+    get_link_options: function(selecteds){
+      /**
+       * Build option items for constraint (desired/undesired) link.
+       */
+      let _this = this;
+      let _result = [];
+      $.each(this.link_options, function(key, item){
+        let _selected = false;
+        if(selecteds) {
+          selecteds.every( s => {
+            if(s == item.value) {
+              _selected = true;
+              return false;
+            }
+            return true;
+          });
+        }
+        let _item = {};
+        _item.value = item.value;
+        _item.description = item.description;
+        _item.selected = _selected;
+
+        _result.push(_item);
+      });
+      return _result;
+    },
+    get_desired_link_options: function(type) {
+      /**
+       * Method to build option items for constraint desired_links.
+       * @parameter type primary_constraints or secondary_constraints
+       */
+      let _links = this.form_constraints[type].desired_links;
+      if (this.form_constraints[type].desired_links == []) {
+        _links = this.constraints[type].desired_links;
+      }
+      let _result = this.get_link_options(_links);
+      return _result;
+    },
+    get_undesired_link_options: function(type) {
+      /**
+       * Method to build option items for constraint undesired_links.
+       * @parameter type primary_constraints or secondary_constraints
+       */
+      let _links = this.form_constraints[type].undesired_links;
+      if (this.form_constraints[type].undesired_links == []) {
+        _links = this.constraints[type].undesired_links;
+      }
+      let _result = this.get_link_options(_links);
+      return _result;
+    },
     showInfoPanel: function() {
       let listConnections = {
           component: 'kytos-mef_eline-k-info-panel-list_connections',
@@ -284,6 +470,28 @@ module.exports = {
         _this.$kytos.$emit("setNotification" , notification);
       });
     },
+    load_topology(){
+      var _this = this;
+
+      $.ajax({
+        async: true,
+        dataType: "json",
+        url: this.$kytos_server_api + "kytos/topology/v3",
+
+        success: function(data) {
+          let _link = data['topology']['links']
+          _this.link_options = [];
+
+          $.each(_link, function(key, value){
+            if (value.metadata.link_name !== undefined && value.metadata.link_name.length !== 0){
+              _this.link_options.push({value:value.id, description:value.metadata.link_name})
+            } else {
+              _this.link_options.push({value:value.id, description:value.id});
+            }
+          });
+        }
+      });
+    },
     onblur_dpid: function() {
       /**
        * Update dpid values on event onblur triggered in dpids fields.
@@ -366,10 +574,15 @@ module.exports = {
                    };
 
       this.links = {"Primary links": data['primary_links'],
-                      "Backup links": data['backup_links']
+                    "Backup links": data['backup_links']
                    };
       
       this.circuit_scheduler = data['circuit_scheduler'];
+
+      this.constraints = {
+        'primary_constraints': this.buildPathConstraintsView(data['primary_constraints']),
+        'secondary_constraints': this.buildPathConstraintsView(data['secondary_constraints']),
+      };
     },
     buildPathView: function(path_data) {
       /**
@@ -458,6 +671,81 @@ module.exports = {
         _this.$kytos.$emit("setNotification" , notification);
       });
     },
+
+    buildPathConstraintsView: function(data) {
+      /**
+      * Build path constraint data for exibition 
+      * (primary and secondary constraints paths).
+      * Parameter:
+      *   constraints_data: json with path constraint data
+      */
+      this.constraint_labels = {
+        'primary_constraints': 'Primary Constraints',
+        'secondary_constraints': 'Secondary Constraints',
+        'desired_links': 'Desired links',
+        'undesired_links': 'Undesired links',
+        'spf_attribute': 'SPF attribute',
+        'spf_max_path_cost': 'SPF max path cost',
+        'minimum_flexible_hits': 'Flexible hits',
+        'mandatory_metrics': 'Mandatory metrics',
+        'mandatory_metrics.bandwidth': 'Bandwidth',
+        'mandatory_metrics.utilization': 'Utilization',
+        'mandatory_metrics.priority': 'Priority',
+        'mandatory_metrics.delay': 'Delay',
+        'mandatory_metrics.ownership': 'Ownership',
+        'flexible_metrics': 'Flexible metrics',
+        'flexible_metrics.bandwidth': 'Bandwidth',
+        'flexible_metrics.utilization': 'Utilization',
+        'flexible_metrics.priority': 'Priority',
+        'flexible_metrics.delay': 'Delay',
+        'flexible_metrics.ownership': 'Ownership',
+      };
+
+      let _constraint = {};
+      if(data) {
+        _constraint = {
+          'desired_links': data['desired_links'],
+          'undesired_links': data['undesired_links'],
+          'spf_attribute': data['spf_attribute'],
+          'spf_max_path_cost': data['spf_max_path_cost'],
+          'minimum_flexible_hits': data['minimum_flexible_hits'],
+        };
+        
+        if(data['mandatory_metrics']) {
+          _constraint.mandatory_metrics = {
+            'bandwidth': data['mandatory_metrics']['bandwidth'],
+            'utilization': data['mandatory_metrics']['utilization'],
+            'priority': data['mandatory_metrics']['priority'],
+            'delay': data['mandatory_metrics']['delay'],
+            'ownership': data['mandatory_metrics']['ownership']
+          };
+        } else {
+          _constraint.mandatory_metrics = {
+            'bandwidth': '', 'utilization': '', 'priority': '',
+            'delay': '', 'ownership': '',
+          };
+        } 
+        if(data['flexible_metrics']) {
+          _constraint.flexible_metrics = {
+            'bandwidth': data['flexible_metrics']['bandwidth'],
+            'utilization': data['flexible_metrics']['utilization'],
+            'priority': data['flexible_metrics']['priority'],
+            'delay': data['flexible_metrics']['delay'],
+            'ownership': data['flexible_metrics']['ownership']
+          };
+        } else {
+          _constraint.flexible_metrics = {
+            'bandwidth': '', 'utilization': '', 'priority': '',
+            'delay': '', 'ownership': '',
+          };
+        }
+
+        this.constraint_descriptions.minimum_flexible_hits = "Minimum number of attributes listed in flexible_metrics that a path will meet. minimum: 0 maximum: 6";
+      }
+
+      return _constraint;
+    },
+
     getEndpointData: function(endpoint) {
       /**
       * Get DPID and Interface attributes and metadata.
@@ -525,6 +813,51 @@ module.exports = {
         };
       }
 
+      ['primary_constraints', 'secondary_constraints'].forEach(_type => {
+        payload[_type] = {};
+        // Dropdown forms
+        if(this.form_constraints[_type].desired_links.length > 0) {
+          payload[_type].desired_links = this.form_constraints[_type].desired_links;
+        }
+        if(this.form_constraints[_type].desired_links.length > 0) {
+          payload[_type].undesired_links = this.form_constraints[_type].undesired_links;
+        }
+        if(this.form_constraints[_type].spf_attribute !== "") {
+          payload[_type].spf_attribute = this.form_constraints[_type].spf_attribute;
+        }
+
+        // Input forms
+        if(this.constraints[_type].spf_max_path_cost !== "") {
+          payload[_type].spf_max_path_cost = parseInt(this.constraints[_type].spf_max_path_cost);
+        }
+        if(this.constraints[_type].minimum_flexible_hits !== "") {
+          payload[_type].minimum_flexible_hits = parseInt(this.constraints[_type].minimum_flexible_hits);
+        }
+
+        ['mandatory_metrics', 'flexible_metrics'].forEach(_metric_type => {
+          if(this.constraints[_type][_metric_type]) {
+            let metric = this.constraints[_type][_metric_type];
+            let _mandatory_metrics = {};
+            ['bandwidth', 'utilization', 'priority', 'delay'].forEach(_m => {
+              if(metric[_m] !== undefined && metric[_m] !== '') {
+                _mandatory_metrics[_m] = parseInt(metric[_m]);
+              } else {
+                //TODO: set the value to remove the metric (ex: 0, undefined, null, -1...)
+                //_mandatory_metrics[_m] = null;
+              }
+            });
+            if(metric['ownership'] !== undefined) { // can be empty
+              _mandatory_metrics['ownership'] = metric['ownership'];
+            }
+            
+            if(!$.isEmptyObject(_mandatory_metrics)) {
+              payload[_type][_metric_type] = _mandatory_metrics;
+            }
+          }
+        });
+      });
+      $payload = payload;
+
       var request = $.ajax({
         url: this.$kytos_server_api + "kytos/mef_eline/v2/evc/" + id,
         type:"PATCH",
@@ -548,17 +881,46 @@ module.exports = {
       });
     },
   },
-  mounted() {
-    if(this.content && this.content.id) {
+  beforeMount() {
       // Load DPID attributes and metadata
       this.loadDpidNames();
+      // load topology links
+      this.load_topology();
+  },
+  mounted() {
+    let _this = this;
+    if(this.content && this.content.id) {
       // Load EVC
       this.loadEVC(this.content.id);
+
       // Make the panel fill the screen except the left menu width
       $('.k-info-panel:has(.mef_circuit_container)').addClass('mef-k-info-panel');
       
       this.$kytos.dpids = this.dpids;
     }
+    ['primary_constraints', 'secondary_constraints'].forEach( s => {
+        _this.form_constraints[s] = {
+          'desired_links': '',
+          'undesired_links': '',
+          'spf_attribute': '',
+          'spf_max_path_cost': '',
+          'minimum_flexible_hits': '',
+          'mandatory_metrics': {
+            'bandwidth': '',
+            'utilization': '',
+            'priority': '',
+            'delay': '',
+            'ownership': ''
+          },
+          'flexible_metrics': {
+            'bandwidth': '',
+            'utilization': '',
+            'priority': '',
+            'delay': '',
+            'ownership': ''
+          }
+        };
+      });
   },
   created() {
     // Check if the UI component k-input-auto exists
@@ -587,6 +949,9 @@ module.exports = {
   .mef_circuit_container .check_false {
     color: #c00000;
   }
+  .mef_circuit_container .k-select {
+    font-size: 1em;
+  }
   .mef_circuit_container .mef-buttons {
     display: flow-root;
   }
@@ -604,6 +969,10 @@ module.exports = {
     text-align: center;
     font-size: 1em;
   }
+  .mef_circuit_container .k-select__select:hover * {
+    color: white;
+    background-color: #515151;
+  }
   .mef_circuit_container input:focus {
     border: 1px solid blueviolet;
   }
@@ -619,12 +988,12 @@ module.exports = {
     float: none;
   }
   .mef_circuit_container tbody tr:hover {
-    background: inherit;
+    background: none;
   }
   .mef_circuit_container table {
     border-collapse: collapse;
     width: 100%;
-    font-size: 0.9em;
+    
   }
   .mef_circuit_container tr:nth-child(even) {
       background-color: #2d2d2d;
@@ -646,6 +1015,9 @@ module.exports = {
       margin-left: 20px;
       margin-bottom: 20px;
   }
+  .mef-circuit-table tbody tr:hover {
+    background: none;
+  }
   .mef-circuit-table th {
     width: 75px;
   }
@@ -654,6 +1026,28 @@ module.exports = {
   }
   .mef-circuit-table table + table {
     margin-top:4px;
+  }
+  .mef-circuit-table-constraints {
+    clear:both; 
+    width:540px;
+  }
+  .mef-circuit-table-constraints #mef-constraints-desired-links {
+    float: left;
+    width: 255px;
+  }
+  .mef-circuit-table-constraints #mef-constraints-undesired-links {
+    float: left;
+    margin-left: 10px;
+    width: 255px;
+  }
+  .mef-circuit-table-constraints #mef-constraints-spf {
+    width: 300px;
+  }
+  .mef-circuit-table-constraints #mef-constraints-spf th {
+    width: 130px;
+  }
+  .mef-circuit-table-constraints select {
+    margin: 0;
   }
   .mef-back-button {
     clear: both;
@@ -674,7 +1068,7 @@ module.exports = {
   }
   .mef-circuit-table-path {
     clear:both; 
-    width:520px;
+    width:540px;
   }
   /* Modal windows */
   .modal-mask {

--- a/ui/k-info-panel/show_circuit.kytos
+++ b/ui/k-info-panel/show_circuit.kytos
@@ -817,7 +817,7 @@ module.exports = {
         payload[_type] = {};
         // Dropdown forms
         if(this.form_constraints[_type].desired_links.length > 0) {
-          payload[_type].desired_links = this.form_constraints[_type].desired_links;
+          payload[_type].desired_links = this.form_constraints[_type].desired_links.filter(item => typeof(item) == "string");
         }
         if(this.form_constraints[_type].desired_links.length > 0) {
           payload[_type].undesired_links = this.form_constraints[_type].undesired_links.filter(item => typeof(item) == "string");

--- a/ui/k-info-panel/show_circuit.kytos
+++ b/ui/k-info-panel/show_circuit.kytos
@@ -686,7 +686,7 @@ module.exports = {
         'undesired_links': 'Undesired links',
         'spf_attribute': 'SPF attribute',
         'spf_max_path_cost': 'SPF max path cost',
-        'minimum_flexible_hits': 'Flexible hits',
+        'minimum_flexible_hits': 'Min. flexible hits',
         'mandatory_metrics': 'Mandatory metrics',
         'mandatory_metrics.bandwidth': 'Bandwidth',
         'mandatory_metrics.utilization': 'Utilization',

--- a/ui/k-info-panel/show_circuit.kytos
+++ b/ui/k-info-panel/show_circuit.kytos
@@ -820,7 +820,7 @@ module.exports = {
           payload[_type].desired_links = this.form_constraints[_type].desired_links;
         }
         if(this.form_constraints[_type].desired_links.length > 0) {
-          payload[_type].undesired_links = this.form_constraints[_type].undesired_links;
+          payload[_type].undesired_links = this.form_constraints[_type].undesired_links.filter(item => typeof(item) == "string");
         }
         if(this.form_constraints[_type].spf_attribute !== "") {
           payload[_type].spf_attribute = this.form_constraints[_type].spf_attribute;

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -289,7 +289,7 @@ module.exports = {
         'undesired_links': 'Undesired links',
         'spf_attribute': 'SPF attribute',
         'spf_max_path_cost': 'SPF max path cost',
-        'minimum_flexible_hits': 'Flexible hits',
+        'minimum_flexible_hits': 'Min. flexible hits',
         'mandatory_metrics': 'Mandatory metrics',
         'bandwidth': 'Bandwidth',
         'utilization': 'Utilization',

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -422,7 +422,7 @@ module.exports = {
 
           // Dropdown forms
           if(this.form_constraints[_type].desired_links.length > 0) {
-            request[_type].desired_links = this.form_constraints[_type].desired_links;
+            request[_type].desired_links = this.form_constraints[_type].desired_links.filter(item => typeof(item) == "string");
           }
           if(this.form_constraints[_type].undesired_links.length > 0) {
             request[_type].undesired_links = this.form_constraints[_type].undesired_links.filter(item => typeof(item) == "string");

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -421,10 +421,10 @@ module.exports = {
           });
 
           // Dropdown forms
-          if(this.form_constraints[_type].desired_links.length > 0) {
+          if(this.form_constraints[_type].desired_links) {
             request[_type].desired_links = this.form_constraints[_type].desired_links.filter(item => typeof(item) == "string");
           }
-          if(this.form_constraints[_type].undesired_links.length > 0) {
+          if(this.form_constraints[_type].undesired_links) {
             request[_type].undesired_links = this.form_constraints[_type].undesired_links.filter(item => typeof(item) == "string");
           }
           if(this.form_constraints[_type].spf_attribute) {

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -425,7 +425,7 @@ module.exports = {
             request[_type].desired_links = this.form_constraints[_type].desired_links;
           }
           if(this.form_constraints[_type].undesired_links.length > 0) {
-            request[_type].undesired_links = this.form_constraints[_type].undesired_links;
+            request[_type].undesired_links = this.form_constraints[_type].undesired_links.filter(item => typeof(item) == "string");
           }
           if(this.form_constraints[_type].spf_attribute) {
             request[_type].spf_attribute = this.form_constraints[_type].spf_attribute;

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -1,7 +1,8 @@
 <template>
-    <k-toolbar-item icon="link" tooltip="Mef-Eline">
+  <k-toolbar-item icon="link" tooltip="Mef-Eline">
+    <div class="scroll">
       <k-accordion>
-         <k-accordion-item title="Request E-Line Circuit">
+        <k-accordion-item title="Request E-Line Circuit">
            <k-input id="name-input" :value.sync="circuit_name"
                     title="Circuit Name:" tooltip="Circuit name"
                     placeholder="Circuit Name" icon="pencil"></k-input>
@@ -11,38 +12,37 @@
                     tooltip="Endpoint A (format: dpid:port_number)"
                     placeholder="Endpoint A" icon="arrow-right"
                     :candidates="dpids" 
-                    @focus="fetchDpids"
+                    @focus="fetch_dpids"
                     @blur="onblur_dpid"
-					v-if="compexists"
+					          v-if="compexists"
                     ></k-input-auto>
             <k-input id="endpoint-a-input" :value.sync="endpoint_a"
                     title="Endpoint A:"
                     tooltip="Endpoint A (format: dpid:port_number)"
                     placeholder="Endpoint A" icon="arrow-right"
-					v-else
+					          v-else
                     ></k-input> 
             <div class="k-input mef-field-label" :value.sync="endpoint_name_a"
                     >{{endpoint_name_a}}</div> 
-            
-           <k-input id="endpoint-a-tag-type" :value.sync="tag_type_a"
+            <k-input id="endpoint-a-tag-type" :value.sync="tag_type_a"
                     v-if=false
                     title="Tag Type A:"
                     tooltip="Enter with a Tag Type"
                     placeholder="tag type" icon="arrow-right"></k-input>
 
-           <k-input id="endpoint-a-tag-value" :value.sync="tag_value_a"
+            <k-input id="endpoint-a-tag-value" :value.sync="tag_value_a"
                     title="Tag Value A:"
                     tooltip="Enter VLAN A value"
                     placeholder="VLAN A" icon="arrow-right"></k-input>
 
-           <k-input-auto id="endpoint-z-input" :value.sync="endpoint_z"
+            <k-input-auto id="endpoint-z-input" :value.sync="endpoint_z"
                     title="Endpoint Z:"
                     tooltip="Endpoint Z (format: dpid:port_number)"
                     placeholder="Endpoint Z" icon="arrow-left"
                     :candidates="dpids"
-                    @focus="fetchDpids"
+                    @focus="fetch_dpids"
                     @blur="onblur_dpid"
-					v-if="compexists"></k-input-auto>
+					          v-if="compexists"></k-input-auto>
             <div class="k-input mef-field-label" :value.sync="endpoint_name_z"
                     >{{endpoint_name_z}}</div> 
            <k-input id="endpoint-z-input" :value.sync="endpoint_z"
@@ -75,19 +75,116 @@
 
            <k-dropdown icon="arrow-right" title="QoS Egress Queue" :options="get_queue_ids"
             :value.sync="queue_id"></k-dropdown>
+        </k-accordion-item>
 
-           <k-button tooltip="Request Circuit" title="Request Circuit"
-                     icon="gear" :on_click="request_circuit">
-                     </k-button>
-         </k-accordion-item>
+        <span v-for="constraint in ['primary_constraints', 'secondary_constraints']">
+            <k-accordion-item :title="constraint_titles[constraint]"
+             v-if="form_constraints[constraint]">
 
-         <k-accordion-item title="List EVCs">
+                <k-select :title="constraint_titles.desired_links"
+                :options="get_link_options()"
+                :value.sync="form_constraints[constraint].desired_links"></k-select>
+
+                <k-select :title="constraint_titles.undesired_links" :options="get_link_options()"
+                :value.sync ="form_constraints[constraint].undesired_links"></k-select>
+                
+                <div class="metric">
+                  <div class="metric-dropdown">
+                    <k-dropdown :title="constraint_titles.spf_attribute" :options="get_spf_attribute_options()"
+                    :value.sync ="form_constraints[constraint].spf_attribute"></k-dropdown>
+                  </div>
+                  <div class="metric-field">
+                    <p><!-- blank space --></p>
+                  </div>
+                </div>
+
+                <div class="metric">
+                  <div class="metric-field">
+                    <label class="metric-label">{{constraint_titles['spf_max_path_cost']}}</label> 
+                    <k-input 
+                    title="Southbound priority:"
+                    :action="function(val) {form_constraints[constraint].spf_max_path_cost = parseInt(val)}"></k-input>
+                  </div>
+                </div>
+
+                <div class="metric">
+                  <div class="metric-field">
+                    <label class="metric-label">{{constraint_titles['minimum_flexible_hits']}}</label> 
+                    <k-input 
+                    :title="constraint_titles['minimum_flexible_hits']"
+                    :action="function(val) {form_constraints[constraint].minimum_flexible_hits = parseInt(val)}"></k-input>
+                  </div>
+                </div>
+
+                <div class="metric">
+                    <div class="metric-dropdown">
+                        <k-dropdown :options="metric_options" 
+                        :title="constraint_titles['bandwidth']"
+                        :value.sync="is_flexible[constraint].bandwidth"></k-dropdown>
+                    </div>
+                    <div class="metric-field">
+                        <k-input icon="arrow-right" :action="function(val) {metrics[constraint].bandwidth = parseInt(val)}"></k-input>
+                    </div>
+                </div>
+
+                <div class="metric">
+                  <div class="metric-dropdown">
+                    <k-dropdown :options="metric_options" 
+                    :title="constraint_titles['utilization']"
+                    :value.sync="is_flexible[constraint].utilization"></k-dropdown>
+                  </div>
+                  <div class="metric-field">
+                    <k-input icon="arrow-right" :action="function(val) {metrics[constraint].utilization = parseInt(val)}"></k-input>
+                  </div>
+                </div>
+
+                <div class="metric">
+                  <div class="metric-dropdown">
+                    <k-dropdown :options="metric_options" 
+                    :title="constraint_titles['priority']"
+                    :value.sync="is_flexible[constraint].priority"></k-dropdown>
+                  </div>
+                  <div class="metric-field">
+                    <k-input icon="arrow-right" :action="function(val) {metrics[constraint].priority = parseInt(val)}"></k-input>
+                  </div>
+                </div>
+
+                <div class="metric">
+                  <div class="metric-dropdown">
+                    <k-dropdown :options="metric_options" 
+                    :title="constraint_titles['delay']"
+                    :value.sync="is_flexible[constraint].delay"></k-dropdown>
+                  </div>
+                  <div class="metric-field">
+                    <k-input icon="arrow-right" :action="function(val) {metrics[constraint].delay = parseInt(val)}"></k-input>
+                  </div>
+                </div>
+
+                <div class="metric">
+                  <div class="metric-dropdown">
+                    <k-dropdown :options="metric_options" 
+                    :title="constraint_titles['ownership']"
+                    :value.sync="is_flexible[constraint].ownership"></k-dropdown>
+                  </div>
+                  <div class="metric-field">
+                    <k-input icon="arrow-right" :action="function(val) {metrics[constraint].ownership = val}"></k-input>
+                  </div>
+                </div>
+            </k-accordion-item>
+        </span>
+        <k-accordion-item>
+          <k-button tooltip="Request Circuit" title="Request Circuit"
+          icon="gear" :on_click="request_circuit">
+          </k-button>
+        </k-accordion-item>
+        <k-accordion-item title="List EVCs">
             <k-button tooltip="List installed EVC" title="List installed EVC"
                      icon="plug" :on_click="viewPanel">
-                     </k-button>
-         </k-accordion-item>
+            </k-button>
+        </k-accordion-item>
       </k-accordion>
-    </k-toolbar-item>
+    </div>
+  </k-toolbar-item>
 </template>
 <script>
 module.exports = {
@@ -106,10 +203,43 @@ module.exports = {
         sb_priority: "",
         queue_id: "",
         dpids: [""],
-        hasAutoComplete:false
+        hasAutoComplete:false,
+
+        constraint_titles: {},
+        constraints: {},
+        form_constraints: {},
+        metrics: {
+          primary_constraints: {},
+          secondary_constraints: {}
+        },
+        is_flexible: {
+          primary_constraints: {
+            bandwidth: false,
+            reliability: false,
+            delay: false,
+            utilization: false,
+            priority: false,
+            ownership: false
+          },
+          secondary_constraints: {
+            bandwidth: false,
+            reliability: false,
+            delay: false,
+            utilization: false,
+            priority: false,
+            ownership: false
+          }
+        },
     }
   },
   computed: {
+    metric_options(){
+      var metric_options = [];
+      metric_options.push({value: false, description: 'Mandatory', selected: true});
+      metric_options.push({value: true, description: 'Flexible'});
+
+      return metric_options;
+    },
     get_queue_ids(){
       let values = Array(8).fill().map((_, i) => i)
       var queue_ids = [{value: "", description: "none", selected: true}]
@@ -120,6 +250,78 @@ module.exports = {
     },
   },
   methods: {
+    get_spf_attribute_options: function() {
+      /**
+       * Method to build option items for spf attribute.
+       */
+      let _result = [
+        {value: "hop", description: "hop", selected: true},
+        {value: "delay", description: "delay"},
+        {value: "priority", description: "priority"},
+      ];
+      return _result;
+    },    
+    get_link_options: function(){
+      /**
+       * Build option items for constraint (desired/undesired) link.
+       */
+      let _result = [];
+      $.each(this.link_options, function(key, item){
+        let _item = {};
+        _item.value = item.value;
+        _item.description = item.description;
+        _result.push(_item);
+      });
+      return _result;
+    },
+    init_path_constraints: function() {
+      /**
+      * Build path constraint data for exibition 
+      * (primary and secondary constraints paths).
+      */
+      this.form_constraints['primary_constraints'] = {};
+      this.form_constraints['secondary_constraints'] = {};
+
+      this.constraint_titles = {
+        'primary_constraints': 'Primary Constraints',
+        'secondary_constraints': 'Secondary Constraints',
+        'desired_links': 'Desired links',
+        'undesired_links': 'Undesired links',
+        'spf_attribute': 'SPF attribute',
+        'spf_max_path_cost': 'SPF max path cost',
+        'minimum_flexible_hits': 'Flexible hits',
+        'mandatory_metrics': 'Mandatory metrics',
+        'bandwidth': 'Bandwidth',
+        'utilization': 'Utilization',
+        'priority': 'Priority',
+        'delay': 'Delay',
+        'ownership': 'Ownership',
+      };
+
+      let _constraint = {};
+      _constraint = {
+        'desired_links': '',
+        'undesired_links': '',
+        'spf_attribute': '',
+        'spf_max_path_cost': '',
+        'minimum_flexible_hits': '',
+      };
+
+      _constraint.mandatory_metrics = {
+        'bandwidth': '', 'utilization': '', 'priority': '',
+        'delay': '', 'ownership': '',
+      };
+    
+      _constraint.flexible_metrics = {
+        'bandwidth': '', 'utilization': '', 'priority': '',
+        'delay': '', 'ownership': '',
+      };
+
+      this.constraint = {
+        primary_constraints: _constraint,
+        secondary_constraints: _constraint
+      };
+    },
     viewPanel() {
         var _this = this;
         // Clear panel
@@ -177,6 +379,7 @@ module.exports = {
         this.$kytos.$emit("setNotification" , notification);
     },
     request_circuit () {
+        var _this = this;
         var request = {
             "name" : this.circuit_name,
             "dynamic_backup_path": true,
@@ -202,6 +405,40 @@ module.exports = {
         if (this.queue_id !== undefined && this.queue_id !== "") {
             request.queue_id = parseInt(this.queue_id)
         }
+
+        ['primary_constraints', 'secondary_constraints'].forEach(_type => {
+          request[_type] = {};
+          request[_type].flexible_metrics = {};
+          request[_type].mandatory_metrics = {};
+
+          // mandatory and flexible metrics
+          ['bandwidth', 'utilization', 'priority', 'delay', 'ownership'].forEach(_m => {
+            if (_this.is_flexible[_type][_m]) {
+              request[_type].flexible_metrics[_m] = _this.metrics[_type][_m];
+            } else {
+              request[_type].mandatory_metrics[_m] = _this.metrics[_type][_m];
+            }
+          });
+
+          // Dropdown forms
+          if(this.form_constraints[_type].desired_links.length > 0) {
+            request[_type].desired_links = this.form_constraints[_type].desired_links;
+          }
+          if(this.form_constraints[_type].undesired_links.length > 0) {
+            request[_type].undesired_links = this.form_constraints[_type].undesired_links;
+          }
+          if(this.form_constraints[_type].spf_attribute) {
+            request[_type].spf_attribute = this.form_constraints[_type].spf_attribute;
+          }
+
+          // Input forms
+          if(this.form_constraints[_type].spf_max_path_cost) {
+            request[_type].spf_max_path_cost = parseInt(this.form_constraints[_type].spf_max_path_cost);
+          }
+          if(this.form_constraints[_type].minimum_flexible_hits) {
+            request[_type].minimum_flexible_hits = parseInt(this.form_constraints[_type].minimum_flexible_hits);
+          }
+        });
         
         let circuit_request = $.ajax({
                                 url: this.$kytos_server_api + "kytos/mef_eline/v2/evc/",
@@ -209,12 +446,12 @@ module.exports = {
                                 data: JSON.stringify(request),
                                 dataType: "json",
                                 contentType: "application/json; charset=utf-8"
-                            })
+                            });
                     
-        circuit_request.done(this.post_success)
-        circuit_request.fail(this.post_error)
+        circuit_request.done(this.post_success);
+        circuit_request.fail(this.post_error);
     },
-    fetchDpids: function() {
+    fetch_dpids: function() {
         var self = this // create a closure to access component in the callback below
         dataUrl = "/api/kytos/topology/v3/interfaces"
         // Autocomplete usage example.
@@ -230,6 +467,28 @@ module.exports = {
                         }
                         self.dpids = dpids;
                     });
+    },
+    load_topology: function() {
+      var _this = this;
+
+      $.ajax({
+        async: true,
+        dataType: "json",
+        url: this.$kytos_server_api + "kytos/topology/v3",
+
+        success: function(data) {
+          let _link = data['topology']['links']
+          _this.link_options = [];
+
+          $.each(_link, function(key, value){
+            if (value.metadata.link_name !== undefined && value.metadata.link_name.length !== 0){
+              _this.link_options.push({value:value.id, description:value.metadata.link_name})
+            } else {
+              _this.link_options.push({value:value.id, description:value.id});
+            }
+          });
+        }
+      });
     },
     onblur_dpid: function() {
         /**
@@ -253,7 +512,9 @@ module.exports = {
     },
   },
   mounted() { // when the Vue app is booted up, this is run automatically.
-    this.fetchDpids();
+    this.fetch_dpids();
+    this.load_topology();
+    this.init_path_constraints();
     compexists = this.$root.$options.components['k-input-auto'] != null;
   },
   created() {
@@ -262,6 +523,7 @@ module.exports = {
 }
 </script>
 <style>
+  .scroll {overflow-y: auto; height:calc(100vh - 60px);}
   .mef-field-label {
     padding-left: 2.3em;
     color: #737373;
@@ -278,4 +540,27 @@ module.exports = {
   .autocomplete-result-list li {
     white-space: nowrap;
   }
+  .metric {width:100%; overflow: hidden; display:flex;flex-wrap: wrap;}
+  .metric-label {
+    width:50%;
+    color: #b3b3b3;
+    font-size: .78em;
+  }
+  .metric-dropdown {width:100%;}
+  .metric-dropdown .k-dropdown {height: 20px; width:100%; display:flex;flex-wrap: wrap;}
+  .metric-dropdown .k-dropdown .k-dropdown__title {width:35%;}
+  .metric-dropdown .k-dropdown .k-dropdown__select {width:60%;}
+  .metric-field {width:100%; display:flex; }
+  .metric-field label {width:60%; }
+  .metric-field label ~.k-input-wrap {width:40%; }
+  .metric-field label ~.k-input-wrap input {width:50px; }
+  
+
+  .metric-field  .k-input-wrap:hover  * {
+    background: #515151;
+  }
+  .metric-field  .k-input-wrap:hover input  * {
+    background: #515151;
+  }
+  
 </style>


### PR DESCRIPTION
Fix #201 
This PR add the fields of primary and secondary constraints.
The fields are included in the request of new E-Line Circuit using the accordion item, for now, without the pagination suggested.
![image](https://user-images.githubusercontent.com/10867136/211416798-969f9a59-464e-4f06-afca-754eb018c2a0.png)
Inside the E-line circuit detail the primary and secondary constraints fields can be visualized and updated.
![image](https://user-images.githubusercontent.com/10867136/211416885-3d79daac-e2ff-4d09-bebb-ae41726856df.png)
Mandatory and flexible metrics are displayed in separated fields to better visualization.