### PR TITLE
Fixed unset queue with null

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -47,6 +47,7 @@ Fixed
 - fixed ``check_list_traces`` to work with the new version of SDN traces
 - fixed updating EVC to be an intra-switch with invalid switch or interface
 - fixed EVC UI list to sort VLAN A and VLAN Z fields to acts as number
+- fixed non-redeployment of circuit when patching with ``{"queue_id":null}``
 
 General Information
 ===================

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -92,7 +92,9 @@ class ELineController:
         updated = self.db.evcs.find_one_and_update(
             {"_id": evc["id"]},
             {
-                "$set": model.dict(exclude={"inserted_at"}, exclude_unset=True),
+                "$set": model.dict(
+                    exclude={"inserted_at"},
+                    exclude_unset=True),
                 "$setOnInsert": {"inserted_at": utc_now},
             },
             return_document=ReturnDocument.AFTER,

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -94,11 +94,22 @@ class ELineController:
             {
                 "$set": model.dict(
                     exclude={"inserted_at"},
-                    exclude_unset=True),
+                    exclude_none=True),
                 "$setOnInsert": {"inserted_at": utc_now},
             },
             return_document=ReturnDocument.AFTER,
             upsert=True,
+        )
+        return updated
+
+    def update_evc(self, evc: Dict) -> Optional[Dict]:
+        """Update or insert an EVC"""
+        updated = self.db.evcs.find_one_and_update(
+            {"_id": evc["id"]},
+            {
+                "$set": evc,
+            },
+            return_document=ReturnDocument.AFTER,
         )
         return updated
 

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -13,7 +13,7 @@ from tenacity import retry_if_exception_type, stop_after_attempt, wait_random
 from kytos.core import log
 from kytos.core.db import Mongo
 from kytos.core.retry import before_sleep, for_all_methods, retries
-from napps.kytos.mef_eline.db.models import EVCBaseDoc
+from napps.kytos.mef_eline.db.models import EVCBaseDoc, EVCUpdateDoc
 
 
 @for_all_methods(
@@ -107,7 +107,7 @@ class ELineController:
         This is needed to correctly set None values to fields"""
 
         # Check for errors in fields only.
-        EVCBaseDoc(
+        EVCUpdateDoc(
             **{
                 **evc,
                 **{"_id": evc["id"]}

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -92,7 +92,7 @@ class ELineController:
         updated = self.db.evcs.find_one_and_update(
             {"_id": evc["id"]},
             {
-                "$set": model.dict(exclude={"inserted_at"}, exclude_none=True),
+                "$set": model.dict(exclude={"inserted_at"}, exclude_unset=True),
                 "$setOnInsert": {"inserted_at": utc_now},
             },
             return_document=ReturnDocument.AFTER,

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -103,7 +103,16 @@ class ELineController:
         return updated
 
     def update_evc(self, evc: Dict) -> Optional[Dict]:
-        """Update or insert an EVC"""
+        """Update an EVC.
+        This is needed to correctly set None values to fields"""
+
+        # Check for errors in fields only.
+        EVCBaseDoc(
+            **{
+                **evc,
+                **{"_id": evc["id"]}
+            }
+        )
         updated = self.db.evcs.find_one_and_update(
             {"_id": evc["id"]},
             {

--- a/db/models.py
+++ b/db/models.py
@@ -77,6 +77,33 @@ class PathConstraints(BaseModel):
     undesired_links: Optional[List[str]]
 
 
+class EVCUpdateDoc(DocumentBaseModel):
+    """Base model when updating an EVC document"""
+    uni_a: Optional[UNIDoc]
+    uni_z: Optional[UNIDoc]
+    name: Optional[str]
+    request_time: Optional[datetime]
+    start_date: Optional[datetime]
+    end_date: Optional[datetime]
+    queue_id: Optional[int]
+    flow_removed_at: Optional[datetime]
+    execution_rounds: Optional[int]
+    bandwidth: Optional[int]
+    primary_path: Optional[List]
+    backup_path: Optional[List]
+    primary_links: Optional[List]
+    backup_links: Optional[List]
+    dynamic_backup_path: Optional[bool]
+    primary_constraints: Optional[PathConstraints]
+    secondary_constraints: Optional[PathConstraints]
+    owner: Optional[str]
+    sb_priority: Optional[int]
+    service_level: Optional[int]
+    circuit_scheduler: Optional[List[CircuitScheduleDoc]]
+    metadata: Optional[dict]
+    enabled: Optional[bool]
+
+
 class EVCBaseDoc(DocumentBaseModel):
     """Base model for EVC documents"""
 

--- a/db/models.py
+++ b/db/models.py
@@ -3,7 +3,7 @@
 # pylint: disable=no-self-argument,no-name-in-module
 
 from datetime import datetime
-from typing import Dict, List, Literal, Optional, Union
+from typing import Dict, List, Literal, Optional, Union, Any
 
 from pydantic import BaseModel, Field, validator
 
@@ -76,6 +76,9 @@ class PathConstraints(BaseModel):
     minimum_flexible_hits: Optional[int]
     undesired_links: Optional[List[str]]
 
+    def __init__(__pydantic_self__, **data: Any) -> None:
+        super().__init__(**data)
+        __pydantic_self__.__fields_set__.add('spf_attribute')
 
 class EVCBaseDoc(DocumentBaseModel):
     """Base model for EVC documents"""
@@ -106,7 +109,7 @@ class EVCBaseDoc(DocumentBaseModel):
     service_level: int = 0
     circuit_scheduler: List[CircuitScheduleDoc]
     archived: bool = False
-    metadata: Optional[Dict] = None
+    metadata: Dict = {}
     active: bool
     enabled: bool
 

--- a/db/models.py
+++ b/db/models.py
@@ -3,7 +3,7 @@
 # pylint: disable=no-self-argument,no-name-in-module
 
 from datetime import datetime
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, Field, validator
 
@@ -76,10 +76,6 @@ class PathConstraints(BaseModel):
     minimum_flexible_hits: Optional[int]
     undesired_links: Optional[List[str]]
 
-    def __init__(__pydantic_self__, **data: Any) -> None:
-        super().__init__(**data)
-        __pydantic_self__.__fields_set__.add('spf_attribute')
-
 
 class EVCBaseDoc(DocumentBaseModel):
     """Base model for EVC documents"""
@@ -99,7 +95,6 @@ class EVCBaseDoc(DocumentBaseModel):
     current_path: Optional[List]
     failover_path: Optional[List]
     primary_links: Optional[List]
-    backup_links: Optional[List]
     backup_links: Optional[List]
     dynamic_backup_path: bool
     primary_constraints: Optional[PathConstraints]

--- a/db/models.py
+++ b/db/models.py
@@ -3,7 +3,7 @@
 # pylint: disable=no-self-argument,no-name-in-module
 
 from datetime import datetime
-from typing import Dict, List, Literal, Optional, Union, Any
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, Field, validator
 
@@ -79,6 +79,7 @@ class PathConstraints(BaseModel):
     def __init__(__pydantic_self__, **data: Any) -> None:
         super().__init__(**data)
         __pydantic_self__.__fields_set__.add('spf_attribute')
+
 
 class EVCBaseDoc(DocumentBaseModel):
     """Base model for EVC documents"""

--- a/models/evc.py
+++ b/models/evc.py
@@ -217,7 +217,7 @@ class EVCBase(GenericEntity):
             else:
                 setattr(self, attribute, value)
                 if attribute in self.attributes_requiring_redeploy:
-                    redeploy = value
+                    redeploy = True
         self.sync()
         return enable, redeploy
 
@@ -1343,10 +1343,10 @@ class LinkProtection(EVCDeploy):
         return False
 
     def handle_link_up(self, link):
-        """Handle circuit when link down.
+        """Handle circuit when link up.
 
         Args:
-            link(Link): Link affected by link.down event.
+            link(Link): Link affected by link.up event.
 
         """
         if self.is_intra_switch():

--- a/models/evc.py
+++ b/models/evc.py
@@ -163,9 +163,12 @@ class EVCBase(GenericEntity):
         self.special_cases = {None, "4096/4096", 0}
         self.table_group = kwargs.get("table_group")
 
-    def sync(self):
+    def sync(self, keys: set = None):
         """Sync this EVC in the MongoDB."""
         self.updated_at = now()
+        if keys:
+            self._mongo_controller.update_evc(self.as_dict(keys))
+            return
         self._mongo_controller.upsert_evc(self.as_dict())
 
     def update(self, **kwargs):
@@ -218,7 +221,7 @@ class EVCBase(GenericEntity):
                 setattr(self, attribute, value)
                 if attribute in self.attributes_requiring_redeploy:
                     redeploy = True
-        self.sync()
+        self.sync(set(kwargs.keys()))
         return enable, redeploy
 
     def set_flow_removed_at(self):
@@ -322,8 +325,10 @@ class EVCBase(GenericEntity):
             return True
         return False
 
-    def as_dict(self):
-        """Return a dictionary representing an EVC object."""
+    def as_dict(self, keys: set = None):
+        """Return a dictionary representing an EVC object.
+            keys: Only fields on this variable will be
+                  returned in the dictionary"""
         evc_dict = {
             "id": self.id,
             "name": self.name,
@@ -373,8 +378,16 @@ class EVCBase(GenericEntity):
         evc_dict["secondary_constraints"] = self.secondary_constraints
         evc_dict["flow_removed_at"] = self.flow_removed_at
         evc_dict["updated_at"] = self.updated_at
-        evc_dict["execution_rounds"] = self.execution_rounds
 
+        if keys:
+            selected = {}
+            for key in keys:
+                if key == "enable":
+                    selected["enabled"] = evc_dict["enabled"]
+                    continue
+                selected[key] = evc_dict[key]
+            selected["id"] = evc_dict["id"]
+            return selected
         return evc_dict
 
     @property

--- a/models/evc.py
+++ b/models/evc.py
@@ -373,6 +373,7 @@ class EVCBase(GenericEntity):
         evc_dict["secondary_constraints"] = self.secondary_constraints
         evc_dict["flow_removed_at"] = self.flow_removed_at
         evc_dict["updated_at"] = self.updated_at
+        evc_dict["execution_rounds"] = self.execution_rounds
 
         return evc_dict
 

--- a/tests/unit/models/test_evc_base.py
+++ b/tests/unit/models/test_evc_base.py
@@ -389,6 +389,32 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
             actual = actual_dict.get(name)
             self.assertEqual(value, actual)
 
+        # Selected fields
+        expected_dict = {
+            "enabled": True,
+            "uni_z": attributes["uni_z"].as_dict(),
+            "circuit_scheduler": [
+                {
+                    "id": 234243247,
+                    "action": "create",
+                    "frequency": "1 * * * *",
+                },
+                {
+                    "id": 234243239,
+                    "action": "create",
+                    "interval": {"hours": 2},
+                },
+            ],
+            "sb_priority": 2,
+        }
+        selected_fields = {
+            "enabled", "uni_z", "circuit_scheduler", "sb_priority"
+        }
+        actual_dict = evc.as_dict(selected_fields)
+        for name, value in expected_dict.items():
+            actual = actual_dict.get(name)
+            assert value == actual
+
     @staticmethod
     def test_get_id_from_cookie():
         """Test get_id_from_cookie."""

--- a/tests/unit/models/test_evc_base.py
+++ b/tests/unit/models/test_evc_base.py
@@ -262,6 +262,22 @@ class TestEVC(TestCase):  # pylint: disable=too-many-public-methods
         _, redeploy = evc.update(**update_dict)
         self.assertTrue(redeploy)
 
+    @patch("napps.kytos.mef_eline.models.EVC.sync")
+    def test_update_queue_null(self, _sync_mock):
+        """Test if evc is set to redeploy."""
+        attributes = {
+            "controller": get_controller_mock(),
+            "name": "circuit_name",
+            "enable": True,
+            "dynamic_backup_path": True,
+            "uni_a": get_uni_mocked(is_valid=True),
+            "uni_z": get_uni_mocked(is_valid=True),
+        }
+        update_dict = {"queue_id": None}
+        evc = EVC(**attributes)
+        _, redeploy = evc.update(**update_dict)
+        self.assertTrue(redeploy)
+
     def test_circuit_representation(self):
         """Test the method __repr__."""
         attributes = {

--- a/tests/unit/test_db_models.py
+++ b/tests/unit/test_db_models.py
@@ -1,14 +1,15 @@
 """Tests for DB models."""
-from unittest import TestCase
+import pytest
 from pydantic import ValidationError
 
-from db.models import EVCBaseDoc, DocumentBaseModel, TAGDoc
+from db.models import EVCBaseDoc, DocumentBaseModel, TAGDoc, EVCUpdateDoc
 
 
-class TestDBModels(TestCase):
+class TestDBModels():
     """Test the DB models"""
 
-    def setUp(self):
+    def setup_method(self):
+        """Setup method."""
         self.evc_dict = {
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:04:1",
@@ -33,6 +34,28 @@ class TestDBModels(TestCase):
             "circuit_scheduler": [],
             "queue_id": None
         }
+        self.evc_update = {
+            "uni_a": {
+                "interface_id": "00:00:00:00:00:00:00:04:1",
+                "tag": {
+                    "tag_type": 1,
+                    "value": 100,
+                },
+            },
+            "uni_z": {
+                "interface_id": "00:00:00:00:00:00:00:02:3",
+                "tag": {
+                    "tag_type": 1,
+                    "value": 100,
+                }
+            },
+            "name": "EVC 2",
+            "dynamic_backup_path": True,
+            "sb_priority": 81,
+            "enabled": False,
+            "circuit_scheduler": [],
+            "queue_id": None
+        }
 
     def test_evcbasedoc(self):
         """Test EVCBaseDoc model"""
@@ -48,12 +71,23 @@ class TestDBModels(TestCase):
         assert not evc.enabled
         assert not evc.circuit_scheduler
 
+    def test_evcupdatedoc(self):
+        """Test EVCUpdateDoc model"""
+        evc = EVCUpdateDoc(**self.evc_update)
+        assert evc.name == "EVC 2"
+        assert evc.uni_a.interface_id == "00:00:00:00:00:00:00:04:1"
+        assert evc.uni_z.interface_id == "00:00:00:00:00:00:00:02:3"
+        assert evc.dynamic_backup_path
+        assert evc.sb_priority == 81
+        assert not evc.enabled
+        assert not evc.circuit_scheduler
+
     def test_evcbasedoc_error(self):
         """Test failure EVCBaseDoc model creation"""
 
         self.evc_dict["queue_id"] = "error"
 
-        with self.assertRaises(ValidationError):
+        with pytest.raises(ValidationError):
             EVCBaseDoc(**self.evc_dict)
 
     def test_document_base_model_dict(self):
@@ -77,5 +111,5 @@ class TestDBModels(TestCase):
     def test_tagdoc_fail(self):
         """Test TAGDoc value fail case"""
         tag_fail = {"tag_type": 1, "value": "test_fail"}
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             TAGDoc(**tag_fail)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1278,6 +1278,7 @@ class TestMain:
 
     @patch('requests.post')
     @patch('napps.kytos.mef_eline.scheduler.Scheduler.add')
+    @patch('napps.kytos.mef_eline.controllers.ELineController.update_evc')
     @patch("napps.kytos.mef_eline.controllers.ELineController.upsert_evc")
     @patch('napps.kytos.mef_eline.models.evc.EVC._validate')
     @patch('kytos.core.Controller.get_interface_by_id')
@@ -1294,6 +1295,7 @@ class TestMain:
         interface_by_id_mock,
         _mock_validate,
         _mongo_controller_upsert_mock,
+        _mongo_controller_update_mock,
         _sched_add_mock,
         requests_mock,
         event_loop,

--- a/ui/k-info-panel/show_circuit.kytos
+++ b/ui/k-info-panel/show_circuit.kytos
@@ -745,7 +745,7 @@ module.exports = {
         dynamic_backup_path: this.flags["Dynamic backup path"]["value"],                
         sb_priority: parseInt(this.others["Southbound priority"]["value"]) || null,
         bandwidth: parseInt(this.others["Bandwidth"]["value"]) || 0,
-        queue_id: parseInt(this.others["Queue"]["value"]) || null,
+        queue_id: parseInt(this.others["Queue"]["value"]),
         service_level: parseInt(this.others["Service level"]["value"]) || 0,
         uni_a: {
           interface_id: this.endpoints_data["DPID"][0]["value"],


### PR DESCRIPTION
Closes #347 

### Summary

Redeployment was based on the field value. Changed to always be `True`

### Local Tests

Added unit test with issue case.
Patched EVC with `{"queue_id":null}`