### PR TITLE
fix: ui initial fix to reset SPF related constraints attrs - backport to 2022.3

### DIFF
--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -102,8 +102,8 @@
                   <div class="metric-field">
                     <label class="metric-label">{{constraint_titles['spf_max_path_cost']}}</label> 
                     <k-input 
-                    title="Southbound priority:"
-                    :action="function(val) {form_constraints[constraint].spf_max_path_cost = parseInt(val)}"></k-input>
+                    :title="constraint_titles['spf_max_path_cost']"
+                    :value.sync="form_constraints[constraint].spf_max_path_cost"></k-input>
                   </div>
                 </div>
 
@@ -112,7 +112,7 @@
                     <label class="metric-label">{{constraint_titles['minimum_flexible_hits']}}</label> 
                     <k-input 
                     :title="constraint_titles['minimum_flexible_hits']"
-                    :action="function(val) {form_constraints[constraint].minimum_flexible_hits = parseInt(val)}"></k-input>
+                    :value.sync="form_constraints[constraint].minimum_flexible_hits"></k-input>
                   </div>
                 </div>
 
@@ -369,6 +369,10 @@ module.exports = {
         this.service_level = "";
         this.sb_priority = "";
         this.queue_id = "";
+        for (const constraint of ["primary_constraints", "secondary_constraints"]) {
+          this.form_constraints[constraint]["spf_max_path_cost"] = null;
+          this.form_constraints[constraint]["minimum_flexible_hits"] = null;
+        }
     },
     post_success(data) {
         let notification = {


### PR DESCRIPTION
Closes #263 (this PR is still in progress and draft more information below) 

### Summary

- ui initial fix to reset SPF related constraints attrs

It turns out that it wasn't trivial to clear or reset the SPF related constraints, I tried to also reuse this func `init_path_constraints()`, but ended up hitting other unwanted side effects, then I also realized that some reactive variables weren't being bind with `.sync` (similar to `v-model`), so it was making it hard to reset the value. @rmotitsuki, could you help out and take over this PR? I believe it'll be easier for you and since you've initially contributed to this feature and binding nested objects on Vue js isn't also as trival to reset them. Thanks.

### Local Tests

- I've explored setting `spf_max_path_cost` and `minimum_flexible_hits` resetting them (the other ones I encountered issues as mentioned in the summary, so to avoid making extra changes that would likely needed to be reverted I stopped testing other cases for now):

![20230214_115142](https://user-images.githubusercontent.com/1010796/218773173-4d54f9e1-f361-4f50-a3b6-e2ae4a32d427.png)

![20230214_115152](https://user-images.githubusercontent.com/1010796/218773218-5ee6b64e-9d36-4236-b270-c0da230bac4f.png)


### End-to-End Tests

N/A