### PR TITLE
Added `uni_a` and `uni_z` to `attributes_requiring_redeploy` - backport to 2022.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,10 @@ Fixed
 [2022.3.1] - 2023-02-14
 ***********************
 
+Added
+=====
+- Added ``uni_a`` and ``uni_z`` to ``attributes_requiring_redeploy``
+
 Fixed
 =====
 - fixed ``minimum_flexible_hits`` EVC attribute to be persistent

--- a/models/evc.py
+++ b/models/evc.py
@@ -41,7 +41,9 @@ class EVCBase(GenericEntity):
         "queue_id",
         "sb_priority",
         "primary_constraints",
-        "secondary_constraints"
+        "secondary_constraints",
+        "uni_a",
+        "uni_z",
     ]
     required_attributes = ["name", "uni_a", "uni_z"]
 

--- a/tests/unit/models/test_evc_base.py
+++ b/tests/unit/models/test_evc_base.py
@@ -37,7 +37,9 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
             "queue_id",
             "sb_priority",
             "primary_constraints",
-            "secondary_constraints"
+            "secondary_constraints",
+            "uni_a",
+            "uni_z",
         ]
         assert EVC.attributes_requiring_redeploy == expected
 


### PR DESCRIPTION
Related to PR [#254](https://github.com/kytos-ng/mef_eline/pull/254), PR [#201](https://github.com/kytos-ng/kytos-end-to-end-tests/pull/201) and Issue [#249](https://github.com/kytos-ng/mef_eline/issues/249)

### Summary

This PR is similar to [#254](https://github.com/kytos-ng/mef_eline/pull/254). The only difference is that it is backported to `2022.3`.

### Local Tests

Same local tests as documented in PR [#254](https://github.com/kytos-ng/mef_eline/pull/254)

### End-to-End Tests

Same E2E tests as in PR [#254](https://github.com/kytos-ng/mef_eline/pull/254). These are in PR [#201](https://github.com/kytos-ng/kytos-end-to-end-tests/pull/201)