### PR TITLE
Fix UI EVC list to sort VLAN as number

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,6 +46,7 @@ Fixed
 - fixed unnecessary redeploy of an intra-switch EVC on link up events
 - fixed ``check_list_traces`` to work with the new version of SDN traces
 - fixed updating EVC to be an intra-switch with invalid switch or interface
+- fixed EVC UI list to sort VLAN A and VLAN Z fields to acts as number
 
 General Information
 ===================

--- a/ui/k-info-panel/list_connections.kytos
+++ b/ui/k-info-panel/list_connections.kytos
@@ -167,11 +167,11 @@ module.exports = {
               "mef_lst_sw_a": endpoint_data_a.node_name,
               "mef_lst_prt_a": '' + endpoint_data_a.port,
               "mef_lst_int_a": endpoint_data_a.interface_name,
-              "mef_lst_tag_a": '' + tag_a,
+              "mef_lst_tag_a": tag_a, // TAG Vlan to be sorted as int
               "mef_lst_sw_z": endpoint_data_z.node_name,
               "mef_lst_prt_z": '' + endpoint_data_z.port,
               "mef_lst_int_z": endpoint_data_z.interface_name,
-              "mef_lst_tag_z": '' + tag_z,
+              "mef_lst_tag_z": tag_z, // TAG Vlan to be sorted as int
               "mef_lst_enabled": evc.enabled,
               "mef_lst_active": evc.active
             };
@@ -254,9 +254,11 @@ module.exports = {
       let filtered = this.data_rows.filter((item)=>
         {
           // for every property check if search is not empty and item[prop] has search[prop]
+          // Cast to string to search VLAN numbers
           let checks = properties.map(i => 
             !this.search_cols[i] || 
-            item[i].toUpperCase().includes(this.search_cols[i].toUpperCase()));
+            item[i].toString().toUpperCase().includes(this.search_cols[i].toString().toUpperCase())
+          );
           // check if no property is false
           return !checks.includes(false);
         }


### PR DESCRIPTION
**Closes** #331 

### Summary
Update EVC list to sort VLAN A and VLAN Z fields to acts as number.

### Local Tests
Test VLAN A and VLAN Z sort with ascending and descending order.
![image](https://github.com/kytos-ng/mef_eline/assets/10867136/e395bfed-a0ba-4878-9ee1-123924c37894)

Test input field to filter the list with partial VLAN values
![image](https://github.com/kytos-ng/mef_eline/assets/10867136/72b074b0-32d2-4b6b-800f-091e81f88b6a)
