### PR TITLE
fix: update path constraint attribute list to add reliability attribute - backport to 2022.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Fixed
 Fixed
 =====
 - fixed ``minimum_flexible_hits`` EVC attribute to be persistent
+- fixed attribute list for path constraints to include ``reliability``
 
 
 [2022.3.0] - 2023-01-23

--- a/ui/k-info-panel/show_circuit.kytos
+++ b/ui/k-info-panel/show_circuit.kytos
@@ -656,12 +656,14 @@ module.exports = {
         'mandatory_metrics.utilization': 'Utilization',
         'mandatory_metrics.priority': 'Priority',
         'mandatory_metrics.delay': 'Delay',
+        'mandatory_metrics.reliability': 'Reliability',
         'mandatory_metrics.ownership': 'Ownership',
         'flexible_metrics': 'Flexible metrics',
         'flexible_metrics.bandwidth': 'Bandwidth',
         'flexible_metrics.utilization': 'Utilization',
         'flexible_metrics.priority': 'Priority',
         'flexible_metrics.delay': 'Delay',
+        'flexible_metrics.reliability': 'Reliability',
         'flexible_metrics.ownership': 'Ownership',
       };
 
@@ -681,12 +683,13 @@ module.exports = {
             'utilization': data['mandatory_metrics']['utilization'],
             'priority': data['mandatory_metrics']['priority'],
             'delay': data['mandatory_metrics']['delay'],
+            'reliability': data['mandatory_metrics']['reliability'],
             'ownership': data['mandatory_metrics']['ownership']
           };
         } else {
           _constraint.mandatory_metrics = {
             'bandwidth': '', 'utilization': '', 'priority': '',
-            'delay': '', 'ownership': '',
+            'delay': '', 'reliability': '', 'ownership': '',
           };
         } 
         if(data['flexible_metrics']) {
@@ -695,12 +698,13 @@ module.exports = {
             'utilization': data['flexible_metrics']['utilization'],
             'priority': data['flexible_metrics']['priority'],
             'delay': data['flexible_metrics']['delay'],
+            'reliability': data['flexible_metrics']['reliability'],
             'ownership': data['flexible_metrics']['ownership']
           };
         } else {
           _constraint.flexible_metrics = {
             'bandwidth': '', 'utilization': '', 'priority': '',
-            'delay': '', 'ownership': '',
+            'delay': '', 'reliability': '', 'ownership': '',
           };
         }
 
@@ -808,7 +812,7 @@ module.exports = {
           if(this.constraints[_type][_metric_type]) {
             let metric = this.constraints[_type][_metric_type];
             let _mandatory_metrics = {};
-            ['bandwidth', 'utilization', 'priority', 'delay'].forEach(_m => {
+            ['bandwidth', 'utilization', 'priority', 'delay', 'reliability'].forEach(_m => {
               if(metric[_m] !== undefined && metric[_m] !== '') {
                 _mandatory_metrics[_m] = parseInt(metric[_m]);
               } else {
@@ -880,6 +884,7 @@ module.exports = {
             'utilization': '',
             'priority': '',
             'delay': '',
+            'reliability': '',
             'ownership': ''
           },
           'flexible_metrics': {
@@ -887,6 +892,7 @@ module.exports = {
             'utilization': '',
             'priority': '',
             'delay': '',
+            'reliability': '',
             'ownership': ''
           }
         };

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -162,6 +162,17 @@
 
                 <div class="metric">
                   <div class="metric-dropdown">
+                    <k-dropdown :options="metric_options"
+                    :title="constraint_titles['reliability']"
+                    :value.sync="is_flexible[constraint].reliability"></k-dropdown>
+                  </div>
+                  <div class="metric-field">
+                    <k-input icon="arrow-right" :action="function(val) {metrics[constraint].reliability = parseInt(val)}"></k-input>
+                  </div>
+                </div>
+
+                <div class="metric">
+                  <div class="metric-dropdown">
                     <k-dropdown :options="metric_options" 
                     :title="constraint_titles['ownership']"
                     :value.sync="is_flexible[constraint].ownership"></k-dropdown>
@@ -295,6 +306,7 @@ module.exports = {
         'utilization': 'Utilization',
         'priority': 'Priority',
         'delay': 'Delay',
+        'reliability': 'Reliability',
         'ownership': 'Ownership',
       };
 
@@ -309,12 +321,12 @@ module.exports = {
 
       _constraint.mandatory_metrics = {
         'bandwidth': '', 'utilization': '', 'priority': '',
-        'delay': '', 'ownership': '',
+        'delay': '', 'reliability': '', 'ownership': '',
       };
     
       _constraint.flexible_metrics = {
         'bandwidth': '', 'utilization': '', 'priority': '',
-        'delay': '', 'ownership': '',
+        'delay': '', 'reliability': '', 'ownership': '',
       };
 
       this.constraint = {
@@ -412,7 +424,7 @@ module.exports = {
           request[_type].mandatory_metrics = {};
 
           // mandatory and flexible metrics
-          ['bandwidth', 'utilization', 'priority', 'delay', 'ownership'].forEach(_m => {
+          ['bandwidth', 'utilization', 'priority', 'delay', 'reliability', 'ownership'].forEach(_m => {
             if (_this.is_flexible[_type][_m]) {
               request[_type].flexible_metrics[_m] = _this.metrics[_type][_m];
             } else {


### PR DESCRIPTION
Related to PR #268 and Issue #264 

### Summary

This PR is similar to #268. The only difference is that it is backported to `2022.3`.

### Local Tests

Same local tests as documented in PR #268

### End-to-End Tests

N/A