### PR TITLE
Added if statement for disabled intra EVC switch

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,7 +43,8 @@ Fixed
 - fixed ``minimum_flexible_hits`` EVC attribute to be persistent
 - fixed attribute list for path constraints to include ``reliability``
 - fixed unnecessary redeploy of an intra-switch EVC on link up events
-- fixed ``check_list_traces`` to work with the new version of SDN traces 
+- fixed ``check_list_traces`` to work with the new version of SDN traces
+- fixed updating EVC to be an intra-switch with invalid switch or interface
 
 General Information
 ===================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Changed
 - ``mef_eline`` now supports table group settings from ``of_multi_table``
 - Changed increasing amount of flows being sent, now it is fixed. Amount can be changed on ``settings.BATCH_SIZE``
 - Changed ui constraints default values to pass the spec validation
+- Changed intra-switch EVC with a disabled switch or interface is not longer allowed to be created
 
 General Information
 ===================

--- a/exceptions.py
+++ b/exceptions.py
@@ -19,3 +19,7 @@ class FlowModException(MEFELineException):
 
 class InvalidPath(MEFELineException):
     """Exception for invalid path."""
+
+
+class DisabledSwitch(MEFELineException):
+    """Exception for disabled switch in path"""

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ from threading import Lock
 from pydantic import ValidationError
 
 from kytos.core import KytosNApp, log, rest
+from kytos.core.common import EntityStatus
 from kytos.core.helpers import (alisten_to, listen_to, load_spec,
                                 validate_openapi)
 from kytos.core.interface import TAG, UNI
@@ -231,6 +232,14 @@ class Main(KytosNApp):
         except ValueError as exception:
             log.debug("create_circuit result %s %s", exception, 400)
             raise HTTPException(400, detail=str(exception)) from exception
+
+        if evc.is_intra_switch():
+            if evc.uni_a.interface.switch.status == EntityStatus.DISABLED:
+                switch = evc.uni_a.interface.switch.dpid
+                raise HTTPException(
+                    409,
+                    detail=f"Path is not valid: {switch} is disabled"
+                )
 
         if evc.primary_path:
             try:

--- a/main.py
+++ b/main.py
@@ -234,12 +234,13 @@ class Main(KytosNApp):
             raise HTTPException(400, detail=str(exception)) from exception
 
         if evc.is_intra_switch():
-            if evc.uni_a.interface.switch.status == EntityStatus.DISABLED:
-                switch = evc.uni_a.interface.switch.dpid
+            try:
+                self.check_disabled_component(evc.uni_a, evc.uni_z)
+            except HTTPException as exception:
                 raise HTTPException(
                     409,
-                    detail=f"Path is not valid: {switch} is disabled"
-                )
+                    detail=f"Path is not valid: {exception}"
+                ) from exception
 
         if evc.primary_path:
             try:
@@ -990,6 +991,28 @@ class Main(KytosNApp):
                 evc = self._evc_from_dict(circuit)
                 self.circuits[c_id] = evc
         return self.circuits
+
+    @staticmethod
+    def check_disabled_component(uni_a: object, uni_z: object):
+        """Check if a switch or an interface is disabled"""
+        if uni_a.interface.switch.status == EntityStatus.DISABLED:
+            dpid = uni_a.interface.switch.dpid
+            raise HTTPException(
+                409,
+                detail=f"Switch {dpid} is disabled"
+            )
+        if uni_a.interface.status == EntityStatus.DISABLED:
+            id_ = uni_a.interface.id
+            raise HTTPException(
+                409,
+                detail=f"Interface {id_} is disabled"
+            )
+        if uni_z.interface.status == EntityStatus.DISABLED:
+            id_ = uni_z.interface.id
+            raise HTTPException(
+                409,
+                detail=f"Interface {id_} is disabled"
+            )
 
     # pylint: disable=attribute-defined-outside-init
     @alisten_to("kytos/of_multi_table.enable_table")

--- a/models/evc.py
+++ b/models/evc.py
@@ -15,7 +15,8 @@ from kytos.core.helpers import get_time, now
 from kytos.core.interface import UNI
 from napps.kytos.mef_eline import controllers, settings
 from napps.kytos.mef_eline.exceptions import FlowModException, InvalidPath
-from napps.kytos.mef_eline.utils import (compare_endpoint_trace,
+from napps.kytos.mef_eline.utils import (check_disabled_component,
+                                         compare_endpoint_trace,
                                          compare_uni_out_trace, emit_event,
                                          map_dl_vlan, map_evc_event_content,
                                          notify_link_available_tags)
@@ -182,6 +183,7 @@ class EVCBase(GenericEntity):
         enable, redeploy = (None, None)
         uni_a = kwargs.get("uni_a") or self.uni_a
         uni_z = kwargs.get("uni_z") or self.uni_z
+        check_disabled_component(uni_a, uni_z)
         self._validate_has_primary_or_dynamic(
             primary_path=kwargs.get("primary_path"),
             dynamic_backup_path=kwargs.get("dynamic_backup_path"),

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1635,6 +1635,8 @@ class TestMain:
             json=update_payload,
         )
         assert 409 == response.status_code
+        description = "00:00:00:00:00:00:00:01:1 is disabled"
+        assert description in response.json()["description"]
 
     def test_link_from_dict_non_existent_intf(self):
         """Test _link_from_dict non existent intf."""

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -91,29 +91,32 @@ class TestUtils(TestCase):
             with self.subTest(range=vlan_range, expected=expected):
                 assert get_vlan_tags_and_masks(*vlan_range) == expected
 
-    async def test_check_disabled_component(self):
+    def test_check_disabled_component(self):
         """Test check disabled component"""
         uni_a = MagicMock()
-        uni_a.interface.switch = "00:01"
-        uni_a.interface.switch.status = EntityStatus.DISABLED
+        switch = MagicMock()
+        switch.status = EntityStatus.DISABLED
+        uni_a.interface.switch = switch
 
         uni_z = MagicMock()
-        uni_z.interface.switch = "00:01"
-        uni_z.interface.switch.status = EntityStatus.DISABLED
+        uni_z.interface.switch = switch
 
         # Switch disabled
         with pytest.raises(DisabledSwitch):
             check_disabled_component(uni_a, uni_z)
 
         # Uni_a interface disabled
-        uni_a.interface = MagicMock()
+        switch.status = EntityStatus.UP
         uni_a.interface.status = EntityStatus.DISABLED
         with pytest.raises(DisabledSwitch):
             check_disabled_component(uni_a, uni_z)
 
         # Uni_z interface disabled
         uni_a.interface.status = EntityStatus.UP
-        uni_z.interface = MagicMock()
         uni_z.interface.status = EntityStatus.DISABLED
         with pytest.raises(DisabledSwitch):
             check_disabled_component(uni_a, uni_z)
+
+        # There is no disabled component
+        uni_z.interface.status = EntityStatus.UP
+        check_disabled_component(uni_a, uni_z)

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,8 @@
 """Utility functions."""
+from kytos.core.common import EntityStatus
 from kytos.core.events import KytosEvent
+from kytos.core.interface import UNI
+from napps.kytos.mef_eline.exceptions import DisabledSwitch
 
 
 def map_evc_event_content(evc, **kwargs):
@@ -96,3 +99,18 @@ def get_vlan_tags_and_masks(start: int, end: int) -> list[tuple[int, int]]:
         tags_and_masks.append((start, 4096-divisor))
         start += divisor
     return tags_and_masks
+
+
+def check_disabled_component(uni_a: UNI, uni_z: UNI):
+    """Check if a switch or an interface is disabled"""
+    if uni_a.interface.switch != uni_z.interface.switch:
+        return
+    if uni_a.interface.switch.status == EntityStatus.DISABLED:
+        dpid = uni_a.interface.switch.dpid
+        raise DisabledSwitch(f"Switch {dpid} is disabled")
+    if uni_a.interface.status == EntityStatus.DISABLED:
+        id_ = uni_a.interface.id
+        raise DisabledSwitch(f"Interface {id_} is disabled")
+    if uni_z.interface.status == EntityStatus.DISABLED:
+        id_ = uni_z.interface.id
+        raise DisabledSwitch(f"Interface {id_} is disabled")


### PR DESCRIPTION
Closes #317 

### Summary

Updated creation of a circuit to not allowed for a intra-switch EVC when the used switch status is `DISABLED`

### Local Tests

Tried to create an EVC:
```
{
    "name": "Intra-EVC",
    "dynamic_backup_path": true,
    "uni_a": {
        "tag": {"value": 101, "tag_type": 1},
        "interface_id": "00:00:00:00:00:00:00:02:2"
    },
    "uni_z": {
        "tag": {"value": 101, "tag_type": 1},
        "interface_id": "00:00:00:00:00:00:00:02:1"
    }
}
```

### End-to-End Tests
```
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.0.0
rootdir: /tests
plugins: timeout-2.1.0, rerunfailures-10.2, anyio-3.6.2
collected 232 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 25%]
tests/test_e2e_11_mef_eline.py ......                                    [ 28%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 31%]
tests/test_e2e_13_mef_eline.py .....xs.s......xs.s.XXxX.xxxx..X......... [ 49%]
...                                                                      [ 50%]
tests/test_e2e_14_mef_eline.py x                                         [ 51%]
tests/test_e2e_15_mef_eline.py ..                                        [ 52%]
tests/test_e2e_20_flow_manager.py .....................                  [ 61%]
tests/test_e2e_21_flow_manager.py ...                                    [ 62%]
tests/test_e2e_22_flow_manager.py ...............                        [ 68%]
tests/test_e2e_23_flow_manager.py ..............                         [ 75%]
tests/test_e2e_30_of_lldp.py ....                                        [ 76%]
tests/test_e2e_31_of_lldp.py ...                                         [ 78%]
tests/test_e2e_32_of_lldp.py ...                                         [ 79%]
tests/test_e2e_40_sdntrace.py ...........                                [ 84%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 87%]
tests/test_e2e_50_maintenance.py ........................                [ 97%]
tests/test_e2e_60_of_multi_table.py .....                                [100%]
```
