### PR TITLE
fix: hid ui primary and secondary constraints on ``k-toolbar`` in the meantime

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Added
 
 Changed
 =======
+- Hid ui primary and secondary constraints on ``k-toolbar`` in the meantime
+- Moved request circuit ``k-button`` out of k-accordion-item since it's mandatory
 
 Removed
 =======

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -79,7 +79,7 @@
 
         <span v-for="constraint in ['primary_constraints', 'secondary_constraints']">
             <k-accordion-item :title="constraint_titles[constraint]"
-             v-if="form_constraints[constraint]">
+             v-if="false">
 
                 <k-select :title="constraint_titles.desired_links"
                 :options="get_link_options()"
@@ -183,11 +183,9 @@
                 </div>
             </k-accordion-item>
         </span>
-        <k-accordion-item>
-          <k-button tooltip="Request Circuit" title="Request Circuit"
-          icon="gear" :on_click="request_circuit">
-          </k-button>
-        </k-accordion-item>
+        <k-button tooltip="Request Circuit" title="Request Circuit"
+        icon="gear" :on_click="request_circuit">
+        </k-button>
         <k-accordion-item title="List EVCs">
             <k-button tooltip="List installed EVC" title="List installed EVC"
                      icon="plug" :on_click="viewPanel">


### PR DESCRIPTION
Closes #283 

### Summary

See updated changelog file (I'll send a backport to 2022.3.1 shortly)

### Local Tests

I confirmed that on `k-toolbar` the constraint options were hid as expected, and in the edit view component the optional constraint options are still available and functioning

![20230224_134619](https://user-images.githubusercontent.com/1010796/221238542-b68a6de5-13dd-4ef8-bcee-557abaa0faf1.png)
![20230224_134735](https://user-images.githubusercontent.com/1010796/221238609-63318fa5-e848-4820-a7e9-7dc2fa4189b3.png)

```
        "primary_constraints": {
            "desired_links": [],
            "mandatory_metrics": {
                "ownership": "blue"
            },
            "spf_attribute": "hop",
            "spf_max_path_cost": 100.0,
            "undesired_links": []
        },
```



### End-to-End Tests

N/A