### PR TITLE
Adding validation mechanism for consistency check on intra-switch EVCs

### DIFF
--- a/models/evc.py
+++ b/models/evc.py
@@ -1191,7 +1191,6 @@ class EVCDeploy(EVCBase):
         return True
 
     @staticmethod
-    # py#####lint: disable=too-many-locals
     def check_list_traces(list_circuits):
         """Check if current_path is deployed comparing with SDN traces."""
         if not list_circuits:

--- a/models/evc.py
+++ b/models/evc.py
@@ -15,8 +15,10 @@ from kytos.core.helpers import get_time, now
 from kytos.core.interface import UNI
 from napps.kytos.mef_eline import controllers, settings
 from napps.kytos.mef_eline.exceptions import FlowModException, InvalidPath
-from napps.kytos.mef_eline.utils import (compare_endpoint_trace, emit_event,
-                                         notify_link_available_tags)
+from napps.kytos.mef_eline.utils import (compare_endpoint_trace,
+                                         compare_uni_out_trace, emit_event,
+                                         notify_link_available_tags,
+                                         uni_to_str)
 
 from .path import DynamicPathManager, Path
 
@@ -291,6 +293,10 @@ class EVCBase(GenericEntity):
                 return False
         return True
 
+    def is_intra_switch(self):
+        """Check if the UNIs are in the same switch."""
+        return self.uni_a.interface.switch == self.uni_z.interface.switch
+
     def shares_uni(self, other):
         """Check if two EVCs share an UNI."""
         if other.uni_a in (self.uni_a, self.uni_z) or other.uni_z in (
@@ -463,10 +469,7 @@ class EVCDeploy(EVCBase):
         if success:
             return True
 
-        if (
-            self.dynamic_backup_path
-            or self.uni_a.interface.switch == self.uni_z.interface.switch
-        ):
+        if self.dynamic_backup_path or self.is_intra_switch():
             return self.deploy_to_path()
 
         return False
@@ -710,7 +713,7 @@ class EVCDeploy(EVCBase):
             if use_path:
                 self._install_nni_flows(use_path)
                 self._install_uni_flows(use_path)
-            elif self.uni_a.interface.switch == self.uni_z.interface.switch:
+            elif self.is_intra_switch():
                 use_path = Path()
                 self._install_direct_uni_flows()
             else:
@@ -743,7 +746,7 @@ class EVCDeploy(EVCBase):
         5. Update failover_path
         """
         # Intra-switch EVCs have no failover_path
-        if self.uni_a.interface.switch == self.uni_z.interface.switch:
+        if self.is_intra_switch():
             return False
 
         # For not only setup failover path for totally dynamic EVCs
@@ -1147,25 +1150,24 @@ class EVCDeploy(EVCBase):
         return response.json()
 
     @staticmethod
-    def check_trace(
-                    circuit_id,
-                    circuit_current_path,
-                    circuit_by_traces,
-                    circuits_checked
-                ):
+    def check_trace(circuit, circuit_by_traces):
         """Auxiliar function to check an individual trace"""
-        if not circuit_current_path:
-            return
-        circuits_checked[circuit_id] = True
-        trace_a = circuit_by_traces[circuit_id]['trace_a']
-        trace_z = circuit_by_traces[circuit_id]['trace_z']
-        if len(trace_a) != len(circuit_current_path) + 1:
+        trace_a = circuit_by_traces[circuit.id]['trace_a']
+        trace_z = circuit_by_traces[circuit.id]['trace_z']
+        if (
+            len(trace_a) != len(circuit.current_path) + 1
+            or not compare_uni_out_trace(circuit.uni_z, trace_a[-1])
+        ):
             log.warning(f"Invalid trace from uni_a: {trace_a}")
-            circuits_checked[circuit_id] = False
-        if len(trace_z) != len(circuit_current_path) + 1:
+            return False
+        if (
+            len(trace_z) != len(circuit.current_path) + 1
+            or not compare_uni_out_trace(circuit.uni_a, trace_z[-1])
+        ):
             log.warning(f"Invalid trace from uni_z: {trace_z}")
-            circuits_checked[circuit_id] = False
-        for link, trace1, trace2 in zip(circuit_current_path,
+            return False
+
+        for link, trace1, trace2 in zip(circuit.current_path,
                                         trace_a[1:],
                                         trace_z[:0:-1]):
             metadata_vlan = None
@@ -1177,17 +1179,19 @@ class EVCDeploy(EVCBase):
                                         trace2
                                     ) is False:
                 log.warning(f"Invalid trace from uni_a: {trace_a}")
-                circuits_checked[circuit_id] = False
+                return False
             if compare_endpoint_trace(
                                         link.endpoint_b,
                                         metadata_vlan,
                                         trace1
                                     ) is False:
                 log.warning(f"Invalid trace from uni_z: {trace_z}")
-                circuits_checked[circuit_id] = False
+                return False
+
+        return True
 
     @staticmethod
-    # pylint: disable=too-many-locals
+    # py#####lint: disable=too-many-locals
     def check_list_traces(list_circuits):
         """Check if current_path is deployed comparing with SDN traces."""
         if not list_circuits:
@@ -1196,28 +1200,23 @@ class EVCDeploy(EVCBase):
         circuit_data = {}
         for circuit_id in list_circuits:
             circuit = list_circuits[circuit_id]
+            # if a inter-switch EVC does not have current_path, it does not
+            # make sense to run sdntrace on it
+            if not circuit.is_intra_switch() and not circuit.current_path:
+                continue
             uni_list.append(circuit.uni_a)
             uni_list.append(circuit.uni_z)
-            dpid_a = circuit.uni_a.interface.switch.dpid
-            port_a = circuit.uni_a.interface.port_number
-            interface_a = str(dpid_a) + ':' + str(port_a)
-            if circuit.uni_a.user_tag:
-                vlan_a = circuit.uni_a.user_tag.value
-                interface_a += ':' + str(vlan_a)
+            interface_a = uni_to_str(circuit.uni_a)
             circuit_data[interface_a] = {
                                             'circuit_id': circuit.id,
                                             'trace_name': 'trace_a'
                                         }
-            dpid_z = circuit.uni_z.interface.switch.dpid
-            port_z = circuit.uni_z.interface.port_number
-            interface_z = str(dpid_z) + ':' + str(port_z)
-            if circuit.uni_z.user_tag:
-                vlan_z = circuit.uni_z.user_tag.value
-                interface_z += ':' + str(vlan_z)
+            interface_z = uni_to_str(circuit.uni_z)
             circuit_data[interface_z] = {
                                             'circuit_id': circuit.id,
                                             'trace_name': 'trace_z'
                                         }
+
         traces = EVCDeploy.run_bulk_sdntraces(uni_list)
 
         circuit_by_traces = {}
@@ -1234,19 +1233,16 @@ class EVCDeploy(EVCBase):
                 circuit_id = circuit_from_data['circuit_id']
                 trace_name = circuit_from_data['trace_name']
                 circuit = list_circuits[circuit_id]
-                circuit_current_path = circuit.current_path.copy()
                 if circuit_id not in circuit_by_traces:
                     circuit_by_traces[circuit_id] = {}
                 circuit_by_traces[circuit_id][trace_name] = trace
 
                 if 'trace_a' in circuit_by_traces[circuit_id] \
                         and 'trace_z' in circuit_by_traces[circuit_id]:
-                    EVCDeploy.check_trace(
-                                            circuit_id,
-                                            circuit_current_path,
-                                            circuit_by_traces,
-                                            circuits_checked
-                                        )
+                    circuits_checked[circuit_id] = EVCDeploy.check_trace(
+                        circuit, circuit_by_traces
+                    )
+
         return circuits_checked
 
 

--- a/tests/unit/models/test_evc_base.py
+++ b/tests/unit/models/test_evc_base.py
@@ -403,3 +403,18 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         evc._id = evc_id
         # pylint: enable=protected-access
         assert EVC.get_id_from_cookie(evc.get_cookie()) == evc_id
+
+    def test_is_intra_switch(self):
+        """Test is_intra_switch method."""
+        attributes = {
+            "controller": get_controller_mock(),
+            "name": "circuit_name",
+            "enable": True,
+            "uni_a": get_uni_mocked(is_valid=True),
+            "uni_z": get_uni_mocked(is_valid=True)
+        }
+        evc = EVC(**attributes)
+        assert not evc.is_intra_switch()
+
+        evc.uni_a.interface.switch = evc.uni_z.interface.switch
+        assert evc.is_intra_switch()

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -433,49 +433,6 @@ class TestEVC(TestCase):
         return EVC(**attributes)
 
     @staticmethod
-    def create_evc_inter_switch_same_dpid():
-        """Create inter-switch EVC with two links in the path"""
-        uni_a = get_uni_mocked(
-            interface_port=2,
-            tag_value=82,
-            switch_id=1,
-            switch_dpid=1,
-            is_valid=True,
-        )
-        uni_z = get_uni_mocked(
-            interface_port=3,
-            tag_value=83,
-            switch_id=1,
-            switch_dpid=1,
-            is_valid=True,
-        )
-
-        attributes = {
-            "controller": get_controller_mock(),
-            "name": "custom_name",
-            "id": "1",
-            "uni_a": uni_a,
-            "uni_z": uni_z,
-            "primary_links": [
-                get_link_mocked(
-                    switch_a=Switch(1),
-                    switch_b=Switch(2),
-                    endpoint_a_port=9,
-                    endpoint_b_port=10,
-                    metadata={"s_vlan": 5},
-                ),
-                get_link_mocked(
-                    switch_a=Switch(2),
-                    switch_b=Switch(3),
-                    endpoint_a_port=11,
-                    endpoint_b_port=12,
-                    metadata={"s_vlan": 6},
-                ),
-            ],
-        }
-        return EVC(**attributes)
-
-    @staticmethod
     @patch("napps.kytos.mef_eline.models.evc.EVC._send_flow_mods")
     def test_install_nni_flows(send_flow_mods_mock):
         """Test install nni flows method.
@@ -1544,57 +1501,6 @@ class TestEVC(TestCase):
         trace_z[-1]["out"] = {"port": 2, "vlan": 99}
         result = EVCDeploy.check_list_traces({evc.id: evc})
         self.assertFalse(result[evc.id])
-
-    @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.run_bulk_sdntraces")
-    def test_check_list_traces_same_switch_unis(self, run_bulk_sdntraces_mock):
-        """Test check_list_traces method."""
-        evc = self.create_evc_inter_switch_same_dpid()
-
-        for link in evc.primary_links:
-            link.metadata['s_vlan'] = MagicMock(value=link.metadata['s_vlan'])
-        evc.current_path = evc.primary_links
-
-        trace_a = [
-            {"dpid": 1, "port": 2, "time": "t1", "type": "start", "vlan": 82},
-            {"dpid": 2, "port": 10, "time": "t2", "type": "trace", "vlan": 5},
-            {"dpid": 3, "port": 12, "time": "t3", "type": "trace", "vlan": 6},
-        ]
-        trace_z = [
-            {"dpid": 1, "port": 3, "time": "t1", "type": "start", "vlan": 83},
-            {"dpid": 2, "port": 11, "time": "t2", "type": "trace", "vlan": 6},
-            {"dpid": 1, "port": 9, "time": "t3", "type": "trace", "vlan": 5},
-        ]
-
-        run_bulk_sdntraces_mock.return_value = {
-                                                1: [trace_a, trace_z]
-                                            }
-        result = EVCDeploy.check_list_traces({evc.id: evc})
-        self.assertTrue(result[evc.id])
-
-    @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.run_bulk_sdntraces")
-    def test_check_list_traces_current_path_empty(self, bulk_sdntraces_mock):
-        """Test check_list_traces method."""
-        evc = self.create_evc_inter_switch_same_dpid()
-        for link in evc.primary_links:
-            link.metadata['s_vlan'] = MagicMock(value=link.metadata['s_vlan'])
-        evc.current_path = []
-
-        trace_a = [
-            {"dpid": 1, "port": 2, "time": "t1", "type": "start", "vlan": 82},
-            {"dpid": 2, "port": 10, "time": "t2", "type": "trace", "vlan": 5},
-            {"dpid": 3, "port": 12, "time": "t3", "type": "trace", "vlan": 6},
-        ]
-        trace_z = [
-            {"dpid": 1, "port": 3, "time": "t1", "type": "start", "vlan": 83},
-            {"dpid": 2, "port": 11, "time": "t2", "type": "trace", "vlan": 6},
-            {"dpid": 1, "port": 9, "time": "t3", "type": "trace", "vlan": 5},
-        ]
-
-        bulk_sdntraces_mock.return_value = {
-                                                1: [trace_a, trace_z]
-                                            }
-        result = EVCDeploy.check_list_traces({evc.id: evc})
-        self.assertEqual(len(result), 0)
 
     @patch(
         "napps.kytos.mef_eline.models.path.DynamicPathManager"

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -433,6 +433,49 @@ class TestEVC(TestCase):
         return EVC(**attributes)
 
     @staticmethod
+    def create_evc_inter_switch_same_dpid():
+        """Create inter-switch EVC with two links in the path"""
+        uni_a = get_uni_mocked(
+            interface_port=2,
+            tag_value=82,
+            switch_id=1,
+            switch_dpid=1,
+            is_valid=True,
+        )
+        uni_z = get_uni_mocked(
+            interface_port=3,
+            tag_value=83,
+            switch_id=1,
+            switch_dpid=1,
+            is_valid=True,
+        )
+
+        attributes = {
+            "controller": get_controller_mock(),
+            "name": "custom_name",
+            "id": "1",
+            "uni_a": uni_a,
+            "uni_z": uni_z,
+            "primary_links": [
+                get_link_mocked(
+                    switch_a=Switch(1),
+                    switch_b=Switch(2),
+                    endpoint_a_port=9,
+                    endpoint_b_port=10,
+                    metadata={"s_vlan": 5},
+                ),
+                get_link_mocked(
+                    switch_a=Switch(2),
+                    switch_b=Switch(3),
+                    endpoint_a_port=11,
+                    endpoint_b_port=12,
+                    metadata={"s_vlan": 6},
+                ),
+            ],
+        }
+        return EVC(**attributes)
+
+    @staticmethod
     @patch("napps.kytos.mef_eline.models.evc.EVC._send_flow_mods")
     def test_install_nni_flows(send_flow_mods_mock):
         """Test install nni flows method.
@@ -1408,7 +1451,7 @@ class TestEVC(TestCase):
         result = EVCDeploy.run_bulk_sdntraces([evc.uni_a])
         self.assertEqual(result, [])
 
-    @patch("napps.kytos.mef_eline.models.evc.log")
+    @patch("napps.kytos.mef_eline.models.evc.log.debug")
     @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.run_bulk_sdntraces")
     def test_check_list_traces(self, run_bulk_sdntraces_mock, _):
         """Test check_list_traces method."""
@@ -1445,7 +1488,7 @@ class TestEVC(TestCase):
         self.assertFalse(result[evc.id])
 
         # case3: fail incomplete trace from uni_z
-        run_bulk_sdntraces_mock.return_values = {
+        run_bulk_sdntraces_mock.return_value = {
                                                 1: [trace_a],
                                                 3: [trace_z[:2]]
         }
@@ -1455,7 +1498,7 @@ class TestEVC(TestCase):
         # case4: fail wrong vlan id in trace from uni_a
         trace_a[1]["vlan"] = 5
         trace_z[1]["vlan"] = 99
-        run_bulk_sdntraces_mock.return_values = {
+        run_bulk_sdntraces_mock.return_value = {
                                                 1: [trace_a],
                                                 3: [trace_z]
         }
@@ -1464,17 +1507,94 @@ class TestEVC(TestCase):
 
         # case5: fail wrong vlan id in trace from uni_z
         trace_a[1]["vlan"] = 99
-        run_bulk_sdntraces_mock.return_values = {
+        run_bulk_sdntraces_mock.return_value = {
                                                 1: [trace_a],
                                                 3: [trace_z]
         }
         result = EVCDeploy.check_list_traces({evc.id: evc})
         self.assertFalse(result[evc.id])
 
-        # case6: evc with empty current path
-        evc.current_path = []
+        # case6: success when no output in traces
+        trace_a[1]["vlan"] = 5
+        trace_z[1]["vlan"] = 6
         result = EVCDeploy.check_list_traces({evc.id: evc})
-        self.assertNotIn(evc.id, result)
+        self.assertTrue(result[evc.id])
+
+        # case7: fail when output is None in trace_a or trace_b
+        trace_a[-1]["out"] = None
+        result = EVCDeploy.check_list_traces({evc.id: evc})
+        self.assertFalse(result[evc.id])
+        trace_a[-1].pop("out", None)
+        trace_z[-1]["out"] = None
+        result = EVCDeploy.check_list_traces({evc.id: evc})
+        self.assertFalse(result[evc.id])
+
+        # case8: success when the output is correct on both uni
+        trace_a[-1]["out"] = {"port": 3, "vlan": 83}
+        trace_z[-1]["out"] = {"port": 2, "vlan": 82}
+        result = EVCDeploy.check_list_traces({evc.id: evc})
+        self.assertTrue(result[evc.id])
+
+        # case9: fail if any output is incorrect
+        trace_a[-1]["out"] = {"port": 3, "vlan": 99}
+        trace_z[-1]["out"] = {"port": 2, "vlan": 82}
+        result = EVCDeploy.check_list_traces({evc.id: evc})
+        self.assertFalse(result[evc.id])
+        trace_a[-1]["out"] = {"port": 3, "vlan": 83}
+        trace_z[-1]["out"] = {"port": 2, "vlan": 99}
+        result = EVCDeploy.check_list_traces({evc.id: evc})
+        self.assertFalse(result[evc.id])
+
+    @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.run_bulk_sdntraces")
+    def test_check_list_traces_same_switch_unis(self, run_bulk_sdntraces_mock):
+        """Test check_list_traces method."""
+        evc = self.create_evc_inter_switch_same_dpid()
+
+        for link in evc.primary_links:
+            link.metadata['s_vlan'] = MagicMock(value=link.metadata['s_vlan'])
+        evc.current_path = evc.primary_links
+
+        trace_a = [
+            {"dpid": 1, "port": 2, "time": "t1", "type": "start", "vlan": 82},
+            {"dpid": 2, "port": 10, "time": "t2", "type": "trace", "vlan": 5},
+            {"dpid": 3, "port": 12, "time": "t3", "type": "trace", "vlan": 6},
+        ]
+        trace_z = [
+            {"dpid": 1, "port": 3, "time": "t1", "type": "start", "vlan": 83},
+            {"dpid": 2, "port": 11, "time": "t2", "type": "trace", "vlan": 6},
+            {"dpid": 1, "port": 9, "time": "t3", "type": "trace", "vlan": 5},
+        ]
+
+        run_bulk_sdntraces_mock.return_value = {
+                                                1: [trace_a, trace_z]
+                                            }
+        result = EVCDeploy.check_list_traces({evc.id: evc})
+        self.assertTrue(result[evc.id])
+
+    @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.run_bulk_sdntraces")
+    def test_check_list_traces_current_path_empty(self, bulk_sdntraces_mock):
+        """Test check_list_traces method."""
+        evc = self.create_evc_inter_switch_same_dpid()
+        for link in evc.primary_links:
+            link.metadata['s_vlan'] = MagicMock(value=link.metadata['s_vlan'])
+        evc.current_path = []
+
+        trace_a = [
+            {"dpid": 1, "port": 2, "time": "t1", "type": "start", "vlan": 82},
+            {"dpid": 2, "port": 10, "time": "t2", "type": "trace", "vlan": 5},
+            {"dpid": 3, "port": 12, "time": "t3", "type": "trace", "vlan": 6},
+        ]
+        trace_z = [
+            {"dpid": 1, "port": 3, "time": "t1", "type": "start", "vlan": 83},
+            {"dpid": 2, "port": 11, "time": "t2", "type": "trace", "vlan": 6},
+            {"dpid": 1, "port": 9, "time": "t3", "type": "trace", "vlan": 5},
+        ]
+
+        bulk_sdntraces_mock.return_value = {
+                                                1: [trace_a, trace_z]
+                                            }
+        result = EVCDeploy.check_list_traces({evc.id: evc})
+        self.assertEqual(len(result), 0)
 
     @patch(
         "napps.kytos.mef_eline.models.path.DynamicPathManager"

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -1451,7 +1451,7 @@ class TestEVC(TestCase):
         result = EVCDeploy.run_bulk_sdntraces([evc.uni_a])
         self.assertEqual(result, [])
 
-    @patch("napps.kytos.mef_eline.models.evc.log.debug")
+    @patch("napps.kytos.mef_eline.models.evc.log")
     @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.run_bulk_sdntraces")
     def test_check_list_traces(self, run_bulk_sdntraces_mock, _):
         """Test check_list_traces method."""

--- a/utils.py
+++ b/utils.py
@@ -40,6 +40,30 @@ def compare_endpoint_trace(endpoint, vlan, trace):
     )
 
 
+def compare_uni_out_trace(uni, trace):
+    """Check if the trace last step (output) matches the UNI attributes."""
+    # keep compatibility for old versions of sdntrace-cp
+    if "out" not in trace:
+        return True
+    if not isinstance(trace["out"], dict):
+        return False
+    uni_vlan = uni.user_tag.value if uni.user_tag else None
+    return (
+        uni.interface.port_number == trace["out"].get("port")
+        and uni_vlan == trace["out"].get("vlan")
+    )
+
+
+def uni_to_str(uni):
+    """Create a string representation of the uni: intf_id:portno[:vlan]."""
+    dpid = uni.interface.switch.dpid
+    port = uni.interface.port_number
+    uni_str = str(dpid) + ':' + str(port)
+    if uni.user_tag:
+        uni_str += ':' + str(uni.user_tag.value)
+    return uni_str
+
+
 def load_spec():
     """Validate openapi spec."""
     napp_dir = Path(__file__).parent


### PR DESCRIPTION
Fixes #245 

### Description of the change

Leveraging the extra information provided by Sdntrace_cp from PR kytos-ng/sdntrace_cp#59, this PR adds an extra validation mechanism for intra-switch EVCs. The extra validation also helps some corner cases where the flows are inconsistent in the last hop of the forwarding process (e.g., due to an unexpected modification from other Napps or -- unlikely -- due to a flow removed).

The modifications provided by this PR are:
- Added a method to encapsulate the verification of intra-switch EVCs (`EVCBase.is_intra_switch()`) and code refactored leveraging the new method
- Refactored `EVCDeploy.check_trace()` to return a boolean to be consumed by its caller and update the list of EVCs to be checked (instead of updating the list directly)
- Added `utils.compare_uni_out_trace()` to compare the output information provided by sdntrace-cp (kytos-ng/sdntrace_cp#59) with the UNIs of an EVC and check if it is correct
- Enhanced `EVCDeploy.check_list_traces()` to avoid requesting a trace for an EVC which don't have current path (i.e., if the EVC don't have a current path, it should be redeployed)
- Code refactoring by adding `utils.uni_to_str()` to abstract the logic behind converting an UNI to string for indexing the traces


### Local tests

- No regression was observed from unit tests 
- No regression was observed from end-to-end tests
- Manually tested by creating intra-switch EVCs and simulating the behavior from Issue #245 showed the bug was no longer appearing: 
1. Create some intra-switch EVCs (I've also created one inter-switch just for comparison):
```
# curl -H 'Content-type: application/json' -X POST http://127.0.0.1:8181/api/kytos/mef_eline/v2/evc -d '{"name": "vlan 202", "dynamic_backup_path": true, "uni_a":{"interface_id":"00:00:00:00:00:00:00:12:51","tag":{"tag_type":1,"value":202}},"uni_z":{"interface_id":"00:00:00:00:00:00:00:11:50","tag":{"tag_type":1,"value":202}}}'
{"circuit_id":"435772b3ac3a4b"}
# for vlan in $(seq 400 410); do curl -H 'Content-type: application/json' -X POST http://127.0.0.1:8181/api/kytos/mef_eline/v2/evc -d '{"name": "vlan '$vlan'", "uni_a":{"interface_id":"00:00:00:00:00:00:00:12:51","tag":{"tag_type":1,"value":'$vlan'}},"uni_z":{"interface_id":"00:00:00:00:00:00:00:12:62","tag":{"tag_type":1,"value":'$vlan'}}}'; done
{"circuit_id":"da67a4524a6248"}
{"circuit_id":"b04e29f365e649"}
{"circuit_id":"558849c5b6f149"}
{"circuit_id":"381d4c86c59b41"}
{"circuit_id":"0f07c412e1a940"}
{"circuit_id":"6e5540a99abf48"}
{"circuit_id":"84778e83625840"}
{"circuit_id":"d303254711d24d"}
{"circuit_id":"477ef9ad86f94e"}
{"circuit_id":"ff748e1ec88f46"}
```
2. Make sure they are enable/active and functional:
```
# curl -s http://127.0.0.1:8181/api/kytos/mef_eline/v2/evc | jq -r '.[].active'
true
true
true
true
true
true
true
true
true
true
true
true

# ovs-ofctl dump-flows Ampath2| egrep -c "dl_vlan=4[0-9]{2}"
22
```
3. Restart Kytos
4. Wait for 5min 

Expected behavior: the intra-switch EVCs should be identified as operational and just the active status should be changed to True. (right after the Kytos restart, on the first execution of Mef_eline consistency check). The inter-switch EVC follow this approach (because the sdntrace works fine for inter-switch EVCs):
```
Jan 20 17:42:40 5003be03af14 kytos.napps.kytos/mef_eline:INFO main:104:  EVC(435772b3ac3a4b, vlan 202) enabled but inactive - activating
```

Actual behavior: after the 5min interval, the intra-switch EVCs will be redeployed:

```
Jan 20 17:47:40 5003be03af14 kytos.napps.kytos/mef_eline:INFO main:111:  EVC(b04e29f365e649, vlan 401) enabled but inactive - redeploy
Jan 20 17:47:40 5003be03af14 kytos.napps.kytos/mef_eline:INFO main:111:  EVC(da67a4524a6248, vlan 400) enabled but inactive - redeploy
Jan 20 17:47:41 5003be03af14 kytos.napps.kytos/mef_eline:INFO main:111:  EVC(0f07c412e1a940, vlan 404) enabled but inactive - redeploy
...
Jan 20 17:47:42 5003be03af14 kytos.napps.kytos/mef_eline:INFO main:111:  EVC(4a221692ef124a, vlan 410) enabled but inactive - redeploy
```

After applying this PR and executing the same process, the observed behavior was:

```
Jan 20 18:38:38 5003be03af14 kytos.napps.kytos/mef_eline:INFO main:104:  EVC(f753a7e6724b4e, vlan 202) enabled but inactive - activating
Jan 20 18:38:38 5003be03af14 kytos.napps.kytos/mef_eline:INFO main:104:  EVC(4b7317e129884d, vlan 401) enabled but inactive - activating
Jan 20 18:38:38 5003be03af14 kytos.napps.kytos/mef_eline:INFO main:104:  EVC(fac8634d03704e, vlan 400) enabled but inactive - activating
Jan 20 18:38:38 5003be03af14 kytos.napps.kytos/mef_eline:INFO main:104:  EVC(1ec0392d4e204e, vlan 404) enabled but inactive - activating
Jan 20 18:38:38 5003be03af14 kytos.napps.kytos/mef_eline:INFO main:104:  EVC(225cd8a2299441, vlan 405) enabled but inactive - activating
Jan 20 18:38:38 5003be03af14 kytos.napps.kytos/mef_eline:INFO main:104:  EVC(89c47d35d05844, vlan 407) enabled but inactive - activating
Jan 20 18:38:38 5003be03af14 kytos.napps.kytos/mef_eline:INFO main:104:  EVC(8a9e3ab2019b41, vlan 403) enabled but inactive - activating
Jan 20 18:38:38 5003be03af14 kytos.napps.kytos/mef_eline:INFO main:104:  EVC(997ba3197bba4e, vlan 402) enabled but inactive - activating
Jan 20 18:38:38 5003be03af14 kytos.napps.kytos/mef_eline:INFO main:104:  EVC(f33909099e614a, vlan 406) enabled but inactive - activating
Jan 20 18:38:38 5003be03af14 kytos.napps.kytos/mef_eline:INFO main:104:  EVC(659a04796ecc44, vlan 408) enabled but inactive - activating
Jan 20 18:38:38 5003be03af14 kytos.napps.kytos/mef_eline:INFO main:104:  EVC(d03f97170fa344, vlan 410) enabled but inactive - activating
Jan 20 18:38:38 5003be03af14 kytos.napps.kytos/mef_eline:INFO main:104:  EVC(d1080b48f63b4c, vlan 409) enabled but inactive - activating
```