### PR TITLE
chore: replaced `@validate` with `@validate_openapi` from `kytos.core.helpers`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,10 @@ Fixed
 - fixed unnecessary redeploy of an intra-switch EVC on link up events
 - fixed ``check_list_traces`` to work with the new version of SDN traces 
 
+General Information
+===================
+- Replaced ``@validate`` with ``@validate_openapi`` from kytos core
+
 [2022.3.1] - 2023-02-14
 ***********************
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -28,6 +28,7 @@ attrs==21.4.0
     # via
     #   glom
     #   jsonschema
+    #   kytos
     #   kytos-mef-eline
     #   pytest
 backcall==0.1.0
@@ -128,7 +129,7 @@ ipython==8.1.1
     # via kytos
 isodate==0.6.1
     # via
-    #   kytos-mef-eline
+    #   kytos
     #   openapi-core
 isort==5.10.1
     # via
@@ -151,18 +152,18 @@ jinja2==3.1.2
 jsonschema==4.17.3
     # via
     #   jsonschema-spec
-    #   kytos-mef-eline
+    #   kytos
     #   openapi-schema-validator
     #   openapi-spec-validator
 jsonschema-spec==0.1.4
     # via
-    #   kytos-mef-eline
+    #   kytos
     #   openapi-core
     #   openapi-spec-validator
 lazy-object-proxy==1.7.1
     # via
     #   astroid
-    #   kytos-mef-eline
+    #   kytos
     #   openapi-spec-validator
 lockfile==0.12.2
     # via
@@ -180,20 +181,20 @@ mccabe==0.6.1
     # via pylint
 more-itertools==8.12.0
     # via
-    #   kytos-mef-eline
+    #   kytos
     #   openapi-core
 mypy-extensions==0.4.3
     # via black
 openapi-core==0.16.6
-    # via kytos-mef-eline
+    # via kytos
 openapi-schema-validator==0.4.4
     # via
-    #   kytos-mef-eline
+    #   kytos
     #   openapi-core
     #   openapi-spec-validator
 openapi-spec-validator==0.5.6
     # via
-    #   kytos-mef-eline
+    #   kytos
     #   openapi-core
 packaging==21.3
     # via
@@ -201,7 +202,7 @@ packaging==21.3
     #   tox
 parse==1.19.0
     # via
-    #   kytos-mef-eline
+    #   kytos
     #   openapi-core
 parso==0.6.2
     # via
@@ -210,7 +211,7 @@ parso==0.6.2
 pathable==0.4.3
     # via
     #   jsonschema-spec
-    #   kytos-mef-eline
+    #   kytos
     #   openapi-core
 pathspec==0.9.0
     # via black
@@ -270,7 +271,7 @@ pyparsing==3.0.6
 pyrsistent==0.18.0
     # via
     #   jsonschema
-    #   kytos-mef-eline
+    #   kytos
 pytest==7.0.0
     # via
     #   kytos-mef-eline
@@ -298,12 +299,12 @@ pytz==2021.3
 pyyaml==6.0
     # via
     #   jsonschema-spec
-    #   kytos-mef-eline
+    #   kytos
 requests==2.27.0
     # via kytos-mef-eline
 rfc3339-validator==0.1.4
     # via
-    #   kytos-mef-eline
+    #   kytos
     #   openapi-schema-validator
 six==1.16.0
     # via
@@ -347,7 +348,6 @@ typing-extensions>=4.0.1
     #   janus
     #   jsonschema-spec
     #   kytos
-    #   kytos-mef-eline
     #   openapi-core
     #   pydantic
     #   pylint
@@ -373,7 +373,6 @@ werkzeug==2.0.3
     # via
     #   flask
     #   kytos
-    #   kytos-mef-eline
     #   openapi-core
 wheel==0.37.1
     # via pip-tools

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/dev.txt requirements/dev.in
 #
--e git+https://github.com/kytos-ng/kytos.git@feat/openapi_decorator#egg=kytos
+-e git+https://github.com/kytos-ng/kytos.git#egg=kytos
     # via -r requirements/dev.in
 -e .
     # via -r requirements/dev.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/dev.txt requirements/dev.in
 #
--e git+https://github.com/kytos-ng/kytos.git#egg=kytos
+-e git+https://github.com/kytos-ng/kytos.git@feat/openapi_decorator#egg=kytos
     # via -r requirements/dev.in
 -e .
     # via -r requirements/dev.in

--- a/requirements/run.in
+++ b/requirements/run.in
@@ -1,4 +1,3 @@
 apscheduler==3.8.0
 requests==2.27.0
 glom==20.11.0
-openapi-core==0.16.6

--- a/requirements/run.txt
+++ b/requirements/run.txt
@@ -7,9 +7,7 @@
 apscheduler==3.8.0
     # via -r requirements/run.in
 attrs==21.4.0
-    # via
-    #   glom
-    #   jsonschema
+    # via glom
 boltons==21.0.0
     # via
     #   face
@@ -24,62 +22,18 @@ glom==20.11.0
     # via -r requirements/run.in
 idna==3.3
     # via requests
-isodate==0.6.1
-    # via openapi-core
-jsonschema==4.17.3
-    # via
-    #   jsonschema-spec
-    #   openapi-schema-validator
-    #   openapi-spec-validator
-jsonschema-spec==0.1.4
-    # via
-    #   openapi-core
-    #   openapi-spec-validator
-lazy-object-proxy==1.7.1
-    # via openapi-spec-validator
-more-itertools==8.12.0
-    # via openapi-core
-openapi-core==0.16.6
-    # via -r requirements/run.in
-openapi-schema-validator==0.4.4
-    # via
-    #   openapi-core
-    #   openapi-spec-validator
-openapi-spec-validator==0.5.6
-    # via openapi-core
-parse==1.19.0
-    # via openapi-core
-pathable==0.4.3
-    # via
-    #   jsonschema-spec
-    #   openapi-core
-pyrsistent==0.18.0
-    # via jsonschema
 pytz==2021.3
     # via
     #   apscheduler
     #   tzlocal
-pyyaml==6.0
-    # via jsonschema-spec
 requests==2.27.0
     # via -r requirements/run.in
-rfc3339-validator==0.1.4
-    # via openapi-schema-validator
 six==1.16.0
-    # via
-    #   apscheduler
-    #   isodate
-    #   rfc3339-validator
-typing-extensions>=4.0.1
-    # via
-    #   jsonschema-spec
-    #   openapi-core
+    # via apscheduler
 tzlocal==2.1
     # via apscheduler
 urllib3==1.26.7
     # via requests
-werkzeug==2.0.3
-    # via openapi-core
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/utils.py
+++ b/utils.py
@@ -1,16 +1,4 @@
 """Utility functions."""
-import functools
-from pathlib import Path
-
-from flask import request
-from openapi_core.contrib.flask import FlaskOpenAPIRequest
-from openapi_core.spec.shortcuts import create_spec
-from openapi_core.validation.request import openapi_request_validator
-from openapi_spec_validator import validate_spec
-from openapi_spec_validator.readers import read_from_filename
-from werkzeug.exceptions import BadRequest, UnsupportedMediaType
-
-from kytos.core import log
 from kytos.core.events import KytosEvent
 
 
@@ -66,65 +54,3 @@ def compare_uni_out_trace(uni, trace):
         uni.interface.port_number == trace["out"].get("port")
         and uni_vlan == trace["out"].get("vlan")
     )
-
-
-def load_spec():
-    """Validate openapi spec."""
-    napp_dir = Path(__file__).parent
-    yml_file = napp_dir / "openapi.yml"
-    spec_dict, _ = read_from_filename(yml_file)
-
-    validate_spec(spec_dict)
-
-    return create_spec(spec_dict)
-
-
-def validate(spec):
-    """Decorator to validate a REST endpoint input.
-
-    Uses the schema defined in the openapi.yml file
-    to validate.
-    """
-
-    def validate_decorator(func):
-        @functools.wraps(func)
-        def wrapper_validate(*args, **kwargs):
-            try:
-                data = request.get_json()
-            except BadRequest:
-                result = "The request body is not a well-formed JSON."
-                log.debug("create_circuit result %s %s", result, 400)
-                raise BadRequest(result) from BadRequest
-            if data is None:
-                result = "The request body mimetype is not application/json."
-                log.debug("update result %s %s", result, 415)
-                raise UnsupportedMediaType(result)
-
-            openapi_request = FlaskOpenAPIRequest(request)
-            result = openapi_request_validator.validate(spec, openapi_request)
-            if result.errors:
-                error_response = (
-                    "The request body contains invalid API data."
-                )
-                errors = result.errors[0]
-                if hasattr(errors, "schema_errors"):
-                    schema_errors = errors.schema_errors[0]
-                    error_log = {
-                        "error_message": schema_errors.message,
-                        "error_validator": schema_errors.validator,
-                        "error_validator_value": schema_errors.validator_value,
-                        "error_path": list(schema_errors.path),
-                        "error_schema": schema_errors.schema,
-                        "error_schema_path": list(schema_errors.schema_path),
-                    }
-                    log.debug("Invalid request (API schema): %s", error_log)
-                    error_response += f" {schema_errors.message} for field"
-                    error_response += (
-                        f" {'/'.join(map(str,schema_errors.path))}."
-                    )
-                raise BadRequest(error_response) from BadRequest
-            return func(*args, data=data, **kwargs)
-
-        return wrapper_validate
-
-    return validate_decorator


### PR DESCRIPTION
Related and depends on https://github.com/kytos-ng/kytos/pull/352

### Summary

See updated changelog file

### Local Tests

- Tried to create an invalid circuit

```
{
    "code": 400,
    "description": "The request body contains invalid API data. 1 is not of type 'string' for field uni_a/interface_id.",
    "name": "Bad Request"
}
```

- Also created a valid circuit:

```
{
    "circuit_id": "760f1c9135264d"
}
```

### End-to-End Tests

Reran https://github.com/kytos-ng/kytos-end-to-end-tests/pull/218 using this branch with `kytos` branch `feat/openapi_decorator` selecting these two relevant tests:

```
+ python3 -m pytest tests/ -k test_026_validate_bad_request_response_format
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /tests
plugins: timeout-2.0.2
collected 224 items / 223 deselected / 1 selected

tests/test_e2e_11_mef_eline.py .                                         [100%]

=============================== warnings summary ===============================
========== 1 passed, 223 deselected, 51 warnings in 65.44s (0:01:05) ===========


+ python3 -m pytest tests/ -k test_025_should_fail_due_to_invalid_attribute_on_payload
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /tests
plugins: timeout-2.0.2
collected 224 items / 223 deselected / 1 selected

tests/test_e2e_11_mef_eline.py .                                         [100%]

========== 1 passed, 223 deselected, 51 warnings in 66.24s (0:01:06) ===========
```
