### PR TITLE
Added bulk api requests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,12 +12,15 @@ Added
 - Added ``uni_a`` and ``uni_z`` to ``attributes_requiring_redeploy``
 - Added ``metadata`` to EVC schema
 - Allow the creation of ``any`` and ``untagged`` EVC.
+- Added api request ``POST /v2/evc/metadata`` to add metadata to EVCs
+- Added api request ``DELETE /v2/evc/metadata/<key>`` to delete metadata from EVCs
 
 Changed
 =======
 - Hid ui primary and secondary constraints on ``k-toolbar`` in the meantime
 - Moved request circuit ``k-button`` out of k-accordion-item since it's mandatory
 - The traces being check rely on ``type``: ``last`` to be considered valid.
+- Augmented ``GET /v2/evc/`` to accept parameters ``metadata.key=item``
 
 Removed
 =======

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -52,17 +52,21 @@ class ELineController:
                      metadata: dict = None) -> Dict:
         """Get all circuits from database."""
         aggregation = []
+        options = {"null": None, "true": True, "false": False}
         match_filters = {"$match": {}}
         aggregation.append(match_filters)
         if archived is not None:
+            archived = options.get(archived, False)
             match_filters["$match"]["archived"] = archived
         if metadata:
             for key in metadata:
-                if "metadata." in key:
+                if "metadata." in key[:9]:
                     try:
                         match_filters["$match"][key] = int(metadata[key])
                     except ValueError:
-                        match_filters["$match"][key] = metadata[key]
+                        item = metadata[key].lower()
+                        match_filters["$match"][key] = options.get(item, item)
+        print("AGREE -> ", aggregation)
         aggregation.extend([
                 {"$sort": {"_id": 1}},
                 {"$project": EVCBaseDoc.projection()},

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -64,9 +64,9 @@ class ELineController:
                     try:
                         match_filters["$match"][key] = int(metadata[key])
                     except ValueError:
-                        item = metadata[key].lower()
-                        match_filters["$match"][key] = options.get(item, item)
-        print("AGREE -> ", aggregation)
+                        item = metadata[key]
+                        item = options.get(item.lower(), item)
+                        match_filters["$match"][key] = item
         aggregation.extend([
                 {"$sort": {"_id": 1}},
                 {"$project": EVCBaseDoc.projection()},

--- a/main.py
+++ b/main.py
@@ -142,9 +142,7 @@ class Main(KytosNApp):
         """
         log.debug("list_circuits /v2/evc")
         args = request.args.to_dict()
-        archived = args.pop("archived", "false")
-        archived_to_optional = {"null": None, "true": True, "false": False}
-        archived = archived_to_optional.get(archived, False)
+        archived = args.pop("archived", "false").lower()
         circuits = self.mongo_controller.get_circuits(archived=archived,
                                                       metadata=args)
         circuits = circuits['circuits']
@@ -384,9 +382,7 @@ class Main(KytosNApp):
     @validate(spec)
     def bulk_add_metadata(self, data):
         """Add metadata to a bulk of EVCs."""
-        circuit_ids = data.pop("circuit_ids", None)
-        if circuit_ids is None:
-            raise BadRequest("The key 'circuit_ids' is missing.")
+        circuit_ids = data.pop("circuit_ids")
         self.mongo_controller.update_evcs(circuit_ids, data, "add")
 
         fail_evcs = []
@@ -436,9 +432,7 @@ class Main(KytosNApp):
     @validate(spec)
     def bulk_delete_metadata(self, data, key):
         """Delete metada from a bulk of EVCs"""
-        circuit_ids = data.pop("circuit_ids", None)
-        if circuit_ids is None:
-            raise BadRequest("The key 'circuit_ids' is missing.")
+        circuit_ids = data.pop("circuit_ids")
         self.mongo_controller.update_evcs(circuit_ids, {key: ""}, "del")
 
         fail_evcs = []

--- a/main.py
+++ b/main.py
@@ -141,16 +141,12 @@ class Main(KytosNApp):
         accordingly, by default only non archived evcs will be listed
         """
         log.debug("list_circuits /v2/evc")
-        archived = request.args.get("archived", "false").lower()
+        args = request.args.to_dict()
+        archived = args.pop("archived", "false")
         archived_to_optional = {"null": None, "true": True, "false": False}
         archived = archived_to_optional.get(archived, False)
-        arg_k = request.args.get("metadata_key")
-        arg_v = request.args.get("metadata_value")
-        if arg_k:
-            circuits = self.mongo_controller.get_circuits(archived=archived,
-                                                          match={arg_k: arg_v})
-        else:
-            circuits = self.mongo_controller.get_circuits(archived=archived)
+        circuits = self.mongo_controller.get_circuits(archived=archived,
+                                                      metadata=args)
         circuits = circuits['circuits']
         return jsonify(circuits), 200
 
@@ -385,44 +381,24 @@ class Main(KytosNApp):
             raise NotFound(f"circuit_id {circuit_id} not found.") from error
 
     @rest("v2/evc/metadata", methods=["POST"])
-    def add_bulk_metadata(self):
+    @validate(spec)
+    def bulk_add_metadata(self, data):
         """Add metadata to a bulk of EVCs."""
-        try:
-            metadata = request.get_json()
-            content_type = request.content_type
-        except BadRequest as error:
-            result = "The request body is not a well-formed JSON."
-            raise BadRequest(result) from error
-        if content_type is None:
-            result = "The request body is empty."
-            raise BadRequest(result)
-        if metadata is None:
-            if content_type != "application/json":
-                result = (
-                    "The content type must be application/json "
-                    f"(received {content_type})."
-                )
-            else:
-                result = "Metadata is empty."
-            raise UnsupportedMediaType(result)
-
-        circuit_ids = metadata.pop("circuit_ids", None)
+        circuit_ids = data.pop("circuit_ids", None)
         if circuit_ids is None:
             raise BadRequest("The key 'circuit_ids' is missing.")
-        payload = {f"metadata.{k}": v for k, v in metadata.items()}
-        self.mongo_controller.update_bulk_evc(circuit_ids, {"$set": payload})
+        self.mongo_controller.update_evcs(circuit_ids, data, "add")
 
-        fail_evcs = set()
+        fail_evcs = []
         for _id in circuit_ids:
             try:
                 evc = self.circuits[_id]
-                evc.extend_metadata(metadata)
-                evc.sync()
+                evc.extend_metadata(data)
             except KeyError:
-                fail_evcs.add(_id)
+                fail_evcs.append(_id)
 
         if fail_evcs:
-            raise NotFound(f"Circuits {str(fail_evcs)} were not found")
+            return jsonify(fail_evcs), 404
         return jsonify("Operation successful"), 201
 
     @rest("v2/evc/<circuit_id>/metadata", methods=["POST"])
@@ -457,44 +433,24 @@ class Main(KytosNApp):
         return jsonify("Operation successful"), 201
 
     @rest("v2/evc/metadata/<key>", methods=["DELETE"])
-    def delete_bulk_metadata(self, key):
+    @validate(spec)
+    def bulk_delete_metadata(self, data, key):
         """Delete metada from a bulk of EVCs"""
-        try:
-            metadata = request.get_json()
-            content_type = request.content_type
-        except BadRequest as error:
-            result = "The request body is not a well-formed JSON."
-            raise BadRequest(result) from error
-        if content_type is None:
-            result = "The request body is empty."
-            raise BadRequest(result)
-        if metadata is None:
-            if content_type != "application/json":
-                result = (
-                    "The content type must be application/json "
-                    f"(received {content_type})."
-                )
-            else:
-                result = "Request is empty."
-            raise UnsupportedMediaType(result)
-
-        circuit_ids = metadata.pop("circuit_ids", None)
+        circuit_ids = data.pop("circuit_ids", None)
         if circuit_ids is None:
             raise BadRequest("The key 'circuit_ids' is missing.")
-        payload = {f"metadata.{key}": ""}
-        self.mongo_controller.update_bulk_evc(circuit_ids, {"$unset": payload})
+        self.mongo_controller.update_evcs(circuit_ids, {key: ""}, "del")
 
-        fail_evcs = set()
+        fail_evcs = []
         for _id in circuit_ids:
             try:
                 evc = self.circuits[_id]
                 evc.remove_metadata(key)
-                evc.sync()
             except KeyError:
-                fail_evcs.add(_id)
+                fail_evcs.append(_id)
 
         if fail_evcs:
-            raise NotFound(f"Circuits {str(fail_evcs)} were not found")
+            return jsonify(fail_evcs), 404
         return jsonify("Operation successful"), 200
 
     @rest("v2/evc/<circuit_id>/metadata/<key>", methods=["DELETE"])

--- a/models/evc.py
+++ b/models/evc.py
@@ -918,9 +918,7 @@ class EVCDeploy(EVCBase):
 
         if uni.user_tag:
             value = uni.user_tag.value
-            if isinstance(value, str):
-                return special.get(value, value)
-            return value
+            return special.get(value, value)
         return None
 
     def _prepare_uni_flows(self, path=None, skip_in=False, skip_out=False):

--- a/openapi.yml
+++ b/openapi.yml
@@ -175,7 +175,7 @@ paths:
           description: EVC not found
         '415':
           description: Wrong type
-  /v2/evc/{circuit_id}/metadata/key:
+  /v2/evc/{circuit_id}/metadata/{key}:
     delete:
       summary: Remove a metadata
       operationId: delete_metadata
@@ -287,6 +287,21 @@ paths:
       summary: Add metadata to a bulk of EVCs
       description: Add metadata to multiple EVCs based on the body content
       operationId: bulk_add_metadata
+      requestBody:
+        description: Metadata to be added to the EVCs
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - circuit_ids
+              properties:
+                circuit_ids:
+                  type: array
+                  items:
+                    type: string
+            
       responses:
         '200':
           description: Operation successful
@@ -298,6 +313,8 @@ paths:
             aplication/json:
               schema:
                 type: array
+                items:
+                  type: string
         '415':
           description: The request body mimetype is not application/json
 
@@ -306,6 +323,20 @@ paths:
       summary: Delete metadata to a bulk of EVCs
       description: Delete metadata from multiple EVCs based on the given key
       operationId: bulk_delete_metadata
+      requestBody:
+        description: Metadata to be deleted from the EVCs
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - circuit_ids
+              properties:
+                circuit_ids:
+                  type: array
+                  items:
+                    type: string
       parameters:            
         - name: key
           in: path
@@ -323,6 +354,8 @@ paths:
             aplication/json:
               schema:
                 type: array
+                items:
+                  type: string
         '415':
           description: The request body mimetype is not application/json
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -18,6 +18,15 @@ paths:
             type: string
           description: "Filter for archived value, if not null. It's false by default"
           required: false
+        - name: metadata
+          in: query
+          schema:
+            oneOf:
+              - type: string
+              - type: integer
+              - type: boolean
+          description: Filter for metadata values with format metadata.key=value, e.g. "metadata.required=false"
+          required: false
       responses:
         '200':
           description: OK

--- a/openapi.yml
+++ b/openapi.yml
@@ -281,6 +281,51 @@ paths:
           description:  Can´t change data. Circuit is deleted and archived.
         '404':
           description:  Schedule id not found.
+
+  /v2/evc/metadata:
+    post:
+      summary: Add metadata to a bulk of EVCs
+      description: Add metadata to multiple EVCs based on the body content
+      operationId: bulk_add_metadata
+      responses:
+        '200':
+          description: Operation successful
+        '400':
+          description: The request body is not a well-formed JSON or circuit_ids is missing
+        '404':
+          description: There were EVCs not found.
+          content:
+            aplication/json:
+              schema:
+                type: array
+        '415':
+          description: The request body mimetype is not application/json
+
+  /v2/evc/metadata/{key}:
+    delete:
+      summary: Delete metadata to a bulk of EVCs
+      description: Delete metadata from multiple EVCs based on the given key
+      operationId: bulk_delete_metadata
+      parameters:            
+        - name: key
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Operation successful
+        '400':
+          description: The request body is not a well-formed JSON or circuit_ids is missing
+        '404':
+          description: There were EVCs not found.
+          content:
+            aplication/json:
+              schema:
+                type: array
+        '415':
+          description: The request body mimetype is not application/json
+
 components:
   #-------------------------------
   # Reusable schemas (data models)

--- a/tests/unit/test_controllers.py
+++ b/tests/unit/test_controllers.py
@@ -67,3 +67,12 @@ class TestControllers(TestCase):
 
         self.eline.upsert_evc(self.evc_dict)
         assert self.eline.db.evcs.find_one_and_update.call_count == 1
+
+    def test_update_bulk_evc(self):
+        """Test update_bulk_evc"""
+        circuit_ids = ["123", "456", "789"]
+        metadata = {"$set": {"metadata.info": "testing"}}
+        self.eline.update_bulk_evc(circuit_ids, metadata)
+        arg = self.eline.db.evcs.bulk_write.call_args[0][0]
+        assert len(arg) == 3
+        assert self.eline.db.evcs.bulk_write.call_count == 1

--- a/tests/unit/test_controllers.py
+++ b/tests/unit/test_controllers.py
@@ -59,7 +59,7 @@ class TestControllers(TestCase):
 
     def test_get_circuits_archived_true(self):
         """Test get_circuits with archive being true"""
-        self.eline.get_circuits(archived=True)
+        self.eline.get_circuits(archived="true")
         args = self.eline.db.evcs.aggregate.call_args[0][0][0]
         assert args["$match"] == {'archived': True}
 

--- a/tests/unit/test_controllers.py
+++ b/tests/unit/test_controllers.py
@@ -51,16 +51,24 @@ class TestControllers(TestCase):
         assert "circuits" in self.eline.get_circuits()
         assert self.eline.db.evcs.aggregate.call_count == 1
 
-    def test_get_circuits_archived(self):
-        """Test get_circuits archived filter"""
-
+    def test_get_circuits_archived_false(self):
+        """Test get_circuits with archive being false"""
         self.eline.get_circuits(archived=None)
-        arg1 = self.eline.db.evcs.aggregate.call_args[0]
-        assert "$match" not in arg1[0][0]
+        args = self.eline.db.evcs.aggregate.call_args[0][0][0]
+        assert args["$match"] == {}
 
+    def test_get_circuits_archived_true(self):
+        """Test get_circuits with archive being true"""
         self.eline.get_circuits(archived=True)
-        arg1 = self.eline.db.evcs.aggregate.call_args[0]
-        assert arg1[0][0]["$match"] == {'archived': True}
+        args = self.eline.db.evcs.aggregate.call_args[0][0][0]
+        assert args["$match"] == {'archived': True}
+
+    def test_get_circuits_metadata(self):
+        """Test get_circuits with metadata"""
+        metadata = {"metadata.test": "123"}
+        self.eline.get_circuits(archived=True, metadata=metadata)
+        args = self.eline.db.evcs.aggregate.call_args[0][0][0]
+        assert args["$match"]["metadata.test"] == 123
 
     def test_upsert_evc(self):
         """Test upsert_evc"""
@@ -68,11 +76,11 @@ class TestControllers(TestCase):
         self.eline.upsert_evc(self.evc_dict)
         assert self.eline.db.evcs.find_one_and_update.call_count == 1
 
-    def test_update_bulk_evc(self):
-        """Test update_bulk_evc"""
+    def test_update_evcs(self):
+        """Test update_evcs"""
         circuit_ids = ["123", "456", "789"]
-        metadata = {"$set": {"metadata.info": "testing"}}
-        self.eline.update_bulk_evc(circuit_ids, metadata)
+        metadata = {"info": "testing"}
+        self.eline.update_evcs(circuit_ids, metadata, "add")
         arg = self.eline.db.evcs.bulk_write.call_args[0][0]
         assert len(arg) == 3
         assert self.eline.db.evcs.bulk_write.call_count == 1

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -389,7 +389,7 @@ class TestMain(TestCase):
 
         response = api.get(url)
         expected_result = circuits["circuits"]
-        get_circuits.assert_called_with(archived=False, metadata={})
+        get_circuits.assert_called_with(archived="false", metadata={})
         self.assertEqual(json.loads(response.data), expected_result)
 
     def test_list_with_archived_circuits_archived(self):
@@ -407,7 +407,7 @@ class TestMain(TestCase):
         url = f"{self.server_name_url}/v2/evc/?archived=true&metadata.a=1"
 
         response = api.get(url)
-        get_circuits.assert_called_with(archived=True,
+        get_circuits.assert_called_with(archived="true",
                                         metadata={"metadata.a": "1"})
         expected_result = {"1": circuits["circuits"]["1"]}
         self.assertEqual(json.loads(response.data), expected_result)


### PR DESCRIPTION
Closes #225 

### Summary

Added bulk updates for metadata
- A new `POST /v2/evc/metadata` for metadata bulk creation/update taking `circuit_id: List[str]` in the request body
- A new `DELETE /v2/evc/metadata/<key>` for deleting a metadata key taking `circuit_id: List[str]` in the request body`
- Augment `GET /v2/evc/` supporting to filter for a given query parameter e.g. `metadata.extra=data`

### Local Tests
- Update bulk
API url: `POST /v2/evc/metadata`
Body request:
```
    {"circuit_ids": [
        "1de5a5a5ec9241",
        "2c255cc263e447",
    ],
    "First": "first data",
    "Second": "data 2"}
```
- Delete bulk
API url: `DELETE /v2/evc/metadata/<key>`
Body request:
```
{
    "circuit_ids": [
        "1de5a5a5ec9241",
        "2c255cc263e447",
        "nonexistent"
    ],
    "First": "first data""
}
```
- Get evcs
API url: `GET /v2/evc?metadata.Test=123`

### End-to-End Tests
In progress