### PR TITLE
Avoid sending a string to `/traces`

### DIFF
--- a/models/evc.py
+++ b/models/evc.py
@@ -1148,7 +1148,6 @@ class EVCDeploy(EVCBase):
         dl_vlan = untagged or 0 -> None
         dl_vlan = any or "4096/4096" -> 1
         dl_vlan = "num1/num2" -> int in [1, 4095]"""
-
         special_unttaged = ["untagged", 0]
         if value in special_unttaged:
             return None

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -1421,6 +1421,8 @@ class TestEVC(TestCase):
                                     json=expected_payload,
                                     timeout=30
                                 )
+        args = put_mock.call_args[1]['json'][0]['trace']
+        assert args['eth'] == {'dl_type': 33024, 'dl_vlan': 10}
 
         expected_payload[0]['trace']['eth'] = {
             'dl_type': 0x8100,


### PR DESCRIPTION
Closes #300 

### Summary

Map `dl_vlan` to an integer in range [1, 4095] for `/traces`.

### Local Tests

[See unit test](https://github.com/kytos-ng/mef_eline/blob/8b28b7796a9ccce525e69915f25f2fac3f78276a/tests/unit/models/test_evc_deploy.py#L1348-L1353)

### End-to-End Tests

N/A