### PR TITLE
Improved content on EVCs CRUD events

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 
 Added
 =====
+- Added more content keys ``evc_id, name, metadata, active, enabled, uni_a, uni_z`` to events from ``mef_eline``
 
 Changed
 =======

--- a/main.py
+++ b/main.py
@@ -235,7 +235,7 @@ class Main(KytosNApp):
         result = {"circuit_id": evc.id}
         status = 201
         log.debug("create_circuit result %s %s", result, status)
-        emit_event(self.controller, _name="created", **{
+        emit_event(self.controller, name="created", content={
             "id": evc.id,
             "name": evc.name,
             "metadata": evc.metadata,
@@ -314,7 +314,10 @@ class Main(KytosNApp):
         status = 200
 
         log.debug("update result %s %s", result, status)
-        emit_event(self.controller, "updated", evc_id=evc.id, data=data)
+        emit_event(self.controller, "updated", content={
+            "evc_id": evc.id,
+            "data": data
+        })
         return jsonify(result), status
 
     @rest("/v2/evc/<circuit_id>", methods=["DELETE"])
@@ -351,7 +354,9 @@ class Main(KytosNApp):
         status = 200
 
         log.debug("delete_circuit result %s %s", result, status)
-        emit_event(self.controller, "deleted", evc_id=evc.id)
+        emit_event(self.controller, "deleted", content={
+            "evc_id": evc.id
+        })
         return jsonify(result), status
 
     @rest("v2/evc/<circuit_id>/metadata", methods=["GET"])
@@ -691,9 +696,11 @@ class Main(KytosNApp):
                 emit_event(
                     self.controller,
                     context="kytos.flow_manager",
-                    _name="flows.install",
-                    dpid=dpid,
-                    flow_dict={"flows": switch_flows[dpid][:offset]},
+                    name="flows.install",
+                    content={
+                        "dpid": dpid,
+                        "flow_dict": {"flows": switch_flows[dpid][:offset]},
+                    }
                 )
                 if offset is None or offset >= len(switch_flows[dpid]):
                     del switch_flows[dpid]
@@ -707,7 +714,9 @@ class Main(KytosNApp):
                 evc.current_path = evc.failover_path
                 evc.failover_path = old_path
                 evc.sync()
-            emit_event(self.controller, "redeployed_link_down", evc_id=evc.id)
+            emit_event(self.controller, "redeployed_link_down", content={
+                "evc_id": evc.id
+            })
             log.info(
                 f"{evc} redeployed with failover due to link down {link.id}"
             )
@@ -716,8 +725,10 @@ class Main(KytosNApp):
             emit_event(
                 self.controller,
                 "evc_affected_by_link_down",
-                evc_id=evc.id,
-                link_id=link.id,
+                content={
+                    "evc_id": evc.id,
+                    "link_id": link.id,
+                }
             )
 
         # After handling the hot path, check if new failover paths are needed.
@@ -745,7 +756,9 @@ class Main(KytosNApp):
         if result:
             log.info(f"{evc} redeployed due to link down {link_id}")
             event_name = "redeployed_link_down"
-        emit_event(self.controller, event_name, evc_id=evc.id)
+        emit_event(self.controller, event_name, content={
+            "evc_id": evc.id
+        })
 
     @listen_to("kytos/mef_eline.(redeployed_link_(up|down)|deployed)")
     def on_evc_deployed(self, event):

--- a/main.py
+++ b/main.py
@@ -309,7 +309,7 @@ class Main(KytosNApp):
 
         log.debug("update result %s %s", result, status)
         emit_event(self.controller, "updated",
-                   content=map_evc_event_content(evc))
+                   content=map_evc_event_content(evc, **data))
         return jsonify(result), status
 
     @rest("/v2/evc/<circuit_id>", methods=["DELETE"])

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-# pylint: disable=protected-access
+# pylint: disable=protected-access, too-many-lines
 """Main module of kytos/mef_eline Kytos Network Application.
 
 NApp to provision circuits from user request.
@@ -236,13 +236,13 @@ class Main(KytosNApp):
         status = 201
         log.debug("create_circuit result %s %s", result, status)
         emit_event(self.controller, name="created", content={
-            "id": evc.id,
+            "evc.id": evc.id,
             "name": evc.name,
             "metadata": evc.metadata,
             "active": evc._active,
             "enabled": evc._enabled,
             "uni_a": evc.uni_a,
-            "uni_z": evc.uni_z
+            "uni_z": evc.uni_z,
         })
         return jsonify(result), status
 
@@ -315,8 +315,13 @@ class Main(KytosNApp):
 
         log.debug("update result %s %s", result, status)
         emit_event(self.controller, "updated", content={
-            "evc_id": evc.id,
-            "data": data
+            "evc.id": evc.id,
+            "name": evc.name,
+            "metadata": evc.metadata,
+            "active": evc._active,
+            "enabled": evc._enabled,
+            "uni_a": evc.uni_a,
+            "uni_z": evc.uni_z,
         })
         return jsonify(result), status
 
@@ -355,7 +360,13 @@ class Main(KytosNApp):
 
         log.debug("delete_circuit result %s %s", result, status)
         emit_event(self.controller, "deleted", content={
-            "evc_id": evc.id
+            "evc_id": evc.id,
+            "name": evc.name,
+            "metadata": evc.metadata,
+            "active": evc._active,
+            "enabled": evc._enabled,
+            "uni_a": evc.uni_a,
+            "uni_z": evc.uni_z,
         })
         return jsonify(result), status
 
@@ -715,7 +726,13 @@ class Main(KytosNApp):
                 evc.failover_path = old_path
                 evc.sync()
             emit_event(self.controller, "redeployed_link_down", content={
-                "evc_id": evc.id
+                "evc_id": evc.id,
+                "name": evc.name,
+                "metadata": evc.metadata,
+                "active": evc._active,
+                "enabled": evc._enabled,
+                "uni_a": evc.uni_a,
+                "uni_z": evc.uni_z,
             })
             log.info(
                 f"{evc} redeployed with failover due to link down {link.id}"
@@ -726,8 +743,14 @@ class Main(KytosNApp):
                 self.controller,
                 "evc_affected_by_link_down",
                 content={
-                    "evc_id": evc.id,
                     "link_id": link.id,
+                    "evc_id": evc.id,
+                    "name": evc.name,
+                    "metadata": evc.metadata,
+                    "active": evc._active,
+                    "enabled": evc._enabled,
+                    "uni_a": evc.uni_a,
+                    "uni_z": evc.uni_z,
                 }
             )
 
@@ -757,7 +780,13 @@ class Main(KytosNApp):
             log.info(f"{evc} redeployed due to link down {link_id}")
             event_name = "redeployed_link_down"
         emit_event(self.controller, event_name, content={
-            "evc_id": evc.id
+            "evc_id": evc.id,
+            "name": evc.name,
+            "metadata": evc.metadata,
+            "active": evc._active,
+            "enabled": evc._enabled,
+            "uni_a": evc.uni_a,
+            "uni_z": evc.uni_z,
         })
 
     @listen_to("kytos/mef_eline.(redeployed_link_(up|down)|deployed)")

--- a/models/evc.py
+++ b/models/evc.py
@@ -504,7 +504,13 @@ class EVCDeploy(EVCBase):
 
         if success:
             emit_event(self._controller, "deployed", content={
-                "evc_id": self.id
+                "evc_id": self.id,
+                "name": self.name,
+                "metadata": self.metadata,
+                "active": self._active,
+                "enabled": self._enabled,
+                "uni_a": self.uni_a.as_dict(),
+                "uni_z": self.uni_z.as_dict(),
             })
         return success
 
@@ -532,7 +538,13 @@ class EVCDeploy(EVCBase):
         self.disable()
         self.sync()
         emit_event(self._controller, "undeployed", content={
-            "evc_id": self.id
+            "evc_id": self.id,
+            "name": self.name,
+            "metadata": self.metadata,
+            "active": self._active,
+            "enabled": self._enabled,
+            "uni_a": self.uni_a.as_dict(),
+            "uni_z": self.uni_z.as_dict(),
         })
 
     def remove_failover_flows(self, exclude_uni_switches=True,
@@ -1320,7 +1332,13 @@ class LinkProtection(EVCDeploy):
 
         if success:
             emit_event(self._controller, "redeployed_link_up", content={
-                "evc_id": self.id
+                "evc_id": self.id,
+                "name": self.name,
+                "metadata": self.metadata,
+                "active": self._active,
+                "enabled": self._enabled,
+                "uni_a": self.uni_a.as_dict(),
+                "uni_z": self.uni_z.as_dict(),
             })
             return True
 

--- a/models/evc.py
+++ b/models/evc.py
@@ -17,6 +17,7 @@ from napps.kytos.mef_eline import controllers, settings
 from napps.kytos.mef_eline.exceptions import FlowModException, InvalidPath
 from napps.kytos.mef_eline.utils import (compare_endpoint_trace,
                                          compare_uni_out_trace, emit_event,
+                                         map_evc_event_content,
                                          notify_link_available_tags,
                                          uni_to_str)
 
@@ -503,15 +504,8 @@ class EVCDeploy(EVCBase):
             success = self.deploy_to_backup_path()
 
         if success:
-            emit_event(self._controller, "deployed", content={
-                "evc_id": self.id,
-                "name": self.name,
-                "metadata": self.metadata,
-                "active": self._active,
-                "enabled": self._enabled,
-                "uni_a": self.uni_a.as_dict(),
-                "uni_z": self.uni_z.as_dict(),
-            })
+            emit_event(self._controller, "deployed",
+                       content=map_evc_event_content(self))
         return success
 
     @staticmethod
@@ -537,15 +531,8 @@ class EVCDeploy(EVCBase):
         self.remove_failover_flows()
         self.disable()
         self.sync()
-        emit_event(self._controller, "undeployed", content={
-            "evc_id": self.id,
-            "name": self.name,
-            "metadata": self.metadata,
-            "active": self._active,
-            "enabled": self._enabled,
-            "uni_a": self.uni_a.as_dict(),
-            "uni_z": self.uni_z.as_dict(),
-        })
+        emit_event(self._controller, "undeployed",
+                   content=map_evc_event_content(self))
 
     def remove_failover_flows(self, exclude_uni_switches=True,
                               force=True, sync=True) -> None:
@@ -1331,15 +1318,8 @@ class LinkProtection(EVCDeploy):
             success = self.deploy_to_path()
 
         if success:
-            emit_event(self._controller, "redeployed_link_up", content={
-                "evc_id": self.id,
-                "name": self.name,
-                "metadata": self.metadata,
-                "active": self._active,
-                "enabled": self._enabled,
-                "uni_a": self.uni_a.as_dict(),
-                "uni_z": self.uni_z.as_dict(),
-            })
+            emit_event(self._controller, "redeployed_link_up",
+                       content=map_evc_event_content(self))
             return True
 
         return True

--- a/models/evc.py
+++ b/models/evc.py
@@ -503,7 +503,9 @@ class EVCDeploy(EVCBase):
             success = self.deploy_to_backup_path()
 
         if success:
-            emit_event(self._controller, "deployed", evc_id=self.id)
+            emit_event(self._controller, "deployed", content={
+                "evc_id": self.id
+            })
         return success
 
     @staticmethod
@@ -529,7 +531,9 @@ class EVCDeploy(EVCBase):
         self.remove_failover_flows()
         self.disable()
         self.sync()
-        emit_event(self._controller, "undeployed", evc_id=self.id)
+        emit_event(self._controller, "undeployed", content={
+            "evc_id": self.id
+        })
 
     def remove_failover_flows(self, exclude_uni_switches=True,
                               force=True, sync=True) -> None:
@@ -1315,7 +1319,9 @@ class LinkProtection(EVCDeploy):
             success = self.deploy_to_path()
 
         if success:
-            emit_event(self._controller, "redeployed_link_up", evc_id=self.id)
+            emit_event(self._controller, "redeployed_link_up", content={
+                "evc_id": self.id
+            })
             return True
 
         return True

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1860,9 +1860,10 @@ class TestMain(TestCase):
     @patch("napps.kytos.mef_eline.main.emit_event")
     def test_handle_link_down(self, emit_event_mock, settings_mock, _):
         """Test handle_link_down method."""
+        uni = create_autospec(UNI)
         evc1 = MagicMock(id="1", service_level=0, creation_time=1,
                          metadata="mock", _active="true", _enabled="true",
-                         uni_a="a_uni", uni_z="z_uni")
+                         uni_a=uni, uni_z=uni)
         evc1.name = "name"
         evc1.is_affected_by_link.return_value = True
         evc1.handle_link_down.return_value = True
@@ -1871,14 +1872,14 @@ class TestMain(TestCase):
         evc2.is_affected_by_link.return_value = False
         evc3 = MagicMock(id="3", service_level=5, creation_time=1,
                          metadata="mock", _active="true", _enabled="true",
-                         uni_a="a_uni", uni_z="z_uni")
+                         uni_a=uni, uni_z=uni)
         evc3.name = "name"
         evc3.is_affected_by_link.return_value = True
         evc3.handle_link_down.return_value = True
         evc3.failover_path = None
         evc4 = MagicMock(id="4", service_level=4, creation_time=1,
                          metadata="mock", _active="true", _enabled="true",
-                         uni_a="a_uni", uni_z="z_uni")
+                         uni_a=uni, uni_z=uni)
         evc4.name = "name"
         evc4.is_affected_by_link.return_value = True
         evc4.is_failover_path_affected_by_link.return_value = False
@@ -1962,8 +1963,8 @@ class TestMain(TestCase):
                 "metadata": "mock",
                 "active": "true",
                 "enabled": "true",
-                "uni_a": "a_uni",
-                "uni_z": "z_uni",
+                "uni_a": uni.as_dict(),
+                "uni_z": uni.as_dict(),
             }),
             call(self.napp.controller, event_name, content={
                 "link_id": "123",
@@ -1972,8 +1973,8 @@ class TestMain(TestCase):
                 "metadata": "mock",
                 "active": "true",
                 "enabled": "true",
-                "uni_a": "a_uni",
-                "uni_z": "z_uni",
+                "uni_a": uni.as_dict(),
+                "uni_z": uni.as_dict(),
             }),
         ])
         evc4.sync.assert_called_once()
@@ -1985,21 +1986,22 @@ class TestMain(TestCase):
                 "metadata": "mock",
                 "active": "true",
                 "enabled": "true",
-                "uni_a": "a_uni",
-                "uni_z": "z_uni",
+                "uni_a": uni.as_dict(),
+                "uni_z": uni.as_dict(),
             }),
         ])
 
     @patch("napps.kytos.mef_eline.main.emit_event")
     def test_handle_evc_affected_by_link_down(self, emit_event_mock):
         """Test handle_evc_affected_by_link_down method."""
+        uni = create_autospec(UNI)
         evc1 = MagicMock(
             id="1",
             metadata="data_mocked",
             _active="true",
             _enabled="false",
-            uni_a="uni_amocked",
-            uni_z="uni_mockedz",
+            uni_a=uni,
+            uni_z=uni,
         )
         evc1.name = "name_mocked"
         evc1.handle_link_down.return_value = True
@@ -2008,8 +2010,8 @@ class TestMain(TestCase):
             metadata="mocked_data",
             _active="false",
             _enabled="true",
-            uni_a="uni_amocked",
-            uni_z="uni_mockedz",
+            uni_a=uni,
+            uni_z=uni,
         )
         evc2.name = "mocked_name"
         evc2.handle_link_down.return_value = False
@@ -2030,8 +2032,8 @@ class TestMain(TestCase):
                 "metadata": "data_mocked",
                 "active": "true",
                 "enabled": "false",
-                "uni_a": "uni_amocked",
-                "uni_z": "uni_mockedz",
+                "uni_a": uni.as_dict(),
+                "uni_z": uni.as_dict(),
             }
         )
 
@@ -2044,8 +2046,8 @@ class TestMain(TestCase):
                 "metadata": "mocked_data",
                 "active": "false",
                 "enabled": "true",
-                "uni_a": "uni_amocked",
-                "uni_z": "uni_mockedz",
+                "uni_a": uni.as_dict(),
+                "uni_z": uni.as_dict(),
             }
         )
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1899,50 +1899,68 @@ class TestMain(TestCase):
             call(
                 self.napp.controller,
                 context="kytos.flow_manager",
-                _name="flows.install",
-                dpid="4",
-                flow_dict={"flows": ["flow7", "flow8"]},
+                name="flows.install",
+                content={
+                    "dpid": "4",
+                    "flow_dict": {"flows": ["flow7", "flow8"]},
+                }
             ),
             call(
                 self.napp.controller,
                 context="kytos.flow_manager",
-                _name="flows.install",
-                dpid="5",
-                flow_dict={"flows": ["flow9", "flow10"]},
+                name="flows.install",
+                content={
+                    "dpid": "5",
+                    "flow_dict": {"flows": ["flow9", "flow10"]},
+                }
             ),
             call(
                 self.napp.controller,
                 context="kytos.flow_manager",
-                _name="flows.install",
-                dpid="2",
-                flow_dict={"flows": ["flow1", "flow2"]},
+                name="flows.install",
+                content={
+                    "dpid": "2",
+                    "flow_dict": {"flows": ["flow1", "flow2"]},
+                }
             ),
             call(
                 self.napp.controller,
                 context="kytos.flow_manager",
-                _name="flows.install",
-                dpid="3",
-                flow_dict={"flows": ["flow3", "flow4"]},
+                name="flows.install",
+                content={
+                    "dpid": "3",
+                    "flow_dict": {"flows": ["flow3", "flow4"]},
+                }
             ),
             call(
                 self.napp.controller,
                 context="kytos.flow_manager",
-                _name="flows.install",
-                dpid="3",
-                flow_dict={"flows": ["flow5", "flow6"]},
+                name="flows.install",
+                content={
+                    "dpid": "3",
+                    "flow_dict": {"flows": ["flow5", "flow6"]},
+                }
             ),
         ])
         event_name = "evc_affected_by_link_down"
         assert evc3.service_level > evc1.service_level
         # evc3 should be handled before evc1
         emit_event_mock.assert_has_calls([
-            call(self.napp.controller, event_name, evc_id="3", link_id="123"),
-            call(self.napp.controller, event_name, evc_id="1", link_id="123"),
+            call(self.napp.controller, event_name, content={
+                "evc_id": "3",
+                "link_id": "123"
+            }),
+            call(self.napp.controller, event_name, content={
+                "evc_id": "1",
+                "link_id": "123"
+            }),
         ])
         evc4.sync.assert_called_once()
         event_name = "redeployed_link_down"
         emit_event_mock.assert_has_calls([
-            call(self.napp.controller, event_name, evc_id="4"),
+            call(self.napp.controller, event_name, content={
+                "evc_id": "4"
+            }),
         ])
 
     @patch("napps.kytos.mef_eline.main.emit_event")
@@ -1961,13 +1979,17 @@ class TestMain(TestCase):
         event.content["evc_id"] = "1"
         self.napp.handle_evc_affected_by_link_down(event)
         emit_event_mock.assert_called_with(
-            self.napp.controller, "redeployed_link_down", evc_id="1"
+            self.napp.controller, "redeployed_link_down", content={
+                "evc_id": "1"
+            }
         )
 
         event.content["evc_id"] = "2"
         self.napp.handle_evc_affected_by_link_down(event)
         emit_event_mock.assert_called_with(
-            self.napp.controller, "error_redeploy_link_down", evc_id="2"
+            self.napp.controller, "error_redeploy_link_down", content={
+                "evc_id": "2"
+            }
         )
 
     def test_handle_evc_deployed(self):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1860,17 +1860,26 @@ class TestMain(TestCase):
     @patch("napps.kytos.mef_eline.main.emit_event")
     def test_handle_link_down(self, emit_event_mock, settings_mock, _):
         """Test handle_link_down method."""
-        evc1 = MagicMock(id="1", service_level=0, creation_time=1)
+        evc1 = MagicMock(id="1", service_level=0, creation_time=1,
+                         metadata="mock", _active="true", _enabled="true",
+                         uni_a="a_uni", uni_z="z_uni")
+        evc1.name = "name"
         evc1.is_affected_by_link.return_value = True
         evc1.handle_link_down.return_value = True
         evc1.failover_path = None
         evc2 = MagicMock(id="2", service_level=6, creation_time=1)
         evc2.is_affected_by_link.return_value = False
-        evc3 = MagicMock(id="3", service_level=5, creation_time=1)
+        evc3 = MagicMock(id="3", service_level=5, creation_time=1,
+                         metadata="mock", _active="true", _enabled="true",
+                         uni_a="a_uni", uni_z="z_uni")
+        evc3.name = "name"
         evc3.is_affected_by_link.return_value = True
         evc3.handle_link_down.return_value = True
         evc3.failover_path = None
-        evc4 = MagicMock(id="4", service_level=4, creation_time=1)
+        evc4 = MagicMock(id="4", service_level=4, creation_time=1,
+                         metadata="mock", _active="true", _enabled="true",
+                         uni_a="a_uni", uni_z="z_uni")
+        evc4.name = "name"
         evc4.is_affected_by_link.return_value = True
         evc4.is_failover_path_affected_by_link.return_value = False
         evc4.failover_path = ["2"]
@@ -1947,40 +1956,82 @@ class TestMain(TestCase):
         # evc3 should be handled before evc1
         emit_event_mock.assert_has_calls([
             call(self.napp.controller, event_name, content={
+                "link_id": "123",
                 "evc_id": "3",
-                "link_id": "123"
+                "name": "name",
+                "metadata": "mock",
+                "active": "true",
+                "enabled": "true",
+                "uni_a": "a_uni",
+                "uni_z": "z_uni",
             }),
             call(self.napp.controller, event_name, content={
+                "link_id": "123",
                 "evc_id": "1",
-                "link_id": "123"
+                "name": "name",
+                "metadata": "mock",
+                "active": "true",
+                "enabled": "true",
+                "uni_a": "a_uni",
+                "uni_z": "z_uni",
             }),
         ])
         evc4.sync.assert_called_once()
         event_name = "redeployed_link_down"
         emit_event_mock.assert_has_calls([
             call(self.napp.controller, event_name, content={
-                "evc_id": "4"
+                "evc_id": "4",
+                "name": "name",
+                "metadata": "mock",
+                "active": "true",
+                "enabled": "true",
+                "uni_a": "a_uni",
+                "uni_z": "z_uni",
             }),
         ])
 
     @patch("napps.kytos.mef_eline.main.emit_event")
     def test_handle_evc_affected_by_link_down(self, emit_event_mock):
         """Test handle_evc_affected_by_link_down method."""
-        evc1 = MagicMock(id="1")
+        evc1 = MagicMock(
+            id="1",
+            metadata="data_mocked",
+            _active="true",
+            _enabled="false",
+            uni_a="uni_amocked",
+            uni_z="uni_mockedz",
+        )
+        evc1.name = "name_mocked"
         evc1.handle_link_down.return_value = True
-        evc2 = MagicMock(id="2")
+        evc2 = MagicMock(
+            id="2",
+            metadata="mocked_data",
+            _active="false",
+            _enabled="true",
+            uni_a="uni_amocked",
+            uni_z="uni_mockedz",
+        )
+        evc2.name = "mocked_name"
         evc2.handle_link_down.return_value = False
         self.napp.circuits = {"1": evc1, "2": evc2}
 
-        event = KytosEvent(name="e1", content={"evc_id": "3", "link_id": "1"})
+        event = KytosEvent(name="e1", content={
+            "evc_id": "3",
+            "link_id": "1",
+        })
         self.napp.handle_evc_affected_by_link_down(event)
         emit_event_mock.assert_not_called()
-
         event.content["evc_id"] = "1"
         self.napp.handle_evc_affected_by_link_down(event)
         emit_event_mock.assert_called_with(
             self.napp.controller, "redeployed_link_down", content={
-                "evc_id": "1"
+                "evc_id": "1",
+                "name": "name_mocked",
+                "metadata": "data_mocked",
+                "active": "true",
+                "enabled": "false",
+                "uni_a": "uni_amocked",
+                "uni_z": "uni_mockedz",
             }
         )
 
@@ -1988,7 +2039,13 @@ class TestMain(TestCase):
         self.napp.handle_evc_affected_by_link_down(event)
         emit_event_mock.assert_called_with(
             self.napp.controller, "error_redeploy_link_down", content={
-                "evc_id": "2"
+                "evc_id": "2",
+                "name": "mocked_name",
+                "metadata": "mocked_data",
+                "active": "false",
+                "enabled": "true",
+                "uni_a": "uni_amocked",
+                "uni_z": "uni_mockedz",
             }
         )
 

--- a/utils.py
+++ b/utils.py
@@ -14,6 +14,17 @@ from kytos.core import log
 from kytos.core.events import KytosEvent
 
 
+def map_evc_event_content(evc):
+    """Returns a set of values from evc to be used for content"""
+    return {"evc_id": evc.id,
+            "name": evc.name,
+            "metadata": evc.metadata,
+            "active": evc._active,
+            "enabled": evc._enabled,
+            "uni_a": evc.uni_a.as_dict(),
+            "uni_z": evc.uni_z.as_dict()}
+
+
 def emit_event(controller, name, context="kytos/mef_eline", content=None):
     """Send an event when something happens with an EVC."""
     event_name = f"{context}.{name}"

--- a/utils.py
+++ b/utils.py
@@ -14,9 +14,9 @@ from kytos.core import log
 from kytos.core.events import KytosEvent
 
 
-def map_evc_event_content(evc):
+def map_evc_event_content(evc, **kwargs):
     """Returns a set of values from evc to be used for content"""
-    return {"evc_id": evc.id,
+    return kwargs | {"evc_id": evc.id,
             "name": evc.name,
             "metadata": evc.metadata,
             "active": evc._active,

--- a/utils.py
+++ b/utils.py
@@ -17,12 +17,12 @@ from kytos.core.events import KytosEvent
 def map_evc_event_content(evc, **kwargs):
     """Returns a set of values from evc to be used for content"""
     return kwargs | {"evc_id": evc.id,
-            "name": evc.name,
-            "metadata": evc.metadata,
-            "active": evc._active,
-            "enabled": evc._enabled,
-            "uni_a": evc.uni_a.as_dict(),
-            "uni_z": evc.uni_z.as_dict()}
+                     "name": evc.name,
+                     "metadata": evc.metadata,
+                     "active": evc._active,
+                     "enabled": evc._enabled,
+                     "uni_a": evc.uni_a.as_dict(),
+                     "uni_z": evc.uni_z.as_dict()}
 
 
 def emit_event(controller, name, context="kytos/mef_eline", content=None):

--- a/utils.py
+++ b/utils.py
@@ -14,16 +14,19 @@ from kytos.core import log
 from kytos.core.events import KytosEvent
 
 
-def emit_event(controller, _name, context="kytos/mef_eline", **kwargs):
+def emit_event(controller, name, context="kytos/mef_eline", content=None):
     """Send an event when something happens with an EVC."""
-    event_name = f"{context}.{_name}"
-    event = KytosEvent(name=event_name, content=kwargs)
+    event_name = f"{context}.{name}"
+    event = KytosEvent(name=event_name, content=content)
     controller.buffers.app.put(event)
 
 
 def notify_link_available_tags(controller, link, src_func=None):
     """Notify link available tags."""
-    emit_event(controller, "link_available_tags", link=link, src_func=src_func)
+    emit_event(controller, "link_available_tags", content={
+        "link": link,
+        "src_func": src_func
+    })
 
 
 def compare_endpoint_trace(endpoint, vlan, trace):


### PR DESCRIPTION
Closes #223 

### Summary
Added these keys to the content to these events:
- Keys: `{"evc_id", "name", "metadata", "active", "enabled", "uni_a", "uni_z"}`
- Events: 
```
kytos/mef_eline.updated
kytos/mef_eline.deleted
kytos/mef_eline.(redeployed_link_(up|down)|deployed)
```
On commit [97ca90fc35edcbbbad3e6848f4e943073246eab8](https://github.com/kytos-ng/mef_eline/pull/257/commits/97ca90fc35edcbbbad3e6848f4e943073246eab8)

### Local Tests
Added the line `print("CONTENT -> ", content)` inside `emit_event()`, here are the results for every event:
- kytos/mef_eline.created
```
2023-02-03 13:00:07,755 - WARNING [kytos.napps.kytos/mef_eline] (thread_pool_app_6) Failover path for EVC(0a7faf5523ee4d, some) was not deployed: No available path was found                             
CONTENT ->  {'evc_id': '0a7faf5523ee4d', 'name': 'some', 'metadata': {}, 'active': True, 'enabled': True, 'uni_a': {'interface_id': '00:00:00:00:00:00:00:01:1', 'tag': {'tag_type': <TAGType.VLAN: 1>, 'value': 100}}, 'uni_z': {'interface_id': '00:00:00:00:00:00:00:03:1', 'tag': {'tag_type': <TAGType.VLAN: 1>, 'value': 100}}}
```
- kytos/mef_eline.updated
```
CONTENT ->  {'evc_id': '0a7faf5523ee4d', 'name': 'name_changed', 'metadata': {}, 'active': True, 'enabled': True, 'uni_a': {'interface_id': '00:00:00:00:00:00:00:01:1', 'tag': {'tag_type': <TAGType.VLAN: 1>, 'value': 100}}, 'uni_z': {'interface_id': '00:00:00:00:00:00:00:03:1', 'tag': {'tag_type': <TAGType.VLAN: 1>, 'value': 100}}}
```
- kytos/mef_eline.deleted
```
2023-02-03 12:08:45,833 - INFO [kytos.napps.kytos/mef_eline] (Thread-81) EVC removed. EVC(ef60c316921b4c, some)
CONTENT ->  {'evc_id': 'ef60c316921b4c', 'name': 'some', 'metadata': {}, 'active': False, 'enabled': False, 'uni_a': {'interface_id': '00:00:00:00:00:00:00:01:1', 'tag': {'tag_type': <TAGType.VLAN: 1>, 'value': 100}}, 'uni_z': {'interface_id': '00:00:00:00:00:00:00:03:1', 'tag': {'tag_type': <TAGType.VLAN: 1>, 'value': 100}}}
```

- kytos/mef_eline.(redeployed_link_(up|down)|deployed)
```
2023-02-03 13:07:37,694 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_4) Event handle_link_down Link(Interface('s1-eth2', 2, Switch('00:00:00:00:00:00:00:01')), Interface('s2-eth2', 2, Switch('00:00:00:00:00:00:00:02')))
CONTENT ->  {'link_id': 'cf0f4071be426b3f745027f5d22bc61f8312ae86293c9b28e7e66015607a9260', 'evc_id': '0a7faf5523ee4d', 'name': 'name_changed', 'metadata': {}, 'active': True, 'enabled': True, 'uni_a': {'interface_id': '00:00:00:00:00:00:00:01:1', 'tag': {'tag_type': <TAGType.VLAN: 1>, 'value': 100}}, 'uni_z': {'interface_id': '00:00:00:00:00:00:00:03:1', 'tag': {'tag_type': <TAGType.VLAN: 1>, 'value': 100}}}
```
Modified tests to suit new keys to the contents of events
