### PR TITLE
fix: avoid redeploy of intra-switch EVCs on link_up events

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Fixed
 =====
 - fixed ``minimum_flexible_hits`` EVC attribute to be persistent
 - fixed attribute list for path constraints to include ``reliability``
+- fixed unnecessary redeploy of an intra-switch EVC on link up events
 
 
 [2022.3.0] - 2023-01-23

--- a/models/evc.py
+++ b/models/evc.py
@@ -1294,6 +1294,9 @@ class LinkProtection(EVCDeploy):
             link(Link): Link affected by link.down event.
 
         """
+        if self.is_intra_switch():
+            return True
+
         if self.is_using_primary_path():
             return True
 


### PR DESCRIPTION
Closes #273 

### Summary

This PR will fix an issue in which Kytos-ng is redeploying intra-switch EVCs upon receiving link_up events. Intra-switch EVCs do not depend on any links to be set up. Thus, adding an earlier return on the link-up handler for those cases makes sense.

### Local Tests

I've repeated the same steps documented in Issue #273 and no intra-switch EVC was redeployed:

```
# grep 'Starting Kytos - Kytos Controller'  /var/log/kytos/kytos.log
2023-02-14 15:02:50,835 - INFO [kytos.core.controller] [controller.py:315:start_controller] (MainThread) Starting Kytos - Kytos Controller

# cat /var/log/kytos/kytos.log | awk 'f;/2023-02-14 15:02:50,835/{f=1}' | grep 'was deployed.' | egrep -o "EVC\(.*\)" | wc -l
0
``` 

### End-to-End Tests

The end-to-end tests also shows that no regression was observed with the proposed changes:

```
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.0.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-10.2, timeout-2.1.0
collected 89 items

tests/test_e2e_10_mef_eline.py ..........ss.....x.....x.....             [ 32%]
tests/test_e2e_11_mef_eline.py .....                                     [ 38%]
tests/test_e2e_12_mef_eline.py .....xx.                                  [ 47%]
tests/test_e2e_13_mef_eline.py .....xxXx......xxXx.XXxX.xxxx..x......... [ 93%]
...                                                                      [ 96%]
tests/test_e2e_14_mef_eline.py x                                         [ 97%]
tests/test_e2e_15_mef_eline.py ..                                        [100%]

------------------------------- start/stop times -------------------------------
= 65 passed, 2 skipped, 17 xfailed, 5 xpassed, 332 warnings in 3980.73s (1:06:20) =

```