### PR TITLE
fix: Remove `run_sdntrace`

### DIFF
--- a/models/evc.py
+++ b/models/evc.py
@@ -1143,29 +1143,6 @@ class EVCDeploy(EVCBase):
         return flow_mod
 
     @staticmethod
-    def run_sdntrace(uni):
-        """Run SDN trace on control plane starting from EVC UNIs."""
-        endpoint = f"{settings.SDN_TRACE_CP_URL}/trace"
-        data_uni = {
-            "trace": {
-                "switch": {
-                    "dpid": uni.interface.switch.dpid,
-                    "in_port": uni.interface.port_number,
-                }
-            }
-        }
-        if uni.user_tag:
-            data_uni["trace"]["eth"] = {
-                "dl_type": 0x8100,
-                "dl_vlan": uni.user_tag.value,
-            }
-        response = requests.put(endpoint, json=data_uni)
-        if response.status_code >= 400:
-            log.error(f"Failed to run sdntrace-cp: {response.text}")
-            return []
-        return response.json().get('result', [])
-
-    @staticmethod
     def run_bulk_sdntraces(uni_list):
         """Run SDN traces on control plane starting from EVC UNIs."""
         endpoint = f"{settings.SDN_TRACE_CP_URL}/traces"

--- a/openapi.yml
+++ b/openapi.yml
@@ -24,7 +24,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
+                type: object
                 items:
                   $ref: '#/components/schemas/Circuit'
 

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -1316,31 +1316,6 @@ class TestEVC(TestCase):
         log_mock.error.assert_called()
 
     @patch("requests.put")
-    def test_run_sdntrace(self, put_mock):
-        """Test run_sdntrace method."""
-        evc = self.create_evc_inter_switch()
-        response = MagicMock()
-        response.status_code = 200
-        response.json.return_value = {"result": "ok"}
-        put_mock.return_value = response
-
-        expected_endpoint = f"{SDN_TRACE_CP_URL}/trace"
-        expected_payload = {
-            'trace': {
-                'switch': {'dpid': 1, 'in_port': 2},
-                'eth': {'dl_type': 0x8100, 'dl_vlan': 82}
-            }
-        }
-
-        result = evc.run_sdntrace(evc.uni_a)
-        put_mock.assert_called_with(expected_endpoint, json=expected_payload)
-        self.assertEqual(result, "ok")
-
-        response.status_code = 400
-        result = evc.run_sdntrace(evc.uni_a)
-        self.assertEqual(result, [])
-
-    @patch("requests.put")
     def test_run_bulk_sdntraces(self, put_mock):
         """Test run_bulk_sdntraces method for bulk request."""
         evc = self.create_evc_inter_switch()


### PR DESCRIPTION
Closes #292 

### Summary

Remove `run_sdntrace` since `run_bulk_sdntraces` is now used.

### Local Tests

N/A

### End-to-End Tests

N/A