### PR TITLE
feature: Early return in `check_trace`.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Changed
 =======
 - Hid ui primary and secondary constraints on ``k-toolbar`` in the meantime
 - Moved request circuit ``k-button`` out of k-accordion-item since it's mandatory
+- The traces being check rely on ``type``: ``last`` to be considered valid.
 
 Removed
 =======

--- a/models/evc.py
+++ b/models/evc.py
@@ -1154,9 +1154,25 @@ class EVCDeploy(EVCBase):
         return response.json()
 
     @staticmethod
+    def trace_invalid(trace):
+        """Auxiliar function to check traces"""
+        if not trace or trace[-1]['type'] != 'last':
+            return True
+        return False
+
+    # pylint: disable=too-many-return-statements
+    @staticmethod
     def check_trace(circuit, trace_a, trace_z):
         """Auxiliar function to check an individual trace"""
-        if not trace_a or not trace_z:
+        if EVCDeploy.trace_invalid(trace_a):
+            log.warning(
+                f"Invalid trace from trace_a: {trace_a}"
+            )
+            return False
+        if EVCDeploy.trace_invalid(trace_z):
+            log.warning(
+                f"Invalid trace from trace_z: {trace_z}"
+            )
             return False
         if (
             len(trace_a) != len(circuit.current_path) + 1


### PR DESCRIPTION
This is related to [PR 73 in sdntrace_cp](https://github.com/kytos-ng/sdntrace_cp/pull/73)

### Summary

Update function `check_trace` for an early return in the case of invalid traces. That is, first it is checked that the traces have type `last` in their last step.

Add one unit test: `test_check_list_traces_invalid_types` to check the correct behavior for traces that do not end with `last`.

### Local Tests

N/A

### End-to-End Tests

N/A