### PR TITLE
Fixed issues with ordered endpoints

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,7 @@ Changed
 - Changed increasing amount of flows being sent, now it is fixed. Amount can be changed on ``settings.BATCH_SIZE``
 - Changed ui constraints default values to pass the spec validation
 - Changed intra-switch EVC with a disabled switch or interface is not longer allowed to be created
+- Adapted ``mef_eline`` to ordered endpoints in a link. Endpoints for flow creation are compared with switch ids to overcome ordered endpoint.
 
 General Information
 ===================

--- a/models/path.py
+++ b/models/path.py
@@ -48,14 +48,19 @@ class Path(list, GenericEntity):
         """Check if this is a valid path."""
         if not self:
             return True
-        previous = {switch_a}
+        previous = visited = {switch_a}
         for link in self:
             current = {link.endpoint_a.switch, link.endpoint_b.switch} \
                       - previous
-            if len(current) == 2:
+            if len(current) != 1:
                 raise InvalidPath(
                     f"Previus switch {previous} is not connected to "
                     f"current link with switches {current}."
+                )
+            if current & visited:
+                raise InvalidPath(
+                    f"Loop detected in path, switch {current} was visited"
+                    f" more than once."
                 )
             if is_scheduled is False and (
                 link.endpoint_a.link is None
@@ -65,6 +70,7 @@ class Path(list, GenericEntity):
             ):
                 raise InvalidPath(f"Link {link} is not available.")
             previous = current
+            visited |= current
         if previous & {switch_z}:
             return True
         raise InvalidPath("Last link does not contain uni_z switch")

--- a/models/path.py
+++ b/models/path.py
@@ -48,11 +48,13 @@ class Path(list, GenericEntity):
         """Check if this is a valid path."""
         if not self:
             return True
-        previous = switch_a
+        previous = {switch_a}
         for link in self:
-            if link.endpoint_a.switch != previous:
+            current = {link.endpoint_a.switch, link.endpoint_b.switch}
+            if len(previous & current) != 1:
                 raise InvalidPath(
-                    f"{link.endpoint_a} switch is different" f" from previous."
+                    f"Previus {previous} and current {current}"
+                    f"are not continuous"
                 )
             if is_scheduled is False and (
                 link.endpoint_a.link is None
@@ -61,10 +63,10 @@ class Path(list, GenericEntity):
                 or link.endpoint_b.link != link
             ):
                 raise InvalidPath(f"Link {link} is not available.")
-            previous = link.endpoint_b.switch
-        if previous == switch_z:
+            previous = current
+        if previous & {switch_z}:
             return True
-        raise InvalidPath("Last endpoint is different from uni_z")
+        raise InvalidPath("Last link does not contain uni_z switch")
 
     @property
     def status(self):

--- a/models/path.py
+++ b/models/path.py
@@ -54,7 +54,7 @@ class Path(list, GenericEntity):
                       - previous
             if len(current) != 1:
                 raise InvalidPath(
-                    f"Previus switch {previous} is not connected to "
+                    f"Previous switch {previous} is not connected to "
                     f"current link with switches {current}."
                 )
             if current & visited:

--- a/models/path.py
+++ b/models/path.py
@@ -50,11 +50,12 @@ class Path(list, GenericEntity):
             return True
         previous = {switch_a}
         for link in self:
-            current = {link.endpoint_a.switch, link.endpoint_b.switch}
-            if len(previous & current) != 1:
+            current = {link.endpoint_a.switch, link.endpoint_b.switch} \
+                      - previous
+            if len(current) == 2:
                 raise InvalidPath(
-                    f"Previus {previous} and current {current}"
-                    f"are not continuous"
+                    f"Previus switch {previous} is not connected to "
+                    f"current link with switches {current}."
                 )
             if is_scheduled is False and (
                 link.endpoint_a.link is None

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -2,7 +2,7 @@
 import sys
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock, call, patch
-
+import operator
 import pytest
 from kytos.lib.helpers import get_controller_mock
 
@@ -1884,3 +1884,13 @@ class TestEVC(TestCase):
         self.evc_deploy.set_flow_table_group_id(flow_mod, None)
         assert flow_mod["table_group"] == "epl"
         assert flow_mod["table_id"] == 3
+
+    def test_get_endpoint_by_id(self):
+        """Test get_endpoint_by_id"""
+        link = MagicMock()
+        link.endpoint_a.switch.id = "01"
+        link.endpoint_b.switch.id = "02"
+        result = self.evc_deploy.get_endpoint_by_id(link, "01", operator.eq)
+        assert result == link.endpoint_a
+        result = self.evc_deploy.get_endpoint_by_id(link, "01", operator.ne)
+        assert result == link.endpoint_b

--- a/tests/unit/models/test_path.py
+++ b/tests/unit/models/test_path.py
@@ -219,14 +219,20 @@ class TestPath(TestCase):
 
         links2 = [
             get_link_mocked(switch_a=switch1, switch_b=switch2),
-            get_link_mocked(switch_a=switch3, switch_b=switch2),
             get_link_mocked(switch_a=switch3, switch_b=switch4),
+            get_link_mocked(switch_a=switch2, switch_b=switch4),
+        ]
+        links3 = [
+            get_link_mocked(switch_a=switch4, switch_b=switch5),
+            get_link_mocked(switch_a=switch1, switch_b=switch5),
+            get_link_mocked(switch_a=switch1, switch_b=switch3),
         ]
 
         for links, switch_a, switch_z, expected in (
             (links1, switch1, switch6, True),
+            (links3, switch5, switch3, True),
             (links2, switch1, switch4, False),
-            (links1, switch2, switch6, False),
+            (links1, switch3, switch6, False),
         ):
             with self.subTest(
                 links=links,

--- a/tests/unit/models/test_path.py
+++ b/tests/unit/models/test_path.py
@@ -208,31 +208,33 @@ class TestPath(TestCase):
         switch4 = Switch("00:00:00:00:00:00:00:04")
         switch5 = Switch("00:00:00:00:00:00:00:05")
         switch6 = Switch("00:00:00:00:00:00:00:06")
-
+        # Links connected
         links1 = [
-            get_link_mocked(switch_a=switch1, switch_b=switch2),
-            get_link_mocked(switch_a=switch2, switch_b=switch3),
-            get_link_mocked(switch_a=switch3, switch_b=switch4),
-            get_link_mocked(switch_a=switch4, switch_b=switch5),
             get_link_mocked(switch_a=switch5, switch_b=switch6),
+            get_link_mocked(switch_a=switch4, switch_b=switch5),
+            get_link_mocked(switch_a=switch3, switch_b=switch4),
+            get_link_mocked(switch_a=switch2, switch_b=switch3),
+            get_link_mocked(switch_a=switch1, switch_b=switch2),
         ]
-
+        # Links not connected
         links2 = [
             get_link_mocked(switch_a=switch1, switch_b=switch2),
             get_link_mocked(switch_a=switch3, switch_b=switch4),
             get_link_mocked(switch_a=switch2, switch_b=switch4),
         ]
+        # Loop
         links3 = [
-            get_link_mocked(switch_a=switch4, switch_b=switch5),
-            get_link_mocked(switch_a=switch1, switch_b=switch4),
-            get_link_mocked(switch_a=switch1, switch_b=switch3),
+            get_link_mocked(switch_a=switch1, switch_b=switch2),
+            get_link_mocked(switch_a=switch2, switch_b=switch3),
+            get_link_mocked(switch_a=switch3, switch_b=switch4),
+            get_link_mocked(switch_a=switch2, switch_b=switch4),
+            get_link_mocked(switch_a=switch2, switch_b=switch5),
         ]
         for links, switch_a, switch_z, expected in (
-            (links1, switch1, switch6, True),
-            (links3, switch5, switch3, True),
+            (links1, switch6, switch1, True),
             (links2, switch1, switch4, False),
             (links1, switch3, switch6, False),
-            (links3, switch4, switch3, False)
+            (links3, switch1, switch5, False)
         ):
             with self.subTest(
                 links=links,

--- a/tests/unit/models/test_path.py
+++ b/tests/unit/models/test_path.py
@@ -224,15 +224,15 @@ class TestPath(TestCase):
         ]
         links3 = [
             get_link_mocked(switch_a=switch4, switch_b=switch5),
-            get_link_mocked(switch_a=switch1, switch_b=switch5),
+            get_link_mocked(switch_a=switch1, switch_b=switch4),
             get_link_mocked(switch_a=switch1, switch_b=switch3),
         ]
-
         for links, switch_a, switch_z, expected in (
             (links1, switch1, switch6, True),
             (links3, switch5, switch3, True),
             (links2, switch1, switch4, False),
             (links1, switch3, switch6, False),
+            (links3, switch4, switch3, False)
         ):
             with self.subTest(
                 links=links,


### PR DESCRIPTION
Related to kytos PR [#221](https://github.com/kytos-ng/kytos/pull/329)

### Summary

Adapting `path` and `EVCDeploy` to ordered endpoints from kytos PR. Endpoints are chosen  depending on first/previous switch which is usually `uni_a` switch.

### Local Tests

Installing EVCs and disabling links

### End-to-End Tests

```
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.0.0
rootdir: /tests
plugins: timeout-2.1.0, rerunfailures-10.2, anyio-3.6.2
collected 232 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x.RRFRRF.......... [ 24%]
...                                                                      [ 25%]
tests/test_e2e_11_mef_eline.py ......                                    [ 28%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 31%]
tests/test_e2e_13_mef_eline.py .....xs.s......xs.s.XXxX.xxxx..X......... [ 49%]
...                                                                      [ 50%]
tests/test_e2e_14_mef_eline.py x                                         [ 51%]
tests/test_e2e_15_mef_eline.py ..                                        [ 52%]
tests/test_e2e_20_flow_manager.py .....................                  [ 61%]
tests/test_e2e_21_flow_manager.py ...                                    [ 62%]
tests/test_e2e_22_flow_manager.py ...............                        [ 68%]
tests/test_e2e_23_flow_manager.py ..............                         [ 75%]
tests/test_e2e_30_of_lldp.py ....                                        [ 76%]
tests/test_e2e_31_of_lldp.py ...                                         [ 78%]
tests/test_e2e_32_of_lldp.py ...                                         [ 79%]
tests/test_e2e_40_sdntrace.py ...........                                [ 84%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 87%]
tests/test_e2e_50_maintenance.py ........................                [ 97%]
tests/test_e2e_60_of_multi_table.py .....                                [100%]
```
Both fails are from unordered paths, they need to be ordered in e2e repository.
These failing tests are:
- `def test_140_current_path_value_given_dynamic_backup_path_and_primary_path_conditions(self)`
- `def test_145_current_path_value_given_dynamic_backup_path_and_empty_primary_conditions(self)`

Fixed on PR [#244](https://github.com/kytos-ng/kytos-end-to-end-tests/pull/244)