### PR TITLE
Update openapi to be used by requests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Changed
 - ``dl_vlan`` value is mapped to an integer in range [1, 4095] for the ``/traces`` requests to ``sdntrace_cp``
 - Augmented ``GET /v2/evc/`` to accept parameters ``metadata.key=item``
 - Upgraded ``openapi-core`` to ``0.16.6`` from ``0.14.5``.
+- Changed ``openapi.yml`` to be used as validation spec for request related methods ``updated()``, ``create_schedule()`` and ``update_schedule()``.
 
 Removed
 =======

--- a/models/evc.py
+++ b/models/evc.py
@@ -167,7 +167,9 @@ class EVCBase(GenericEntity):
         """Update evc attributes.
 
         This method will raises an error trying to change the following
-        attributes: [name, uni_a and uni_z]
+        attributes: [creation_time, active, current_path, failover_path,
+        _id, archived]
+        [name, uni_a and uni_z]
 
         Returns:
             the values for enable and a redeploy attribute, if exists and None

--- a/openapi.yml
+++ b/openapi.yml
@@ -90,7 +90,8 @@ paths:
     patch:
       summary: Update a circuit
       description: Update a circuit based on payload. The EVC required
-        attributes (name, uni_a, uni_z) can't be updated.
+        attributes (creation_time, active, current_path,
+        failover_path, _id, archived) can't be updated.
       operationId: update
       parameters:
         - name: circuit_id
@@ -446,7 +447,7 @@ components:
           type: boolean
         metadata:
           type: object
-    NewLink:
+    NewLink: # Can be referenced via '#/components/schemas/NewLink'
       type: object
       required:
         - endpoint_a
@@ -482,7 +483,6 @@ components:
     Link: # Can be referenced via '#/components/schemas/Link'
       type: object
       required:
-        - id
         - endpoint_a
         - endpoint_b
       properties:
@@ -593,11 +593,6 @@ components:
           example: "Bill"
     Circuit: # Can be referenced via '#/components/schemas/Circuit'
       type: object
-      required:
-        - id
-        - name
-        - uni_a
-        - uni_z
       properties:
         id:
           type: integer
@@ -630,13 +625,21 @@ components:
             $ref: '#/components/schemas/Path'
 
         current_path:
-          $ref: '#/components/schemas/Path'
+          type: array
+          items:
+            $ref: '#/components/schemas/NewLink'
         failover_path:
-          $ref: '#/components/schemas/Path'
+          type: array
+          items:
+            $ref: '#/components/schemas/NewLink'
         primary_path:
-          $ref: '#/components/schemas/Path'
+          type: array
+          items:
+            $ref: '#/components/schemas/NewLink'
         backup_path:
-          $ref: '#/components/schemas/Path'
+          type: array
+          items:
+            $ref: '#/components/schemas/NewLink'
         primary_constraints:
           $ref: '#/components/schemas/PathConstraints'
         secondary_constraints:
@@ -701,9 +704,6 @@ components:
     CircuitSchedule: # Can be referenced via '#/components/schemas/CircuitSchedule'
       type: object
       properties:
-        id:
-          type: integer
-          format: int32
         date:
           type: string
           format: date-time
@@ -717,21 +717,22 @@ components:
   #------------------------------------------
   # Reusable schemas for request or responses
   #------------------------------------------
-    NewCircuitSchedule:
+    NewCircuitSchedule: # Can be referenced via '#/components/schemas/NewCircuitSchedule'
       type: object
+      required:
+        - circuit_id
+        - schedule
       properties:
         circuit_id:
-          type: integer
-          format: int32
+          type: string
         schedule: {
             "$ref": "#/components/schemas/CircuitSchedule"
         }
-    CircuitScheduleList:
+    CircuitScheduleList: # Can be referenced via '#/components/schemas/CircuitScheduleList'
       type: object
       properties:
         circuit_id:
-          type: integer
-          format: int32
+          type: string
         schedule_id:
           type: integer
           format: int32


### PR DESCRIPTION
Closes #291 
Closes #306

### Summary

Updated `openapi.yml` to be used by the endpoints:
```
@rest("/v2/evc/<circuit_id>", methods=["PATCH"])
@rest("/v2/evc/schedule/", methods=["POST"])
@rest("/v2/evc/schedule/<schedule_id>", methods=["PATCH"])
```

### Local Tests

Use the rest endpoints listed before to test results. Also ran unit tests which covers error codes.

### End-to-End Tests
```
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 26%]
tests/test_e2e_11_mef_eline.py ......                                    [ 29%]
tests/test_e2e_12_mef_eline.py .....xx.                                  [ 32%]
tests/test_e2e_13_mef_eline.py .....xs.s......xs.s.XXxX.xxxx..x......... [ 50%]
...                                                                      [ 51%]
tests/test_e2e_14_mef_eline.py x                                         [ 52%]
tests/test_e2e_15_mef_eline.py ..                                        [ 53%]
tests/test_e2e_20_flow_manager.py .....................                  [ 62%]
tests/test_e2e_21_flow_manager.py ...                                    [ 63%]
tests/test_e2e_22_flow_manager.py ...............                        [ 70%]
tests/test_e2e_23_flow_manager.py ..............                         [ 76%]
tests/test_e2e_30_of_lldp.py ....                                        [ 78%]
tests/test_e2e_31_of_lldp.py ...                                         [ 79%]
tests/test_e2e_32_of_lldp.py ...                                         [ 81%]
tests/test_e2e_40_sdntrace.py ...........                                [ 85%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 89%]
tests/test_e2e_50_maintenance.py ........................                [100%]
```
