### PR TITLE
Added UNIs to attributes_requiring_redeploy

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,11 +3,12 @@ Changelog
 #########
 All notable changes to the MEF_ELine NApp will be documented in this file.
 
-[Unreleased]
+[2022.3.1]
 ************
 
 Added
 =====
+- Added ``uni_a`` and ``uni_z`` to ``attributes_requiring_redeploy``
 
 Changed
 =======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 #########
 All notable changes to the MEF_ELine NApp will be documented in this file.
 
-[2022.3.1]
+[Unreleased]
 ************
 
 Added

--- a/models/evc.py
+++ b/models/evc.py
@@ -41,7 +41,9 @@ class EVCBase(GenericEntity):
         "queue_id",
         "sb_priority",
         "primary_constraints",
-        "secondary_constraints"
+        "secondary_constraints",
+        "uni_a",
+        "uni_z"
     ]
     required_attributes = ["name", "uni_a", "uni_z"]
 

--- a/models/evc.py
+++ b/models/evc.py
@@ -43,7 +43,7 @@ class EVCBase(GenericEntity):
         "primary_constraints",
         "secondary_constraints",
         "uni_a",
-        "uni_z"
+        "uni_z",
     ]
     required_attributes = ["name", "uni_a", "uni_z"]
 

--- a/tests/unit/models/test_evc_base.py
+++ b/tests/unit/models/test_evc_base.py
@@ -37,7 +37,9 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
             "queue_id",
             "sb_priority",
             "primary_constraints",
-            "secondary_constraints"
+            "secondary_constraints",
+            "uni_a",
+            "uni_z"
         ]
         assert EVC.attributes_requiring_redeploy == expected
 

--- a/tests/unit/models/test_evc_base.py
+++ b/tests/unit/models/test_evc_base.py
@@ -39,7 +39,7 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
             "primary_constraints",
             "secondary_constraints",
             "uni_a",
-            "uni_z"
+            "uni_z",
         ]
         assert EVC.attributes_requiring_redeploy == expected
 


### PR DESCRIPTION
Closes #249 

### Summary
Added `uni_a` and `uni_z` to `attributes_requiring_redeploy`

### Local Tests
Updated local test `test_expected_requiring_redeploy_attributes()` adding `uni_a` and `uni_z` to expected values.

### End-to-End Tests
e2e tests on PR [#201](https://github.com/kytos-ng/kytos-end-to-end-tests/pull/201)