### PR TITLE
fix: solves typo in minimum_flexible_hits attribute name - for 2022.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,14 @@ Fixed
 =====
 
 
+[2022.3.1] - 2023-02-14
+***********************
+
+Fixed
+=====
+- fixed ``minimum_flexible_hits`` EVC attribute to be persistent
+
+
 [2022.3.0] - 2023-01-23
 ***********************
 

--- a/db/models.py
+++ b/db/models.py
@@ -63,7 +63,7 @@ class PathConstraints(BaseModel):
     spf_max_path_cost: Optional[float]
     mandatory_metrics: Optional[LinkConstraints]
     flexible_metrics: Optional[LinkConstraints]
-    minimul_flexible_hits: Optional[int]
+    minimum_flexible_hits: Optional[int]
     desired_links: Optional[List[str]]
     undesired_links: Optional[List[str]]
 


### PR DESCRIPTION
Related to PR #267 and Issue #265 

### Summary

This PR is similar to #267. The only difference is that it is backported to `2022.3`.

### Local Tests

Same local tests as documented in PR #267

### End-to-End Tests

N/A