### PR TITLE
feat: Utility function to split a vlan range

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -71,13 +71,20 @@ class TestUtils(TestCase):
 
     def test_get_vlan_tags_and_masks(self):
         """Test get_vlan_tags_and_masks"""
-        expected = [
-            (101, 4095),
-            (102, 4094),
-            (104, 4088),
-            (112, 4080),
-            (128, 4032),
-            (192, 4088),
-            (200, 4095),
+        vlan_ranges = [[101, 200], [101, 90], [34, 34]]
+        expecteds = [
+            [
+                (101, 4095),
+                (102, 4094),
+                (104, 4088),
+                (112, 4080),
+                (128, 4032),
+                (192, 4088),
+                (200, 4095),
+            ],
+            [],
+            [(34, 4095)],
         ]
-        assert get_vlan_tags_and_masks(101, 200) == expected
+        for vlan_range, expected in zip(vlan_ranges, expecteds):
+            with self.subTest(range=vlan_range, expected=expected):
+                assert get_vlan_tags_and_masks(*vlan_range) == expected

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -3,7 +3,10 @@ from unittest import TestCase
 from unittest.mock import MagicMock
 
 from napps.kytos.mef_eline.utils import (
-    compare_endpoint_trace, compare_uni_out_trace, map_dl_vlan
+    compare_endpoint_trace,
+    compare_uni_out_trace,
+    get_vlan_tags_and_masks,
+    map_dl_vlan,
 )
 
 
@@ -61,7 +64,20 @@ class TestUtils(TestCase):
 
     def test_map_dl_vlan(self):
         """Test map_dl_vlan"""
-        cases = {0: None, 'untagged': None, 'any': 1, '4096/4096': 1, 10: 10}
+        cases = {0: None, "untagged": None, "any": 1, "4096/4096": 1, 10: 10}
         for value, mapped in cases.items():
             result = map_dl_vlan(value)
             assert result == mapped
+
+    def test_get_vlan_tags_and_masks(self):
+        """Test get_vlan_tags_and_masks"""
+        expected = [
+            (101, 4095),
+            (102, 4094),
+            (104, 4088),
+            (112, 4080),
+            (128, 4032),
+            (192, 4088),
+            (200, 4095),
+        ]
+        assert get_vlan_tags_and_masks(101, 200) == expected

--- a/utils.py
+++ b/utils.py
@@ -70,3 +70,23 @@ def compare_uni_out_trace(uni, trace):
         uni.interface.port_number == trace["out"].get("port")
         and uni_vlan == trace["out"].get("vlan")
     )
+
+
+def max_power2_divisor(number: int, limit: int = 4096) -> int:
+    """Get the max power of 2 that is divisor of number"""
+    while number % limit > 0:
+        limit //= 2
+    return limit
+
+
+def get_vlan_tags_and_masks(start: int, end: int) -> list[tuple[int, int]]:
+    """Get the minimum number of vlan/mask pairs for a given range."""
+    limit = end + 1
+    tags_and_masks = []
+    while start < limit:
+        divisor = max_power2_divisor(start)
+        while divisor > limit - start:
+            divisor //= 2
+        tags_and_masks.append((start, 4096-divisor))
+        start += divisor
+    return tags_and_masks


### PR DESCRIPTION
Fixes #308 

Create a function to split a vlan range into the minimum number of possible vlan/mask pairs.
At each step, finds the maximum power of 2 that divides the first remaining tag of the range, without going beyond the end of the range.