### PR TITLE
fix: solves typo in minimum_flexible_hits attribute name

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,13 +20,6 @@ Removed
 
 Fixed
 =====
-
-
-[2022.3.1] - 2023-012-13
-***********************
-
-Fixed
-=====
 - fixed ``minimum_flexible_hits`` EVC attribute to be persistent
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,14 @@ Fixed
 =====
 
 
+[2022.3.1] - 2023-012-13
+***********************
+
+Fixed
+=====
+- fixed ``minimum_flexible_hits`` EVC attribute to be persistent
+
+
 [2022.3.0] - 2023-01-23
 ***********************
 

--- a/db/models.py
+++ b/db/models.py
@@ -63,7 +63,7 @@ class PathConstraints(BaseModel):
     spf_max_path_cost: Optional[float]
     mandatory_metrics: Optional[LinkConstraints]
     flexible_metrics: Optional[LinkConstraints]
-    minimul_flexible_hits: Optional[int]
+    minimum_flexible_hits: Optional[int]
     desired_links: Optional[List[str]]
     undesired_links: Optional[List[str]]
 


### PR DESCRIPTION
Closes #265 

### Summary

This PR fixes a minor typo in the persistence of the `minimum_flexible_hits` path constraints doc. The attribute was not persistent due to the incorrect name.

### Local Tests

After testing mef_eline with the proposed change, the attribute gets persistent. The behavior observed in the Issue #265 is no longer observed:

```
# curl -H 'Content-type: application/json' -X POST  http://127.0.0.1:8181/api/kytos/mef_eline/v2/evc -d '{"name":"test 306", "dynamic_backup_path":true, "uni_a":{"interface_id":"00:00:00:00:00:00:00:16:55","tag":{"tag_type":1,"value":306}},"uni_z":{"interface_id":"00:00:00:00:00:00:00:21:60","tag":{"tag_type":1,"value":306}},"primary_constraints":{"undesired_links":["f84da0639233fe9d44614e6060abfa41d997b28d9ad729e8882ba4ddc02c29ed"],"minimum_flexible_hits":2, "flexible_metrics":{"bandwidth":100,"utilization":0,"priority":10,"delay":10}}, "secondary_constraints":{"undesired_links":["f84da0639233fe9d44614e6060abfa41d997b28d9ad729e8882ba4ddc02c29ed"]}}'
{"circuit_id":"16ca6e281ddf48"}

# curl -s http://127.0.0.1:8181/api/kytos/mef_eline/v2/evc/16ca6e281ddf48 | jq -r '.primary_constraints'
{
  "flexible_metrics": {
    "bandwidth": 100,
    "delay": 10,
    "priority": 10,
    "utilization": 0
  },
  "minimum_flexible_hits": 2,
  "spf_attribute": "hop",
  "undesired_links": [
    "f84da0639233fe9d44614e6060abfa41d997b28d9ad729e8882ba4ddc02c29ed"
  ]
}
```

### End-to-End Tests

Not necessary.