### PR TITLE
Change log level to info for link up event

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Added
 - Documented ``GET /v2/evc?archived`` query arg on openapi.yml
 - Added ``flow_removed_at`` and ``updated_at`` parameters in EVC.
 - Added ``execution_rounds`` in EVC to be used by the consistency check. 
+- Added logging message for ``link_up`` events.
 
 Changed
 =======

--- a/main.py
+++ b/main.py
@@ -645,7 +645,7 @@ class Main(KytosNApp):
 
     def handle_link_up(self, event):
         """Change circuit when link is up or end_maintenance."""
-        log.debug("Event handle_link_up %s", event)
+        log.info("Event handle_link_up %s", event.content["link"])
         for evc in self.get_evcs_by_svc_level():
             if evc.is_enabled() and not evc.archived:
                 with evc.lock:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1691,6 +1691,15 @@ class TestMain(TestCase):
         with self.assertRaises(ValueError):
             self.napp._link_from_dict(link_dict)
 
+    def test_uni_from_dict_non_existent_intf(self):
+        """Test _link_from_dict non existent intf."""
+        self.napp.controller.get_interface_by_id = MagicMock(return_value=None)
+        uni_dict = {
+            "interface_id": "aaa",
+        }
+        with self.assertRaises(ValueError):
+            self.napp._uni_from_dict(uni_dict)
+
     @patch("napps.kytos.mef_eline.models.evc.EVC.deploy")
     @patch("napps.kytos.mef_eline.scheduler.Scheduler.add")
     @patch("napps.kytos.mef_eline.main.Main._uni_from_dict")

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -321,6 +321,12 @@ class TestMain(TestCase):
                     "endpoint_b": {
                         "interface_id": "00:00:00:00:00:00:00:02:2"
                     },
+                    "metadata": {
+                        "s_vlan": {
+                            "tag_type": 1,
+                            "value": 100
+                        }
+                    },
                 }
             ],
             "backup_links": [],
@@ -1089,6 +1095,11 @@ class TestMain(TestCase):
                             content_type='application/json')
         self.assertEqual(response.status_code, 403)
 
+        # case 8: invalid json
+        response = api.post(url, data='{"test"}',
+                            content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+
     @patch('apscheduler.schedulers.background.BackgroundScheduler.remove_job')
     @patch('napps.kytos.mef_eline.scheduler.Scheduler.add')
     @patch('napps.kytos.mef_eline.main.Main._uni_from_dict')
@@ -1678,7 +1689,7 @@ class TestMain(TestCase):
             "endpoint_b": {"id": "b"}
         }
         with self.assertRaises(ValueError):
-            self.napp._uni_from_dict(link_dict)
+            self.napp._link_from_dict(link_dict)
 
     @patch("napps.kytos.mef_eline.models.evc.EVC.deploy")
     @patch("napps.kytos.mef_eline.scheduler.Scheduler.add")


### PR DESCRIPTION
Fix #239 

### Description of the change

This is a very simple change to modify the log level of link up events, to add more information for network operators to troubleshoot issues.

### Local tests

- Unit tests were executed to confirm everything was okay
- Manual execution of Kytos also demonstrated the new messages were being logged successfully:

```
Jan 18 18:50:32 5003be03af14 kytos.napps.kytos/mef_eline:INFO main:648:  Event handle_link_up Link(Interface('Ampath1-eth1', 1, Switch('00:00:00:00:00:00:00:11')), Interface('Ampath2-eth1', 1, Switch('00:00:00:00:00:00:00:12')))
Jan 18 18:50:32 5003be03af14 kytos.napps.kytos/mef_eline:INFO main:648:  Event handle_link_up Link(Interface('Ampath1-eth11', 11, Switch('00:00:00:00:00:00:00:11')), Interface('Ampath4-eth11', 11, Switch('00:00:00:00:00:00:00:18')))
Jan 18 18:50:32 5003be03af14 kytos.napps.kytos/mef_eline:INFO main:648:  Event handle_link_up Link(Interface('Ampath1-eth2', 2, Switch('00:00:00:00:00:00:00:11')), Interface('SoL2-eth2', 2, Switch('00:00:00:00:00:00:00:13')))
```
