### PR TITLE
Handled disabled UNI

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ Changed
 - Changed ui constraints default values to pass the spec validation
 - Changed intra-switch EVC with a disabled switch or interface is not longer allowed to be created
 - Adapted ``mef_eline`` to ordered endpoints in a link. Endpoints for flow creation are compared with switch ids to overcome ordered endpoint.
+- EVCs UNI will be checked for disabled interfaces so the EVC is disabled as well.
 
 General Information
 ===================

--- a/main.py
+++ b/main.py
@@ -85,8 +85,7 @@ class Main(KytosNApp):
             self.execute_consistency()
         log.debug("Finished consistency routine")
 
-    @staticmethod
-    def should_be_checked(circuit, switches):
+    def should_be_checked(self, circuit):
         "Verify if the circuit meets the necessary conditions to be checked"
         # pylint: disable=too-many-boolean-expressions
         if (
@@ -95,7 +94,7 @@ class Main(KytosNApp):
                 and not circuit.lock.locked()
                 and not circuit.has_recent_removed_flow()
                 and not circuit.is_recent_updated()
-                and circuit.are_unis_active(switches)
+                and circuit.are_unis_active(self.controller.switches)
                 # if a inter-switch EVC does not have current_path, it does not
                 # make sense to run sdntrace on it
                 and (circuit.is_intra_switch() or circuit.current_path)
@@ -109,7 +108,7 @@ class Main(KytosNApp):
         stored_circuits = self.mongo_controller.get_circuits()['circuits']
         for circuit in self.get_evcs_by_svc_level():
             stored_circuits.pop(circuit.id, None)
-            if self.should_be_checked(circuit, self.controller.switches):
+            if self.should_be_checked(circuit):
                 circuits_to_check.append(circuit)
         circuits_checked = EVCDeploy.check_list_traces(circuits_to_check)
         for circuit in circuits_to_check:

--- a/main.py
+++ b/main.py
@@ -94,7 +94,7 @@ class Main(KytosNApp):
                 and not circuit.lock.locked()
                 and not circuit.has_recent_removed_flow()
                 and not circuit.is_recent_updated()
-                and circuit.should_be_active(switches)
+                and circuit.are_unis_active(switches)
                 # if a inter-switch EVC does not have current_path, it does not
                 # make sense to run sdntrace on it
                 and (circuit.is_intra_switch() or circuit.current_path)
@@ -718,12 +718,13 @@ class Main(KytosNApp):
 
     def handle_topology_update(self, event):
         """Handle topology update"""
-        for evc in self.get_evcs_by_svc_level():
-            if evc.is_enabled() and not evc.archived:
-                with evc.lock:
-                    evc.handle_topology_update(
-                        event.content["topology"].switches
-                    )
+        with self._lock:
+            for evc in self.get_evcs_by_svc_level():
+                if evc.is_enabled() and not evc.archived:
+                    with evc.lock:
+                        evc.handle_topology_update(
+                            event.content["topology"].switches
+                        )
 
     @listen_to("kytos/topology.link_down")
     def on_link_down(self, event):

--- a/models/evc.py
+++ b/models/evc.py
@@ -1463,7 +1463,7 @@ class LinkProtection(EVCDeploy):
     def is_uni_interface_active(
         interface_a: Interface,
         interface_z: Interface
-    ) -> tuple[bool, Interface]:
+    ) -> tuple[bool, dict]:
         """Determine whether a UNI should be active"""
         active = True
         interfaces = {}

--- a/models/evc.py
+++ b/models/evc.py
@@ -1419,6 +1419,11 @@ class LinkProtection(EVCDeploy):
 
     def handle_topology_update(self, switches: dict):
         """Handle changes in the topology"""
+        # All intra-switch EVCs do not have current_path.
+        # In case of inter-switch EVC and not current_path,
+        # link_down should take care of deactivation.
+        if not self.is_intra_switch and not self.current_path:
+            return
         try:
             interface_a = self.get_interface_from_switch(self.uni_a, switches)
         except KeyError:
@@ -1439,7 +1444,9 @@ class LinkProtection(EVCDeploy):
         if self.is_active() != active:
             if active:
                 self.activate()
-                log.info(f"Activating EVC {self.id}")
+                interfaces = {interface_a.id, interface_z.id}
+                log.info(f"Activating EVC {self.id}. Interfaces "
+                         f"{interfaces} are activated.")
             else:
                 self.deactivate()
                 log.info(f"Interface {interface.id} is "

--- a/tests/unit/models/test_link_protection.py
+++ b/tests/unit/models/test_link_protection.py
@@ -780,16 +780,26 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
         interface_a.status = EntityStatus.UP
         interface_z.status = EntityStatus.UP
         actual = self.evc.is_uni_interface_active(interface_a, interface_z)
-        expected = (True, None)
+        interfaces = {
+            '00:01:1': {"status": "UP", "status_reason": set()},
+            '00:03:1': {"status": "UP", "status_reason": set()},
+        }
+        expected = (True, interfaces)
         assert actual == expected
 
         interface_a.status = EntityStatus.DOWN
         actual = self.evc.is_uni_interface_active(interface_a, interface_z)
-        expected = (False, interface_a)
+        interfaces = {
+            '00:01:1': {'status': 'DOWN', 'status_reason': set()}
+        }
+        expected = (False, interfaces)
         assert actual == expected
 
         interface_a.status = EntityStatus.UP
         interface_z.status = EntityStatus.DOWN
         actual = self.evc.is_uni_interface_active(interface_a, interface_z)
-        expected = (False, interface_z)
+        interfaces = {
+            '00:03:1': {'status': 'DOWN', 'status_reason': set()}
+        }
+        expected = (False, interfaces)
         assert actual == expected

--- a/tests/unit/models/test_link_protection.py
+++ b/tests/unit/models/test_link_protection.py
@@ -1,7 +1,5 @@
 """Module to test the LinkProtection class."""
 import sys
-
-from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from kytos.core.common import EntityStatus
@@ -11,6 +9,7 @@ from napps.kytos.mef_eline.tests.helpers import (
     get_link_mocked,
     get_uni_mocked,
     get_mocked_requests,
+    id_to_interface_mock
 )  # NOQA pycodestyle
 
 
@@ -28,10 +27,11 @@ GET_BEST_PATH = (
 )
 
 
-class TestLinkProtection(TestCase):  # pylint: disable=too-many-public-methods
+class TestLinkProtection():  # pylint: disable=too-many-public-methods
     """Tests to validate LinkProtection class."""
 
-    def setUp(self):
+    def setup_method(self):
+        """Set up method"""
         primary_path = [
             get_link_mocked(
                 endpoint_a_port=9,
@@ -72,7 +72,7 @@ class TestLinkProtection(TestCase):  # pylint: disable=too-many-public-methods
         }
         self.evc = EVC(**attributes)
 
-    def test_is_using_backup_path(self):
+    async def test_is_using_backup_path(self):
         """Test test is using backup path."""
 
         attributes = {
@@ -95,11 +95,11 @@ class TestLinkProtection(TestCase):  # pylint: disable=too-many-public-methods
         }
 
         evc = EVC(**attributes)
-        self.assertFalse(evc.is_using_backup_path())
+        assert evc.is_using_backup_path() is False
         evc.current_path = evc.backup_path
-        self.assertTrue(evc.is_using_backup_path())
+        assert evc.is_using_backup_path()
 
-    def test_is_using_primary_path(self):
+    async def test_is_using_primary_path(self):
         """Test test is using primary path."""
         primary_path = [
             get_link_mocked(
@@ -118,12 +118,12 @@ class TestLinkProtection(TestCase):  # pylint: disable=too-many-public-methods
             "primary_path": primary_path,
         }
         evc = EVC(**attributes)
-        self.assertFalse(evc.is_using_primary_path())
+        assert evc.is_using_primary_path() is False
         evc.current_path = evc.primary_path
-        self.assertTrue(evc.is_using_primary_path())
+        assert evc.is_using_primary_path()
 
     @patch("napps.kytos.mef_eline.models.evc.log")
-    def test_deploy_to_case_1(self, log_mocked):
+    async def test_deploy_to_case_1(self, log_mocked):
         """Test if the path is equal to current_path."""
         primary_path = [
             get_link_mocked(
@@ -146,7 +146,7 @@ class TestLinkProtection(TestCase):  # pylint: disable=too-many-public-methods
         expected_deployed = evc.deploy_to("primary_path", evc.primary_path)
         expected_msg = "primary_path is equal to current_path."
         log_mocked.debug.assert_called_with(expected_msg)
-        self.assertTrue(expected_deployed)
+        assert expected_deployed
 
     # pylint: disable=too-many-arguments
     @patch("napps.kytos.mef_eline.models.evc.notify_link_available_tags")
@@ -156,7 +156,7 @@ class TestLinkProtection(TestCase):  # pylint: disable=too-many-public-methods
     @patch("napps.kytos.mef_eline.models.evc.EVC._install_nni_flows")
     @patch("napps.kytos.mef_eline.models.evc.EVC._install_uni_flows")
     @patch("napps.kytos.mef_eline.models.path.Path.status", EntityStatus.UP)
-    def test_deploy_to_case_2(
+    async def test_deploy_to_case_2(
         self,
         install_uni_flows_mocked,
         install_nni_flows_mocked,
@@ -188,11 +188,11 @@ class TestLinkProtection(TestCase):  # pylint: disable=too-many-public-methods
         deployed = evc.deploy_to("primary_path", evc.primary_path)
         install_uni_flows_mocked.assert_called_with(evc.primary_path)
         install_nni_flows_mocked.assert_called_with(evc.primary_path)
-        self.assertTrue(deployed)
+        assert deployed
         notify_mock.assert_called()
 
     @patch("requests.get", side_effect=get_mocked_requests)
-    def test_deploy_to_case_3(self, requests_mocked):
+    async def test_deploy_to_case_3(self, requests_mocked):
         # pylint: disable=unused-argument
         """Test deploy with one link down."""
         link1 = get_link_mocked()
@@ -211,14 +211,14 @@ class TestLinkProtection(TestCase):  # pylint: disable=too-many-public-methods
         evc = EVC(**attributes)
 
         deployed = evc.deploy_to("primary_path", evc.primary_path)
-        self.assertFalse(deployed)
+        assert deployed is False
 
     @patch("napps.kytos.mef_eline.models.evc.log")
     @patch("napps.kytos.mef_eline.models.evc.EVCDeploy._send_flow_mods")
     @patch(DEPLOY_TO_BACKUP_PATH)
     @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.deploy")
     @patch("napps.kytos.mef_eline.models.path.Path.status")
-    def test_handle_link_down_case_1(
+    async def test_handle_link_down_case_1(
         self,
         path_status_mocked,
         deploy_mocked,
@@ -234,10 +234,10 @@ class TestLinkProtection(TestCase):  # pylint: disable=too-many-public-methods
         self.evc.activate()
         deploy_to_mocked.reset_mock()
         current_handle_link_down = self.evc.handle_link_down()
-        self.assertEqual(deploy_mocked.call_count, 0)
+        assert deploy_mocked.call_count == 0
         deploy_to_mocked.assert_called_once()
 
-        self.assertTrue(current_handle_link_down)
+        assert current_handle_link_down
         msg = f"{self.evc} deployed after link down."
         log_mocked.debug.assert_called_once_with(msg)
 
@@ -245,7 +245,7 @@ class TestLinkProtection(TestCase):  # pylint: disable=too-many-public-methods
     @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.deploy")
     @patch(DEPLOY_TO_PRIMARY_PATH)
     @patch("napps.kytos.mef_eline.models.path.Path.status")
-    def test_handle_link_down_case_2(
+    async def test_handle_link_down_case_2(
         self, path_status_mocked, deploy_to_mocked, deploy_mocked, log_mocked
     ):
         """Test if deploy_to backup path is called."""
@@ -294,9 +294,9 @@ class TestLinkProtection(TestCase):  # pylint: disable=too-many-public-methods
         evc.current_path = evc.backup_path
         deploy_to_mocked.reset_mock()
         current_handle_link_down = evc.handle_link_down()
-        self.assertEqual(deploy_mocked.call_count, 0)
+        assert deploy_mocked.call_count == 0
         deploy_to_mocked.assert_called_once()
-        self.assertTrue(current_handle_link_down)
+        assert current_handle_link_down
         msg = f"{evc} deployed after link down."
         log_mocked.debug.assert_called_once_with(msg)
 
@@ -306,7 +306,7 @@ class TestLinkProtection(TestCase):  # pylint: disable=too-many-public-methods
     @patch(DEPLOY_TO_PRIMARY_PATH)
     @patch("napps.kytos.mef_eline.models.path.DynamicPathManager.get_paths")
     @patch("napps.kytos.mef_eline.models.path.Path.status", EntityStatus.DOWN)
-    def test_handle_link_down_case_3(
+    async def test_handle_link_down_case_3(
         self, get_paths_mocked, deploy_to_mocked, deploy_mocked, log_mocked, _
     ):
         """Test if circuit without dynamic path is return failed."""
@@ -355,11 +355,11 @@ class TestLinkProtection(TestCase):  # pylint: disable=too-many-public-methods
         deploy_to_mocked.reset_mock()
         current_handle_link_down = evc.handle_link_down()
 
-        self.assertEqual(get_paths_mocked.call_count, 0)
-        self.assertEqual(deploy_mocked.call_count, 0)
-        self.assertEqual(deploy_to_mocked.call_count, 1)
+        assert get_paths_mocked.call_count == 0
+        assert deploy_mocked.call_count == 0
+        assert deploy_to_mocked.call_count == 1
 
-        self.assertFalse(current_handle_link_down)
+        assert current_handle_link_down is False
         msg = f"Failed to re-deploy {evc} after link down."
         log_mocked.debug.assert_called_once_with(msg)
 
@@ -368,7 +368,7 @@ class TestLinkProtection(TestCase):  # pylint: disable=too-many-public-methods
     @patch("napps.kytos.mef_eline.models.evc.EVCDeploy._send_flow_mods")
     @patch(DEPLOY_TO_PRIMARY_PATH)
     @patch("napps.kytos.mef_eline.models.path.Path.status", EntityStatus.DOWN)
-    def test_handle_link_down_case_4(
+    async def test_handle_link_down_case_4(
         self,
         deploy_to_mocked,
         _send_flow_mods_mocked,
@@ -422,15 +422,19 @@ class TestLinkProtection(TestCase):  # pylint: disable=too-many-public-methods
 
         deploy_to_mocked.reset_mock()
         current_handle_link_down = evc.handle_link_down()
-        self.assertEqual(deploy_to_mocked.call_count, 1)
+        assert deploy_to_mocked.call_count == 1
 
-        self.assertTrue(current_handle_link_down)
+        assert current_handle_link_down
         msg = f"{evc} deployed after link down."
         log_mocked.debug.assert_called_with(msg)
 
     @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.deploy")
     @patch("napps.kytos.mef_eline.models.evc.LinkProtection.deploy_to")
-    def test_handle_link_up_case_1(self, deploy_to_mocked, deploy_mocked):
+    async def test_handle_link_up_case_1(
+        self,
+        deploy_to_mocked,
+        deploy_mocked
+    ):
         """Test if handle link up do nothing when is using primary path."""
         deploy_mocked.return_value = True
         deploy_to_mocked.return_value = True
@@ -477,14 +481,18 @@ class TestLinkProtection(TestCase):  # pylint: disable=too-many-public-methods
         evc.current_path = evc.primary_path
         deploy_to_mocked.reset_mock()
         current_handle_link_up = evc.handle_link_up(backup_path[0])
-        self.assertEqual(deploy_mocked.call_count, 0)
-        self.assertEqual(deploy_to_mocked.call_count, 0)
-        self.assertTrue(current_handle_link_up)
+        assert deploy_mocked.call_count == 0
+        assert deploy_to_mocked.call_count == 0
+        assert current_handle_link_up
 
     @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.deploy")
     @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.deploy_to_path")
     @patch("napps.kytos.mef_eline.models.path.Path.status", EntityStatus.UP)
-    def test_handle_link_up_case_2(self, deploy_to_path_mocked, deploy_mocked):
+    async def test_handle_link_up_case_2(
+        self,
+        deploy_to_path_mocked,
+        deploy_mocked
+    ):
         """Test if it is changing from backup_path to primary_path."""
         deploy_mocked.return_value = True
         deploy_to_path_mocked.return_value = True
@@ -531,10 +539,10 @@ class TestLinkProtection(TestCase):  # pylint: disable=too-many-public-methods
         evc.current_path = evc.backup_path
         deploy_to_path_mocked.reset_mock()
         current_handle_link_up = evc.handle_link_up(primary_path[0])
-        self.assertEqual(deploy_mocked.call_count, 0)
-        self.assertEqual(deploy_to_path_mocked.call_count, 1)
+        assert deploy_mocked.call_count == 0
+        assert deploy_to_path_mocked.call_count == 1
         deploy_to_path_mocked.assert_called_once_with(evc.primary_path)
-        self.assertTrue(current_handle_link_up)
+        assert current_handle_link_up
 
     @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.deploy")
     @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.deploy_to_path")
@@ -542,7 +550,7 @@ class TestLinkProtection(TestCase):  # pylint: disable=too-many-public-methods
     @patch("napps.kytos.mef_eline.models.evc.EVC._install_nni_flows")
     @patch("napps.kytos.mef_eline.models.evc.EVC._install_uni_flows")
     @patch("napps.kytos.mef_eline.models.path.Path.status", EntityStatus.UP)
-    def test_handle_link_up_case_3(
+    async def test_handle_link_up_case_3(
         self,
         _install_uni_flows_mocked,
         _install_nni_flows_mocked,
@@ -598,18 +606,18 @@ class TestLinkProtection(TestCase):  # pylint: disable=too-many-public-methods
         deploy_to_path_mocked.reset_mock()
         current_handle_link_up = evc.handle_link_up(backup_path[0])
 
-        self.assertEqual(get_best_path_mocked.call_count, 0)
-        self.assertEqual(deploy_mocked.call_count, 0)
-        self.assertEqual(deploy_to_path_mocked.call_count, 1)
+        assert get_best_path_mocked.call_count == 0
+        assert deploy_mocked.call_count == 0
+        assert deploy_to_path_mocked.call_count == 1
         deploy_to_path_mocked.assert_called_once_with(evc.backup_path)
-        self.assertTrue(current_handle_link_up)
+        assert current_handle_link_up
 
     @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.deploy_to_path")
     @patch(GET_BEST_PATH)
     @patch("napps.kytos.mef_eline.models.evc.EVC._install_nni_flows")
     @patch("napps.kytos.mef_eline.models.evc.EVC._install_uni_flows")
     @patch("napps.kytos.mef_eline.models.path.Path.status", EntityStatus.DOWN)
-    def test_handle_link_up_case_4(self, *args):
+    async def test_handle_link_up_case_4(self, *args):
         """Test if not path is found a dynamic path is used."""
         (
             _install_uni_flows_mocked,
@@ -671,18 +679,18 @@ class TestLinkProtection(TestCase):  # pylint: disable=too-many-public-methods
         deploy_to_path_mocked.reset_mock()
         current_handle_link_up = evc.handle_link_up(backup_path[0])
 
-        self.assertEqual(get_best_path_mocked.call_count, 0)
-        self.assertEqual(deploy_to_path_mocked.call_count, 1)
+        assert get_best_path_mocked.call_count == 0
+        assert deploy_to_path_mocked.call_count == 1
         deploy_to_path_mocked.assert_called_once_with()
-        self.assertTrue(current_handle_link_up)
+        assert current_handle_link_up
 
-    def test_handle_link_up_case_5(self):
+    async def test_handle_link_up_case_5(self):
         """Test handle_link_up method."""
         return_false_mock = MagicMock(return_value=False)
         self.evc.is_using_primary_path = return_false_mock
         self.evc.primary_path.is_affected_by_link = return_false_mock
         self.evc.is_using_backup_path = MagicMock(return_value=True)
-        self.assertTrue(self.evc.handle_link_up(MagicMock()))
+        assert self.evc.handle_link_up(MagicMock())
 
         # not possible to deploy this evc (it will not benefit from link up)
         self.evc.is_using_backup_path = return_false_mock
@@ -690,4 +698,98 @@ class TestLinkProtection(TestCase):  # pylint: disable=too-many-public-methods
         self.evc.backup_path.is_affected_by_link = return_false_mock
         self.evc.dynamic_backup_path = True
         self.evc.deploy_to_path = return_false_mock
-        self.assertTrue(self.evc.handle_link_up(MagicMock()))
+        assert self.evc.handle_link_up(MagicMock())
+
+    async def test_get_interface_from_switch(self):
+        """Test get_interface_from_switch"""
+        interface = id_to_interface_mock('00:01:1')
+        interface.switch.interfaces = {1: interface}
+        switches = {
+            '00:01': interface.switch
+        }
+        uni = get_uni_mocked(is_valid=True, switch_dpid='00:01')
+        actual_interface = self.evc.get_interface_from_switch(uni, switches)
+        assert interface == actual_interface
+
+    @patch("napps.kytos.mef_eline.models.evc.EVCBase.sync")
+    async def test_handle_topology_update(self, mock_sync):
+        """Test handle_topology_update"""
+        self.evc.get_interface_from_switch = MagicMock()
+        self.evc.is_uni_interface_active = MagicMock()
+        self.evc.activate = MagicMock()
+        self.evc.deactivate = MagicMock()
+        interface = id_to_interface_mock('00:01:1')
+
+        self.evc.is_uni_interface_active.return_value = (True, None)
+        self.evc._active = False
+        self.evc.handle_topology_update('mocked_switches')
+        assert self.evc.activate.call_count == 1
+        assert self.evc.deactivate.call_count == 0
+        assert mock_sync.call_count == 1
+
+        self.evc.is_uni_interface_active.return_value = (False, interface)
+        self.evc._active = True
+        self.evc.handle_topology_update('mocked_switches')
+        assert self.evc.activate.call_count == 1
+        assert self.evc.deactivate.call_count == 1
+        assert mock_sync.call_count == 2
+
+        self.evc.is_uni_interface_active.return_value = (True, None)
+        self.evc._active = True
+        self.evc.handle_topology_update('mocked_switches')
+        assert self.evc.activate.call_count == 1
+        assert self.evc.deactivate.call_count == 1
+        assert mock_sync.call_count == 2
+
+    async def test_handle_topology_update_error(self):
+        """Test handle_topology_update with error and early return"""
+        self.evc.get_interface_from_switch = MagicMock()
+        self.evc.get_interface_from_switch.side_effect = KeyError
+        self.evc.is_uni_interface_active = MagicMock()
+
+        self.evc.handle_topology_update('mocked_switches')
+        assert self.evc.is_uni_interface_active.call_count == 0
+
+    async def test_are_unis_active(self):
+        """Test are_unis_active"""
+        interface = id_to_interface_mock('00:01:1')
+
+        interface.switch.interfaces = {1: interface}
+        switches = {
+            'custom_switch_dpid': interface.switch
+        }
+
+        interface.status_reason = set()
+        interface.status = EntityStatus.UP
+        assert self.evc.are_unis_active(switches) is True
+
+        interface.status_reason = {'disabled'}
+        assert self.evc.are_unis_active(switches) is False
+
+        interface.status_reason = set()
+        interface.status = EntityStatus.DISABLED
+        assert self.evc.are_unis_active(switches) is False
+
+    async def test_is_uni_interface_active(self):
+        """Test is_uni_interface_active"""
+        interface_a = id_to_interface_mock('00:01:1')
+        interface_a.status_reason = set()
+        interface_z = id_to_interface_mock('00:03:1')
+        interface_z.status_reason = set()
+
+        interface_a.status = EntityStatus.UP
+        interface_z.status = EntityStatus.UP
+        actual = self.evc.is_uni_interface_active(interface_a, interface_z)
+        expected = (True, None)
+        assert actual == expected
+
+        interface_a.status = EntityStatus.DOWN
+        actual = self.evc.is_uni_interface_active(interface_a, interface_z)
+        expected = (False, interface_a)
+        assert actual == expected
+
+        interface_a.status = EntityStatus.UP
+        interface_z.status = EntityStatus.DOWN
+        actual = self.evc.is_uni_interface_active(interface_a, interface_z)
+        expected = (False, interface_z)
+        assert actual == expected

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2288,3 +2288,20 @@ class TestMain:
         calls = self.napp.mongo_controller.update_evcs.call_count
         assert calls == 1
         assert evc_mock.remove_metadata.call_count == 1
+
+    async def test_handle_topology_update(self):
+        """Test handle_topology_update"""
+        evc_mock = create_autospec(EVC)
+        evc_mock.service_level, evc_mock.creation_time = 0, 1
+        evc_mock.is_enabled = MagicMock(side_effect=[True, False, True])
+        evc_mock.lock = MagicMock()
+        type(evc_mock).archived = PropertyMock(
+            side_effect=[True, False, False]
+        )
+        evcs = [evc_mock, evc_mock, evc_mock]
+        topology = MagicMock()
+        topology.switches = "mock"
+        event = KytosEvent(name="test", content={"topology": topology})
+        self.napp.circuits = dict(zip(["1", "2", "3"], evcs))
+        self.napp.handle_topology_update(event)
+        evc_mock.handle_topology_update.assert_called_once_with("mock")


### PR DESCRIPTION
Closes #338 

### Summary
Added listener for `kytos/topology.updated` for recent disabled interfaces
Added new condition to circuit consistency to additionally check for interfaces

### Local Tests

Create an EVC and disable the interface of one of the UNIs
Check if consistency check enables the previous EVC only when its interfaces have been enabled

### APM
Teste with 400 EVCs with `uni_a` interface `00:00:00:00:00:00:00:01:1`
Activating and deactivating interface `00:00:00:00:00:00:00:01:1` in intervals of 5 seconds yields these results:

MongoDB:

![image](https://github.com/kytos-ng/mef_eline/assets/55767214/8dad47b6-e3be-4b2b-88c0-a8afc06c65fe)

Kytos Transactions:

![image](https://github.com/kytos-ng/mef_eline/assets/55767214/b620e5b3-cda4-418c-82e1-ba697584d915)

Kytos dependency:

![image](https://github.com/kytos-ng/mef_eline/assets/55767214/be59288e-a19b-4291-869c-a2c14e13c8ca)
