### PR TITLE
Fix not nullable value for constraint fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,7 @@ Changed
 - Changed ``openapi.yml`` to be used as validation spec for request related methods ``updated()``, ``create_schedule()`` and ``update_schedule()``.
 - ``mef_eline`` now supports table group settings from ``of_multi_table``
 - Changed increasing amount of flows being sent, now it is fixed. Amount can be changed on ``settings.BATCH_SIZE``
+- Changed ui constraints default values to pass the spec validation
 
 General Information
 ===================

--- a/openapi.yml
+++ b/openapi.yml
@@ -428,7 +428,6 @@ components:
         sb_priority:
           type: integer
           nullable: true
-          x-nullable: true
           format: int32
           description: "Southbound priority value"
           minimum: 0
@@ -442,7 +441,6 @@ components:
         queue_id:
           type: integer
           nullable: true
-          x-nullable: true
           format: int32
           description: "QoS Egress Queue ID"
           minimum: 0

--- a/openapi.yml
+++ b/openapi.yml
@@ -427,6 +427,8 @@ components:
             $ref: '#/components/schemas/CircuitSchedule'
         sb_priority:
           type: integer
+          nullable: true
+          x-nullable: true
           format: int32
           description: "Southbound priority value"
           minimum: 0
@@ -439,6 +441,8 @@ components:
           maximum: 7
         queue_id:
           type: integer
+          nullable: true
+          x-nullable: true
           format: int32
           description: "QoS Egress Queue ID"
           minimum: 0
@@ -654,6 +658,7 @@ components:
         sb_priority:
           type: integer
           format: int32
+          nullable: true
           description: "Southbound priority value"
           minimum: 0
         service_level:
@@ -666,6 +671,7 @@ components:
         queue_id:
           type: integer
           format: int32
+          nullable: true
           description: "QoS Egress Queue ID"
           minimum: 0
           maximum: 7

--- a/ui/k-info-panel/show_circuit.kytos
+++ b/ui/k-info-panel/show_circuit.kytos
@@ -743,9 +743,9 @@ module.exports = {
         name: this.basics["Name"]["value"],
         enable: this.flags["Enabled"]["value"],
         dynamic_backup_path: this.flags["Dynamic backup path"]["value"],                
-        sb_priority: parseInt(this.others["Southbound priority"]["value"]) || 0,
+        sb_priority: parseInt(this.others["Southbound priority"]["value"]) || null,
         bandwidth: parseInt(this.others["Bandwidth"]["value"]) || 0,
-        queue_id: parseInt(this.others["Queue"]["value"]) || 0,
+        queue_id: parseInt(this.others["Queue"]["value"]) || null,
         service_level: parseInt(this.others["Service level"]["value"]) || 0,
         uni_a: {
           interface_id: this.endpoints_data["DPID"][0]["value"],
@@ -754,7 +754,7 @@ module.exports = {
           interface_id: this.endpoints_data["DPID"][1]["value"],
         },
       };
-
+      
       // Tag is optional
       if(this.endpoints_data["VLAN"][0]["value"]) {
         payload["uni_a"]["tag"] = {
@@ -772,11 +772,6 @@ module.exports = {
       ['primary_constraints', 'secondary_constraints'].forEach(_type => {
         let _constraint_payload = {}; 
         // Dropdown forms
-        if(this.constraints[_type].desired_links !== undefined && this.constraints[_type].desired_links.length > 0) {
-          _constraint_payload.desired_links = [].concat(
-            this.constraints[_type].desired_links.filter(item => typeof(item) == "string")
-          );
-        }
         if(this.constraints[_type].undesired_links !== undefined && this.constraints[_type].undesired_links.length > 0) {
           _constraint_payload.undesired_links = [].concat(
             this.constraints[_type].undesired_links.filter(item => typeof(item) == "string")

--- a/ui/k-info-panel/show_circuit.kytos
+++ b/ui/k-info-panel/show_circuit.kytos
@@ -328,12 +328,15 @@ module.exports = {
        */
       let _this = this;
       let _result = [];
-      $.each(this.link_options, function(key, item){
-        let _item = {};
-        _item.value = item.value;
-        _item.description = item.description;
-        _result.push(_item);
-      });
+
+      if (this.link_options) {
+        $.each(this.link_options, function(key, item){
+          let _item = {};
+          _item.value = item.value;
+          _item.description = item.description;
+          _result.push(_item);
+        });
+      }
       return _result;
     },
     showInfoPanel: function() {
@@ -740,10 +743,10 @@ module.exports = {
         name: this.basics["Name"]["value"],
         enable: this.flags["Enabled"]["value"],
         dynamic_backup_path: this.flags["Dynamic backup path"]["value"],                
-        sb_priority: parseInt(this.others["Southbound priority"]["value"]),
-        bandwidth: this.others["Bandwidth"]["value"],
-        queue_id: this.others["Queue"]["value"],
-        service_level: this.others["Service level"]["value"],
+        sb_priority: parseInt(this.others["Southbound priority"]["value"]) || 0,
+        bandwidth: parseInt(this.others["Bandwidth"]["value"]) || 0,
+        queue_id: parseInt(this.others["Queue"]["value"]) || 0,
+        service_level: parseInt(this.others["Service level"]["value"]) || 0,
         uni_a: {
           interface_id: this.endpoints_data["DPID"][0]["value"],
         },
@@ -767,47 +770,53 @@ module.exports = {
       }
 
       ['primary_constraints', 'secondary_constraints'].forEach(_type => {
-        payload[_type] = {};
+        let _constraint_payload = {}; 
         // Dropdown forms
-        payload[_type].undesired_links = [];
-        if(this.constraints[_type].undesired_links && this.constraints[_type].undesired_links.length > 0) {
-          payload[_type].undesired_links = [].concat(
+        if(this.constraints[_type].desired_links !== undefined && this.constraints[_type].desired_links.length > 0) {
+          _constraint_payload.desired_links = [].concat(
+            this.constraints[_type].desired_links.filter(item => typeof(item) == "string")
+          );
+        }
+        if(this.constraints[_type].undesired_links !== undefined && this.constraints[_type].undesired_links.length > 0) {
+          _constraint_payload.undesired_links = [].concat(
             this.constraints[_type].undesired_links.filter(item => typeof(item) == "string")
           );
         }
-        if(this.constraints[_type].spf_attribute !== "") {
-          payload[_type].spf_attribute = this.constraints[_type].spf_attribute;
+        if(this.constraints[_type].spf_attribute !== undefined && this.constraints[_type].spf_attribute !== "") {
+          _constraint_payload.spf_attribute = this.constraints[_type].spf_attribute;
         }
 
         // Input forms
-        if(this.constraints[_type].spf_max_path_cost !== "") {
-          payload[_type].spf_max_path_cost = parseInt(this.constraints[_type].spf_max_path_cost);
+        if(this.constraints[_type].spf_max_path_cost !== undefined && this.constraints[_type].spf_max_path_cost !== "") {
+          _constraint_payload.spf_max_path_cost = parseInt(this.constraints[_type].spf_max_path_cost);
         }
-        if(this.constraints[_type].minimum_flexible_hits !== "") {
-          payload[_type].minimum_flexible_hits = parseInt(this.constraints[_type].minimum_flexible_hits);
+        if(this.constraints[_type].minimum_flexible_hits !== undefined && this.constraints[_type].minimum_flexible_hits !== "") {
+          _constraint_payload.minimum_flexible_hits = parseInt(this.constraints[_type].minimum_flexible_hits);
         }
 
         ['mandatory_metrics', 'flexible_metrics'].forEach(_metric_type => {
-          if(this.constraints[_type][_metric_type]) {
+          if(this.constraints[_type][_metric_type] !== undefined) {
             let metric = this.constraints[_type][_metric_type];
-            let _mandatory_metrics = {};
+            let _result_metrics = {};
             ['bandwidth', 'utilization', 'priority', 'delay', 'reliability'].forEach(_m => {
               if(metric[_m] !== undefined && metric[_m] !== '') {
-                _mandatory_metrics[_m] = parseInt(metric[_m]);
+                _result_metrics[_m] = parseInt(metric[_m]);
               } else {
                 //TODO: set the value to remove the metric (ex: 0, undefined, null, -1...)
-                //_mandatory_metrics[_m] = null;
+                  //_result_metrics[_m] = {};
               }
             });
             if(metric['ownership'] !== undefined) { // can be empty
-              _mandatory_metrics['ownership'] = metric['ownership'];
+              _result_metrics['ownership'] = metric['ownership'];
             }
-            
-            if(!$.isEmptyObject(_mandatory_metrics)) {
-              payload[_type][_metric_type] = _mandatory_metrics;
+            if(!$.isEmptyObject(_result_metrics)) {
+              _constraint_payload[_metric_type] = _result_metrics;
+            } else {
+              _constraint_payload[_metric_type] = {};
             }
           }
         });
+        payload[_type] = _constraint_payload;
       });
       $payload = payload;
 


### PR DESCRIPTION
Fixes #315

### Summary

Check constraint field values while building the payload. It should remove empty constraint attributes.
The following attributes´ default values: bandwidth, service_level were set to 0, and sb_priority and queue were set to null, as the API spec validation requires to be integer.

### Local test
Select the Mef-Eline item
Click the button "List Installed EVC"
Choose an EVC
 - Leave the Southbound priority, Bandwidth, Queue, Service level with empty values and save.
 - Change the values Southbound priority, Bandwidth, Queue, Service level and save.
