### PR TITLE
fix: avoid redeploy of intra-switch EVCs on link_up events - backport to 2022.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,7 @@ Fixed
 =====
 - fixed ``minimum_flexible_hits`` EVC attribute to be persistent
 - fixed attribute list for path constraints to include ``reliability``
+- fixed unnecessary redeploy of an intra-switch EVC on link up events
 
 
 [2022.3.0] - 2023-01-23

--- a/models/evc.py
+++ b/models/evc.py
@@ -1291,6 +1291,9 @@ class LinkProtection(EVCDeploy):
             link(Link): Link affected by link.down event.
 
         """
+        if self.is_intra_switch():
+            return True
+
         if self.is_using_primary_path():
             return True
 


### PR DESCRIPTION
Related to PR #275, and Issue #273 

### Summary

This PR is similar to #275. The only difference is that it is backported to `2022.3`.

### Local Tests

Same local tests as documented in PR #275

### End-to-End Tests

Same E2E tests as in PR #275