### PR TITLE
feature: Update `v1` on routes of `sdntrace_cp`

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -10,7 +10,7 @@ MANAGER_URL = "http://localhost:8181/api/kytos/flow_manager/v2"
 TOPOLOGY_URL = "http://localhost:8181/api/kytos/topology/v3"
 
 # Base URL of SDN trace CP
-SDN_TRACE_CP_URL = "http://localhost:8181/api/amlight/sdntrace_cp"
+SDN_TRACE_CP_URL = "http://localhost:8181/api/amlight/sdntrace_cp/v1"
 
 # EVC consistency interval
 DEPLOY_EVCS_INTERVAL = 60


### PR DESCRIPTION
Related to [PR of sdntrace_cp](https://github.com/kytos-ng/sdntrace_cp/pull/93)

### Summary

Add `v1` on routes of `sdntrace_cp`

### Local Tests

I made sure `/traces` is called correctly:

```
2023-04-11 19:12:15,082 - INFO [kytos.napps.kytos/mef_eline] (mef_eline) EVC(6875c026f20a4b, epl) was deployed.
2023-04-11 19:12:15,083 - INFO [kytos.napps.kytos/mef_eline] (mef_eline) EVC(5b1147f173c84a, epl) enabled but inactive - redeploy

```

### End-to-End Tests

N/A