### PR TITLE
fix: removed support for `desired_links` on path constraints and reverted pathfinder#37 workaround

### DIFF
--- a/db/models.py
+++ b/db/models.py
@@ -74,7 +74,6 @@ class PathConstraints(BaseModel):
     mandatory_metrics: Optional[LinkConstraints]
     flexible_metrics: Optional[LinkConstraints]
     minimum_flexible_hits: Optional[int]
-    desired_links: Optional[List[str]]
     undesired_links: Optional[List[str]]
 
 

--- a/models/path.py
+++ b/models/path.py
@@ -115,15 +115,6 @@ class DynamicPathManager:
     @staticmethod
     def get_paths(circuit, max_paths=2, **kwargs):
         """Get a valid path for the circuit from the Pathfinder."""
-        # pylint: disable=fixme
-        # XXX: temporary workaround for kytos-ng/pathfinder#37
-        if (
-            len(circuit.secondary_constraints.get('undesired_links', [])) > 0
-            or len(circuit.secondary_constraints.get('desired_links', [])) > 0
-            or len(circuit.primary_constraints.get('undesired_links', [])) > 0
-            or len(circuit.primary_constraints.get('desired_links', [])) > 0
-        ):
-            max_paths += 10
         endpoint = settings.PATHFINDER_URL
         request_data = {
             "source": circuit.uni_a.interface.id,

--- a/models/path.py
+++ b/models/path.py
@@ -128,7 +128,7 @@ class DynamicPathManager:
             log.error(
                 "Failed to get paths at %s. Returned %s",
                 endpoint,
-                api_reply.status_code,
+                api_reply.text,
             )
             return None
         reply_data = api_reply.json()

--- a/openapi.yml
+++ b/openapi.yml
@@ -508,14 +508,6 @@ components:
     PathConstraints:
       type: object
       properties:
-        desired_links:
-          type: array
-          description: List of link IDs that should be in the path, included as a logical AND.
-          items:
-            type: string
-          example:
-            - '2bd01b0d-c875-4263-ad38-fec0b2999582'
-            - 'c41f6249-3ea6-4aba-a083-08049face1e2'
         undesired_links:
           type: array
           description: List of link IDs that should not be in the path, excluded as a logical OR.

--- a/settings.py
+++ b/settings.py
@@ -1,7 +1,7 @@
 """Settings for the mef_eline NApp."""
 
 # Base URL of the Pathfinder endpoint
-PATHFINDER_URL = "http://localhost:8181/api/kytos/pathfinder/v2/"
+PATHFINDER_URL = "http://localhost:8181/api/kytos/pathfinder/v3/"
 
 # Base URL of the Flow Manager endpoint
 MANAGER_URL = "http://localhost:8181/api/kytos/flow_manager/v2"

--- a/tests/unit/models/test_path.py
+++ b/tests/unit/models/test_path.py
@@ -426,7 +426,7 @@ class TestDynamicPathManager(TestCase):
             [link.id for link in expected_paths_1]
         )
         expected_call = call(
-            "http://localhost:8181/api/kytos/pathfinder/v2/",
+            "http://localhost:8181/api/kytos/pathfinder/v3/",
             json={
                 **{
                     "source": circuit.uni_a.interface.id,
@@ -626,7 +626,7 @@ class TestDynamicPathManager(TestCase):
 
         max_paths = 10
         expected_call = call(
-            "http://localhost:8181/api/kytos/pathfinder/v2/",
+            "http://localhost:8181/api/kytos/pathfinder/v3/",
             json={
                 **{
                     "source": evc.uni_a.interface.id,

--- a/ui/k-info-panel/show_circuit.kytos
+++ b/ui/k-info-panel/show_circuit.kytos
@@ -144,19 +144,6 @@
               <tbody>
               <tr><th>{{constraint_labels[p_constraint_index]}}</th></tr>
               <tr><td>
-                <div id="mef-constraints-desired-links">
-                  <table class="table">
-                    <tr><th>{{constraint_labels['desired_links']}}</th>
-                    </tr>
-                    <tr>
-                    <td>
-                      <k-select :options="get_link_options()"
-                      :value.sync=p_constraint.desired_links>
-                      </k-select>
-                    </td>
-                    </tr>
-                  </table>
-                </div>
                 <div id="mef-constraints-undesired-links">
                   <table class="table">
                     <tr><th>{{constraint_labels['undesired_links']}}</th></tr>
@@ -646,7 +633,6 @@ module.exports = {
       this.constraint_labels = {
         'primary_constraints': 'Primary Constraints',
         'secondary_constraints': 'Secondary Constraints',
-        'desired_links': 'Desired links',
         'undesired_links': 'Undesired links',
         'spf_attribute': 'SPF attribute',
         'spf_max_path_cost': 'SPF max path cost',
@@ -670,7 +656,6 @@ module.exports = {
       let _constraint = {};
       if(data) {
         _constraint = {
-          'desired_links': data['desired_links'],
           'undesired_links': data['undesired_links'],
           'spf_attribute': data['spf_attribute'],
           'spf_max_path_cost': data['spf_max_path_cost'],
@@ -784,12 +769,6 @@ module.exports = {
       ['primary_constraints', 'secondary_constraints'].forEach(_type => {
         payload[_type] = {};
         // Dropdown forms
-        payload[_type].desired_links = [];
-        if(this.constraints[_type].desired_links && this.constraints[_type].desired_links.length > 0) {
-          payload[_type].desired_links = [].concat(
-            this.constraints[_type].desired_links.filter(item => typeof(item) == "string")
-          );
-        }
         payload[_type].undesired_links = [];
         if(this.constraints[_type].undesired_links && this.constraints[_type].undesired_links.length > 0) {
           payload[_type].undesired_links = [].concat(
@@ -874,7 +853,6 @@ module.exports = {
     }
     ['primary_constraints', 'secondary_constraints'].forEach( s => {
         _this.form_constraints[s] = {
-          'desired_links': '',
           'undesired_links': '',
           'spf_attribute': '',
           'spf_max_path_cost': '',

--- a/ui/k-info-panel/show_circuit.kytos
+++ b/ui/k-info-panel/show_circuit.kytos
@@ -142,9 +142,9 @@
           <div class="mef-circuit-table mef-circuit-table-constraints">
             <table class="table">
               <tbody>
-              <tr><th>{{constraint_labels[p_constraint_index]}}</th></tr>
+              <th>{{constraint_labels[p_constraint_index]}}</th>
               <tr><td>
-                <div id="mef-constraints-undesired-links">
+                <div>
                   <table class="table">
                     <tr><th>{{constraint_labels['undesired_links']}}</th></tr>
                     <tr>
@@ -825,10 +825,10 @@ module.exports = {
         _this.$kytos.$emit("setNotification" , notification);
         _this.loadEVC(_this.content.id);
       });
-      request.fail(function( jqXHR, textStatus ) {
+      request.fail(function(data) {
         let notification = {
           title: 'Update EVC failed',
-          description: 'Error updating EVC ' + id +'. ' + textStatus
+          description: 'Error updating EVC ' + id +'. ' + data.responseJSON.description
         }
         _this.$kytos.$emit("setNotification" , notification);
       });
@@ -985,17 +985,8 @@ module.exports = {
     clear:both; 
     width:540px;
   }
-  .mef-circuit-table-constraints #mef-constraints-desired-links {
-    float: left;
-    width: 255px;
-  }
-  .mef-circuit-table-constraints #mef-constraints-undesired-links {
-    float: left;
-    margin-left: 10px;
-    width: 255px;
-  }
   .mef-circuit-table-constraints #mef-constraints-spf {
-    width: 300px;
+    width: 400px;
   }
   .mef-circuit-table-constraints #mef-constraints-spf th {
     width: 130px;

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -81,10 +81,6 @@
             <k-accordion-item :title="constraint_titles[constraint]"
              v-if="false">
 
-                <k-select :title="constraint_titles.desired_links"
-                :options="get_link_options()"
-                :value.sync="form_constraints[constraint].desired_links"></k-select>
-
                 <k-select :title="constraint_titles.undesired_links" :options="get_link_options()"
                 :value.sync ="form_constraints[constraint].undesired_links"></k-select>
                 
@@ -294,7 +290,6 @@ module.exports = {
       this.constraint_titles = {
         'primary_constraints': 'Primary Constraints',
         'secondary_constraints': 'Secondary Constraints',
-        'desired_links': 'Desired links',
         'undesired_links': 'Undesired links',
         'spf_attribute': 'SPF attribute',
         'spf_max_path_cost': 'SPF max path cost',
@@ -310,7 +305,6 @@ module.exports = {
 
       let _constraint = {};
       _constraint = {
-        'desired_links': '',
         'undesired_links': '',
         'spf_attribute': '',
         'spf_max_path_cost': '',
@@ -431,9 +425,6 @@ module.exports = {
           });
 
           // Dropdown forms
-          if(this.form_constraints[_type].desired_links) {
-            request[_type].desired_links = this.form_constraints[_type].desired_links.filter(item => typeof(item) == "string");
-          }
           if(this.form_constraints[_type].undesired_links) {
             request[_type].undesired_links = this.form_constraints[_type].undesired_links.filter(item => typeof(item) == "string");
           }


### PR DESCRIPTION
Closes #296

This depends on https://github.com/kytos-ng/pathfinder/pull/47

### Summary

See updated changelog file

### Local Tests

- Provisioned an EPL and also double checked it was correctly displayed in the UI

![20230510_210232](https://github.com/kytos-ng/mef_eline/assets/1010796/20a9d0c1-3e26-41c7-8b08-50a05279cdf5)


### End-to-End Tests

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.0.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 227 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 26%]
tests/test_e2e_11_mef_eline.py ......                                    [ 29%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 32%]
tests/test_e2e_13_mef_eline.py .....xs.s......xs.s.XXxX.xxxx..X......... [ 50%]
...                                                                      [ 51%]
tests/test_e2e_14_mef_eline.py x                                         [ 52%]
tests/test_e2e_15_mef_eline.py ..                                        [ 53%]
tests/test_e2e_20_flow_manager.py ......................                 [ 62%]
tests/test_e2e_21_flow_manager.py ...                                    [ 63%]
tests/test_e2e_22_flow_manager.py ...............                        [ 70%]
tests/test_e2e_23_flow_manager.py ..............                         [ 76%]
tests/test_e2e_30_of_lldp.py ....                                        [ 78%]
tests/test_e2e_31_of_lldp.py ...                                         [ 79%]
tests/test_e2e_32_of_lldp.py ...                                         [ 81%]
tests/test_e2e_40_sdntrace.py ...........                                [ 85%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 89%]
tests/test_e2e_50_maintenance.py ........................                [100%]
=============================== warnings summary ===============================
= 205 passed, 6 skipped, 11 xfailed, 5 xpassed, 799 warnings in 10444.28s (2:54:04) 
```