### PR TITLE
Adding workaround for pathfinder issue #37 - getting the paths when desired and undesired links are specified

### DIFF
--- a/models/path.py
+++ b/models/path.py
@@ -115,6 +115,15 @@ class DynamicPathManager:
     @staticmethod
     def get_paths(circuit, max_paths=2, **kwargs):
         """Get a valid path for the circuit from the Pathfinder."""
+        # pylint: disable=fixme
+        # XXX: temporary workaround for kytos-ng/pathfinder#37
+        if (
+            len(circuit.secondary_constraints.get('undesired_links', [])) > 0
+            or len(circuit.secondary_constraints.get('desired_links', [])) > 0
+            or len(circuit.primary_constrains.get('undesired_links', [])) > 0
+            or len(circuit.primary_constrains.get('desired_links', [])) > 0
+        ):
+            max_paths += 10
         endpoint = settings.PATHFINDER_URL
         request_data = {
             "source": circuit.uni_a.interface.id,

--- a/models/path.py
+++ b/models/path.py
@@ -120,8 +120,8 @@ class DynamicPathManager:
         if (
             len(circuit.secondary_constraints.get('undesired_links', [])) > 0
             or len(circuit.secondary_constraints.get('desired_links', [])) > 0
-            or len(circuit.primary_constrains.get('undesired_links', [])) > 0
-            or len(circuit.primary_constrains.get('desired_links', [])) > 0
+            or len(circuit.primary_constraints.get('undesired_links', [])) > 0
+            or len(circuit.primary_constraints.get('desired_links', [])) > 0
         ):
             max_paths += 10
         endpoint = settings.PATHFINDER_URL


### PR DESCRIPTION
This PR is a workaround for kytos-ng/pathfinder#37

### Description of the change

While kytos-ng/pathfinder#37 is not fixed, this PR adds an extra procedure before requesting paths from pathfinder to increase the number of returned paths before applying `desired_links` or `undesired_links`.

### Local tests

Unit tests were executed and no issue was found.

Manual validation was also executed without problems:
1. Running Kytos with Amlight Mininet topoligy
2. Requesting an EVC with uni_a being 00:00:00:00:00:00:00:21:60 and uni_z being 00:00:00:00:00:00:00:16:55, also added `primary_constraints={"desired_links": ["3d8cb9eb085cf90837f49de8cdb951487936fc4fdeb3699be017c9c2701d9d6a"]}`, and `"secondary_constraints": { "undesired_links": ["21c046f5eb9fbf577701974e207c2fd2ccd8cc4b91fae77ad396924b79c48483"]}`
3. without this workaround, Kytos didnt deploy the EVC due to no path found:
```
# curl -H 'Content-type: application/json' -X POST http://127.0.0.1:8181/api/kytos/mef_eline/v2/evc -d '{"name": "vlan 123", "dynamic_backup_path": true, "uni_a":{"interface_id":"00:00:00:00:00:00:00:21:60","tag":{"tag_type":1,"value":123}},"uni_z":{"interface_id":"00:00:00:00:00:00:00:16:55","tag":{"tag_type":1,"value":123}}, "primary_constraints":{"desired_links":["3d8cb9eb085cf90837f49de8cdb951487936fc4fdeb3699be017c9c2701d9d6a"]}, "secondary_constraints":{"undesired_links":["21c046f5eb9fbf577701974e207c2fd2ccd8cc4b91fae77ad396924b79c48483"]}}'
{"circuit_id":"80bbcf7e518141"}
# grep 80bbcf7e518141 /var/log/syslog
Jan 18 20:31:04 5003be03af14 kytos.napps.kytos/mef_eline:WARNING evc:717:  EVC(80bbcf7e518141, vlan 123) was not deployed. No available path was found.
```
4. with the workaround, Kytos returned: 
```
root@5003be03af14:/src/kytos-mef-eline# curl -H 'Content-type: application/json' -X POST http://127.0.0.1:8181/api/kytos/mef_eline/v2/evc -d '{"name": "vlan 123", "dynamic_backup_path": true, "uni_a":{"interface_id":"00:00:00:00:00:00:00:21:60","tag":{"tag_type":1,"value":123}},"uni_z":{"interface_id":"00:00:00:00:00:00:00:16:55","tag":{"tag_type":1,"value":123}}, "primary_constraints":{"desired_links":["3d8cb9eb085cf90837f49de8cdb951487936fc4fdeb3699be017c9c2701d9d6a"]}, "secondary_constraints":{"undesired_links":["21c046f5eb9fbf577701974e207c2fd2ccd8cc4b91fae77ad396924b79c48483"]}}'
{"circuit_id":"f16248b1631446"}

# grep f16248b1631446 /var/log/syslog
Jan 18 20:21:18 5003be03af14 kytos.napps.kytos/mef_eline:INFO evc:730:  EVC(f16248b1631446, vlan 123) was deployed.
Jan 18 20:21:19 5003be03af14 kytos.napps.kytos/mef_eline:INFO evc:789:  Failover path for EVC(f16248b1631446, vlan 123) was deployed.
```