### PR TITLE
feat: Add vlan range support to DB models

### DIFF
--- a/db/models.py
+++ b/db/models.py
@@ -2,6 +2,7 @@
 # pylint: disable=unused-argument,invalid-name,unused-argument
 # pylint: disable=no-self-argument,no-name-in-module
 
+import re
 from datetime import datetime
 from typing import Dict, List, Literal, Optional, Union
 
@@ -47,14 +48,9 @@ class TAGDoc(BaseModel):
             return value
         if isinstance(value, str) and value in ("any", "untagged"):
             return value
-        if isinstance(value, str):
-            tags = value.split("-")
-            try:
-                values = list(map(int, tags))
-                if len(tags) == 2 and values[1] >= values[0]:
-                    return value
-            except ValueError:
-                pass
+        if (isinstance(value, str) and
+                re.match(r"^\d+(-\d+)?(,\d+(-\d+)?)*$", value)):
+            return value
         raise ValueError(f"{value} is not allowed as {type(value)}. " +
                          "Allowed strings are 'any' and 'untagged' " +
                          "or '<int>-<int>'.")

--- a/db/models.py
+++ b/db/models.py
@@ -47,8 +47,17 @@ class TAGDoc(BaseModel):
             return value
         if isinstance(value, str) and value in ("any", "untagged"):
             return value
+        if isinstance(value, str):
+            tags = value.split("-")
+            try:
+                values = list(map(int, tags))
+                if len(tags) == 2 and values[1] >= values[0]:
+                    return value
+            except ValueError:
+                pass
         raise ValueError(f"{value} is not allowed as {type(value)}. " +
-                         "Allowed strings are 'any' and 'untagged'.")
+                         "Allowed strings are 'any' and 'untagged' " +
+                         "or '<int>-<int>'.")
 
 
 class UNIDoc(BaseModel):

--- a/tests/unit/test_db_models.py
+++ b/tests/unit/test_db_models.py
@@ -80,6 +80,10 @@ class TestDBModels(TestCase):
         tag = TAGDoc(**tag_range)
         assert tag.value == "23-45"
 
+        tag_range = {"tag_type": 1, "value": "43-54,98,101-200"}
+        tag = TAGDoc(**tag_range)
+        assert tag.value == "43-54,98,101-200"
+
     def test_tagdoc_fail(self):
         """Test TAGDoc value fail case"""
         tag_fail = {"tag_type": 1, "value": "test_fail"}
@@ -88,7 +92,7 @@ class TestDBModels(TestCase):
 
     def test_tagdoc_fail_range(self):
         """Test TAGDoc ranges fail cases"""
-        tag_fail = {"tag_type": 1, "value": "67-54"}
+        tag_fail = {"tag_type": 1, "value": "43,32-67-54"}
         with self.assertRaises(ValueError):
             TAGDoc(**tag_fail)
 

--- a/tests/unit/test_db_models.py
+++ b/tests/unit/test_db_models.py
@@ -74,8 +74,24 @@ class TestDBModels(TestCase):
         assert tag.tag_type == 1
         assert tag.value == "any"
 
+    def test_tagdoc_range(self):
+        """Test TAGDoc ranges"""
+        tag_range = {"tag_type": 1, "value": "23-45"}
+        tag = TAGDoc(**tag_range)
+        assert tag.value == "23-45"
+
     def test_tagdoc_fail(self):
         """Test TAGDoc value fail case"""
         tag_fail = {"tag_type": 1, "value": "test_fail"}
+        with self.assertRaises(ValueError):
+            TAGDoc(**tag_fail)
+
+    def test_tagdoc_fail_range(self):
+        """Test TAGDoc ranges fail cases"""
+        tag_fail = {"tag_type": 1, "value": "67-54"}
+        with self.assertRaises(ValueError):
+            TAGDoc(**tag_fail)
+
+        tag_fail = {"tag_type": 1, "value": "ra-65"}
         with self.assertRaises(ValueError):
             TAGDoc(**tag_fail)


### PR DESCRIPTION
Modify `TAGDoc` validation allowing a string with `<int>-<int>` format.

Fixes #318