### PR TITLE
pinned tox version due to Issue kytos-ng/kytos#313

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions
+        pip install tox==3.27.1 tox-gh-actions==2.12.0
     - name: Test with tox
       run: tox


### PR DESCRIPTION
- Pinned tox version while kytos-ng/kytos#313 gets fixed

- Pinned tox-gh-actions following the compatibility matrix (https://pypi.org/project/tox-gh-actions/)