### PR TITLE
fix: update function `check_list_traces` for consistency check with bulk traces

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,7 +23,7 @@ Fixed
 - fixed ``minimum_flexible_hits`` EVC attribute to be persistent
 - fixed attribute list for path constraints to include ``reliability``
 - fixed unnecessary redeploy of an intra-switch EVC on link up events
-
+- fixed ``check_list_traces`` to work with the new version of SDN traces 
 
 [2022.3.0] - 2023-01-23
 ***********************

--- a/main.py
+++ b/main.py
@@ -82,19 +82,30 @@ class Main(KytosNApp):
             self.execute_consistency()
         log.debug("Finished consistency routine")
 
+    @staticmethod
+    def should_be_checked(circuit):
+        "Verify if the circuit meets the necessary conditions to be checked"
+        # pylint: disable=too-many-boolean-expressions
+        if (
+                circuit.is_enabled()
+                and not circuit.is_active()
+                and not circuit.lock.locked()
+                and not circuit.has_recent_removed_flow()
+                and not circuit.is_recent_updated()
+                # if a inter-switch EVC does not have current_path, it does not
+                # make sense to run sdntrace on it
+                and (circuit.is_intra_switch() or circuit.current_path)
+                ):
+            return True
+        return False
+
     def execute_consistency(self):
         """Execute consistency routine."""
         circuits_to_check = []
         stored_circuits = self.mongo_controller.get_circuits()['circuits']
         for circuit in self.get_evcs_by_svc_level():
             stored_circuits.pop(circuit.id, None)
-            if (
-                circuit.is_enabled()
-                and not circuit.is_active()
-                and not circuit.lock.locked()
-                and not circuit.has_recent_removed_flow()
-                and not circuit.is_recent_updated()
-            ):
+            if self.should_be_checked(circuit):
                 circuits_to_check.append(circuit)
         circuits_checked = EVCDeploy.check_list_traces(circuits_to_check)
         for circuit in circuits_to_check:

--- a/main.py
+++ b/main.py
@@ -84,7 +84,7 @@ class Main(KytosNApp):
 
     def execute_consistency(self):
         """Execute consistency routine."""
-        circuits_to_check = {}
+        circuits_to_check = []
         stored_circuits = self.mongo_controller.get_circuits()['circuits']
         for circuit in self.get_evcs_by_svc_level():
             stored_circuits.pop(circuit.id, None)
@@ -95,10 +95,10 @@ class Main(KytosNApp):
                 and not circuit.has_recent_removed_flow()
                 and not circuit.is_recent_updated()
             ):
-                circuits_to_check[circuit.id] = circuit
+                circuits_to_check.append(circuit)
         circuits_checked = EVCDeploy.check_list_traces(circuits_to_check)
-        for circuit_id, circuit in circuits_to_check.items():
-            is_checked = circuits_checked.get(circuit_id)
+        for circuit in circuits_to_check:
+            is_checked = circuits_checked.get(circuit.id)
             if is_checked:
                 circuit.execution_rounds = 0
                 log.info(f"{circuit} enabled but inactive - activating")

--- a/models/evc.py
+++ b/models/evc.py
@@ -1156,6 +1156,8 @@ class EVCDeploy(EVCBase):
     @staticmethod
     def check_trace(circuit, trace_a, trace_z):
         """Auxiliar function to check an individual trace"""
+        if not trace_a or not trace_z:
+            return False
         if (
             len(trace_a) != len(circuit.current_path) + 1
             or not compare_uni_out_trace(circuit.uni_z, trace_a[-1])
@@ -1199,11 +1201,6 @@ class EVCDeploy(EVCBase):
             return {}
         uni_list = []
         for circuit in list_circuits:
-            # if a inter-switch EVC does not have current_path, it does not
-            # make sense to run sdntrace on it
-            if not circuit.is_intra_switch() and not circuit.current_path:
-                list_circuits.remove(circuit)
-                continue
             uni_list.append(circuit.uni_a)
             uni_list.append(circuit.uni_z)
 
@@ -1216,8 +1213,6 @@ class EVCDeploy(EVCBase):
             for i, circuit in enumerate(list_circuits):
                 trace_a = traces[2*i]
                 trace_z = traces[2*i+1]
-                if not (trace_a and trace_z):
-                    continue
                 circuits_checked[circuit.id] = EVCDeploy.check_trace(
                         circuit, trace_a, trace_z
                     )

--- a/models/evc.py
+++ b/models/evc.py
@@ -1226,28 +1226,27 @@ class EVCDeploy(EVCBase):
         circuit_by_traces = {}
         circuits_checked = {}
 
-        for trace_switch in traces:
-            for trace in traces[trace_switch]:
-                if not trace:
-                    continue
-                id_trace = str(trace[0]['dpid']) + ':' + str(trace[0]['port'])
-                if 'vlan' in trace[0]:
-                    id_trace += ':' + str(trace[0]['vlan'])
-                circuit_from_data = circuit_data.get(id_trace)
-                if circuit_from_data is None:
-                    continue
-                circuit_id = circuit_from_data['circuit_id']
-                trace_name = circuit_from_data['trace_name']
-                circuit = list_circuits[circuit_id]
-                if circuit_id not in circuit_by_traces:
-                    circuit_by_traces[circuit_id] = {}
-                circuit_by_traces[circuit_id][trace_name] = trace
+        for trace in traces["result"]:
+            if not trace:
+                continue
+            id_trace = str(trace[0]['dpid']) + ':' + str(trace[0]['port'])
+            if 'vlan' in trace[0]:
+                id_trace += ':' + str(trace[0]['vlan'])
+            circuit_from_data = circuit_data.get(id_trace)
+            if circuit_from_data is None:
+                continue
+            circuit_id = circuit_from_data['circuit_id']
+            trace_name = circuit_from_data['trace_name']
+            circuit = list_circuits[circuit_id]
+            if circuit_id not in circuit_by_traces:
+                circuit_by_traces[circuit_id] = {}
+            circuit_by_traces[circuit_id][trace_name] = trace
 
-                if 'trace_a' in circuit_by_traces[circuit_id] \
-                        and 'trace_z' in circuit_by_traces[circuit_id]:
-                    circuits_checked[circuit_id] = EVCDeploy.check_trace(
-                        circuit, circuit_by_traces
-                    )
+            if 'trace_a' in circuit_by_traces[circuit_id] \
+                    and 'trace_z' in circuit_by_traces[circuit_id]:
+                circuits_checked[circuit_id] = EVCDeploy.check_trace(
+                    circuit, circuit_by_traces
+                )
 
         return circuits_checked
 

--- a/models/evc.py
+++ b/models/evc.py
@@ -1228,6 +1228,8 @@ class EVCDeploy(EVCBase):
 
         for trace_switch in traces:
             for trace in traces[trace_switch]:
+                if not trace:
+                    continue
                 id_trace = str(trace[0]['dpid']) + ':' + str(trace[0]['port'])
                 if 'vlan' in trace[0]:
                     id_trace += ':' + str(trace[0]['vlan'])

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -1406,7 +1406,7 @@ class TestEVC(TestCase):
 
         response.status_code = 400
         result = EVCDeploy.run_bulk_sdntraces([evc.uni_a])
-        self.assertEqual(result, [])
+        self.assertEqual(result, {"result": []})
 
     @patch("napps.kytos.mef_eline.models.evc.log")
     @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.run_bulk_sdntraces")
@@ -1432,7 +1432,7 @@ class TestEVC(TestCase):
         run_bulk_sdntraces_mock.return_value = {
                                                 "result": [trace_a, trace_z]
                                             }
-        result = EVCDeploy.check_list_traces({evc.id: evc})
+        result = EVCDeploy.check_list_traces([evc])
         self.assertTrue(result[evc.id])
 
         # case2: fail incomplete trace from uni_a
@@ -1442,7 +1442,7 @@ class TestEVC(TestCase):
                                                             trace_z
                                                         ]
         }
-        result = EVCDeploy.check_list_traces({evc.id: evc})
+        result = EVCDeploy.check_list_traces([evc])
         self.assertFalse(result[evc.id])
 
         # case3: fail incomplete trace from uni_z
@@ -1452,7 +1452,7 @@ class TestEVC(TestCase):
                                                             trace_z[:2]
                                                         ]
         }
-        result = EVCDeploy.check_list_traces({evc.id: evc})
+        result = EVCDeploy.check_list_traces([evc])
         self.assertFalse(result[evc.id])
 
         # case4: fail wrong vlan id in trace from uni_a
@@ -1461,7 +1461,7 @@ class TestEVC(TestCase):
         run_bulk_sdntraces_mock.return_value = {
                                                 "result": [trace_a, trace_z]
         }
-        result = EVCDeploy.check_list_traces({evc.id: evc})
+        result = EVCDeploy.check_list_traces([evc])
         self.assertFalse(result[evc.id])
 
         # case5: fail wrong vlan id in trace from uni_z
@@ -1469,38 +1469,38 @@ class TestEVC(TestCase):
         run_bulk_sdntraces_mock.return_value = {
                                                 "result": [trace_a, trace_z]
         }
-        result = EVCDeploy.check_list_traces({evc.id: evc})
+        result = EVCDeploy.check_list_traces([evc])
         self.assertFalse(result[evc.id])
 
         # case6: success when no output in traces
         trace_a[1]["vlan"] = 5
         trace_z[1]["vlan"] = 6
-        result = EVCDeploy.check_list_traces({evc.id: evc})
+        result = EVCDeploy.check_list_traces([evc])
         self.assertTrue(result[evc.id])
 
         # case7: fail when output is None in trace_a or trace_b
         trace_a[-1]["out"] = None
-        result = EVCDeploy.check_list_traces({evc.id: evc})
+        result = EVCDeploy.check_list_traces([evc])
         self.assertFalse(result[evc.id])
         trace_a[-1].pop("out", None)
         trace_z[-1]["out"] = None
-        result = EVCDeploy.check_list_traces({evc.id: evc})
+        result = EVCDeploy.check_list_traces([evc])
         self.assertFalse(result[evc.id])
 
         # case8: success when the output is correct on both uni
         trace_a[-1]["out"] = {"port": 3, "vlan": 83}
         trace_z[-1]["out"] = {"port": 2, "vlan": 82}
-        result = EVCDeploy.check_list_traces({evc.id: evc})
+        result = EVCDeploy.check_list_traces([evc])
         self.assertTrue(result[evc.id])
 
         # case9: fail if any output is incorrect
         trace_a[-1]["out"] = {"port": 3, "vlan": 99}
         trace_z[-1]["out"] = {"port": 2, "vlan": 82}
-        result = EVCDeploy.check_list_traces({evc.id: evc})
+        result = EVCDeploy.check_list_traces([evc])
         self.assertFalse(result[evc.id])
         trace_a[-1]["out"] = {"port": 3, "vlan": 83}
         trace_z[-1]["out"] = {"port": 2, "vlan": 99}
-        result = EVCDeploy.check_list_traces({evc.id: evc})
+        result = EVCDeploy.check_list_traces([evc])
         self.assertFalse(result[evc.id])
 
     @patch(

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -1430,24 +1430,27 @@ class TestEVC(TestCase):
         ]
 
         run_bulk_sdntraces_mock.return_value = {
-                                                1: [trace_a],
-                                                3: [trace_z]
+                                                "result": [trace_a, trace_z]
                                             }
         result = EVCDeploy.check_list_traces({evc.id: evc})
         self.assertTrue(result[evc.id])
 
         # case2: fail incomplete trace from uni_a
         run_bulk_sdntraces_mock.return_value = {
-                                                1: [trace_a[:2]],
-                                                3: [trace_z]
+                                                "result": [
+                                                            trace_a[:2],
+                                                            trace_z
+                                                        ]
         }
         result = EVCDeploy.check_list_traces({evc.id: evc})
         self.assertFalse(result[evc.id])
 
         # case3: fail incomplete trace from uni_z
         run_bulk_sdntraces_mock.return_value = {
-                                                1: [trace_a],
-                                                3: [trace_z[:2]]
+                                                "result": [
+                                                            trace_a,
+                                                            trace_z[:2]
+                                                        ]
         }
         result = EVCDeploy.check_list_traces({evc.id: evc})
         self.assertFalse(result[evc.id])
@@ -1456,8 +1459,7 @@ class TestEVC(TestCase):
         trace_a[1]["vlan"] = 5
         trace_z[1]["vlan"] = 99
         run_bulk_sdntraces_mock.return_value = {
-                                                1: [trace_a],
-                                                3: [trace_z]
+                                                "result": [trace_a, trace_z]
         }
         result = EVCDeploy.check_list_traces({evc.id: evc})
         self.assertFalse(result[evc.id])
@@ -1465,8 +1467,7 @@ class TestEVC(TestCase):
         # case5: fail wrong vlan id in trace from uni_z
         trace_a[1]["vlan"] = 99
         run_bulk_sdntraces_mock.return_value = {
-                                                1: [trace_a],
-                                                3: [trace_z]
+                                                "result": [trace_a, trace_z]
         }
         result = EVCDeploy.check_list_traces({evc.id: evc})
         self.assertFalse(result[evc.id])
@@ -1501,22 +1502,6 @@ class TestEVC(TestCase):
         trace_z[-1]["out"] = {"port": 2, "vlan": 99}
         result = EVCDeploy.check_list_traces({evc.id: evc})
         self.assertFalse(result[evc.id])
-
-    @patch("napps.kytos.mef_eline.models.evc.log")
-    @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.run_bulk_sdntraces")
-    def test_check_list_traces_empty(self, run_bulk_sdntraces_mock, _):
-        """Test check_list_traces method."""
-        evc = self.create_evc_inter_switch()
-
-        for link in evc.primary_links:
-            link.metadata['s_vlan'] = MagicMock(value=link.metadata['s_vlan'])
-        evc.current_path = evc.primary_links
-
-        run_bulk_sdntraces_mock.return_value = {
-                                                1: [[]]
-                                            }
-        result = EVCDeploy.check_list_traces({evc.id: evc})
-        assert not result
 
     @patch(
         "napps.kytos.mef_eline.models.path.DynamicPathManager"

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -1502,6 +1502,22 @@ class TestEVC(TestCase):
         result = EVCDeploy.check_list_traces({evc.id: evc})
         self.assertFalse(result[evc.id])
 
+    @patch("napps.kytos.mef_eline.models.evc.log")
+    @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.run_bulk_sdntraces")
+    def test_check_list_traces_empty(self, run_bulk_sdntraces_mock, _):
+        """Test check_list_traces method."""
+        evc = self.create_evc_inter_switch()
+
+        for link in evc.primary_links:
+            link.metadata['s_vlan'] = MagicMock(value=link.metadata['s_vlan'])
+        evc.current_path = evc.primary_links
+
+        run_bulk_sdntraces_mock.return_value = {
+                                                1: [[]]
+                                            }
+        result = EVCDeploy.check_list_traces({evc.id: evc})
+        assert not result
+
     @patch(
         "napps.kytos.mef_eline.models.path.DynamicPathManager"
         ".get_disjoint_paths"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock
 
 from napps.kytos.mef_eline.utils import (
-    compare_endpoint_trace, uni_to_str, compare_uni_out_trace
+    compare_endpoint_trace, compare_uni_out_trace
 )
 
 
@@ -34,18 +34,6 @@ class TestUtils(TestCase):
                 self.assertEqual(
                     compare_endpoint_trace(endpoint, None, trace), expected
                 )
-
-    def test_uni_to_str(self):
-        """Test uni_to_str method"""
-        uni = MagicMock()
-        uni.interface.switch.dpid = "00:00:00:00:00:00:00:01"
-        uni.interface.port_number = 1
-        uni.user_tag.value = 2
-        self.assertEqual(uni_to_str(uni), "00:00:00:00:00:00:00:01:1:2")
-
-        # without user_tag
-        uni.user_tag = None
-        self.assertEqual(uni_to_str(uni), "00:00:00:00:00:00:00:01:1")
 
     def test_compare_uni_out_trace(self):
         """Test compare_uni_out_trace method."""

--- a/utils.py
+++ b/utils.py
@@ -68,16 +68,6 @@ def compare_uni_out_trace(uni, trace):
     )
 
 
-def uni_to_str(uni):
-    """Create a string representation of the uni: intf_id:portno[:vlan]."""
-    dpid = uni.interface.switch.dpid
-    port = uni.interface.port_number
-    uni_str = str(dpid) + ':' + str(port)
-    if uni.user_tag:
-        uni_str += ':' + str(uni.user_tag.value)
-    return uni_str
-
-
 def load_spec():
     """Validate openapi spec."""
     napp_dir = Path(__file__).parent


### PR DESCRIPTION
This PR is related to [PR 75 in sdtrace_cp](https://github.com/kytos-ng/sdntrace_cp/pull/75).

### Summary

Previously, for:

```
traces = EVCDeploy.run_bulk_sdntraces(uni_list)
```

The response was a dictionary where the keys were switches and the values were lists of paths.
Now the response is simpler: A list of lists (paths).

This PR updates `check_list_traces` to use the new version of `PUT /traces` from `sdntrace_cp`

Also, previously the following error was obtained:
```
  File "/home/gretel/repos_kytos/env_for_kytos/var/lib/kytos/napps/kytos/mef_eline/main.py", line 99, in execute_consistency
    circuits_checked = EVCDeploy.check_list_traces(circuits_to_check)
  File "/home/gretel/repos_kytos/env_for_kytos/var/lib/kytos/napps/../napps/kytos/mef_eline/models/evc.py", line 1232, in check_list_traces
    id_trace = str(trace[0]['dpid']) + ':' + str(trace[0]['port'])
TypeError: string indices must be integers
```

Now it is verified that each [trace is not empty](https://github.com/kytos-ng/mef_eline/blob/384209cb1758e9700e07facfc57471ea87a24dc0/models/evc.py#L1229-L1231) to avoid the error.