### PR TITLE
misc: set core-reviewers team as default reviewers for this repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# kytos-ng/core-reviewers team will be the default owners for everything in
+# the repo. Unless a later match takes precedence.
+* @kytos-ng/core-reviewers


### PR DESCRIPTION
### Summary

Related to https://github.com/kytos-ng/kytos/issues/328

### Summary

- Set `core-reviewers` team as default reviewers for this repo on `CODEOWNERS` file
- For more information check out [this page](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#about-code-owners)

### Local Tests

N/A

### Local Tests

### End-to-End Tests
