### PR TITLE
feat: exposed default `SPF_ATTRIBUTE` on settings.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Added
 - Subscribed to new event ``kytos/of_multi_table.enable_table`` as well as publishing ``kytos/mef_eline.enable_table`` required to set a different ``table_id`` to flows.
 - Added ``settings.TABLE_GROUP_ALLOWED`` set containning the allowed table groups, for now ``'evpl', 'epl'`` are supported.
 - Added ui support for primary and secondary constraints
+- Exposed default ``SPF_ATTRIBUTE`` on settings.py, by default it still uses ``"hop"`` to not break compatibility, when creating an EVC if ``primary_constraint.spf_attribute``  or ``secondary_constraints.spf_attribute`` isn't present, then it'll use this value as default.
 
 Changed
 =======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,7 @@ Added
 - Subscribed to new event ``kytos/of_multi_table.enable_table`` as well as publishing ``kytos/mef_eline.enable_table`` required to set a different ``table_id`` to flows.
 - Added ``settings.TABLE_GROUP_ALLOWED`` set containning the allowed table groups, for now ``'evpl', 'epl'`` are supported.
 - Added ui support for primary and secondary constraints
-- Exposed default ``SPF_ATTRIBUTE`` on settings.py, by default it still uses ``"hop"`` to not break compatibility, when creating an EVC if ``primary_constraint.spf_attribute``  or ``secondary_constraints.spf_attribute`` isn't present, then it'll use this value as default.
+- Exposed default ``SPF_ATTRIBUTE`` on settings.py, by default it still uses ``"hop"`` to not break compatibility, when creating an EVC if ``primary_constraint.spf_attribute``  or ``secondary_constraints.spf_attribute`` isn't set, then it'll use this value as default.
 
 Changed
 =======

--- a/db/models.py
+++ b/db/models.py
@@ -7,6 +7,8 @@ from typing import Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, Field, validator
 
+from napps.kytos.mef_eline import settings
+
 
 class DocumentBaseModel(BaseModel):
     """Base model for Mongo documents"""
@@ -69,7 +71,7 @@ class LinkConstraints(BaseModel):
 
 class PathConstraints(BaseModel):
     """Pathfinder Constraints."""
-    spf_attribute: Optional[Literal["hop", "delay", "priority"]]
+    spf_attribute: Literal["hop", "delay", "priority"] = settings.SPF_ATTRIBUTE
     spf_max_path_cost: Optional[float]
     mandatory_metrics: Optional[LinkConstraints]
     flexible_metrics: Optional[LinkConstraints]

--- a/db/models.py
+++ b/db/models.py
@@ -69,7 +69,7 @@ class LinkConstraints(BaseModel):
 
 class PathConstraints(BaseModel):
     """Pathfinder Constraints."""
-    spf_attribute: Literal["hop", "delay", "priority"] = "hop"
+    spf_attribute: Optional[Literal["hop", "delay", "priority"]]
     spf_max_path_cost: Optional[float]
     mandatory_metrics: Optional[LinkConstraints]
     flexible_metrics: Optional[LinkConstraints]

--- a/models/evc.py
+++ b/models/evc.py
@@ -51,6 +51,7 @@ class EVCBase(GenericEntity):
     ]
     required_attributes = ["name", "uni_a", "uni_z"]
 
+    # pylint: disable=too-many-statements
     def __init__(self, controller, **kwargs):
         """Create an EVC instance with the provided parameters.
 

--- a/models/evc.py
+++ b/models/evc.py
@@ -118,7 +118,12 @@ class EVCBase(GenericEntity):
         self.backup_path = Path(kwargs.get("backup_path", []))
         self.dynamic_backup_path = kwargs.get("dynamic_backup_path", False)
         self.primary_constraints = kwargs.get("primary_constraints", {})
+        spf_attribute = settings.SPF_ATTRIBUTE
+        if not self.primary_constraints.get("spf_attribute"):
+            self.primary_constraints["spf_attribute"] = spf_attribute
         self.secondary_constraints = kwargs.get("secondary_constraints", {})
+        if not self.secondary_constraints.get("spf_attribute"):
+            self.secondary_constraints["spf_attribute"] = spf_attribute
         self.creation_time = get_time(kwargs.get("creation_time")) or now()
         self.owner = kwargs.get("owner", None)
         self.sb_priority = kwargs.get("sb_priority", None) or kwargs.get(

--- a/openapi.yml
+++ b/openapi.yml
@@ -520,7 +520,7 @@ components:
             - "ee8d9017-1efd-49ac-9149-4cbeea86f751"
         spf_attribute:
           type: string
-          description: Link metadata attribute that will be used as link cost by SPF.
+          description: Link metadata attribute that will be used as link cost by SPF. If it is null, the default value will be settings.SPF_ATTRIBUTE, which defaults to "hop"
           default: "hop"
           enum: 
             - "hop"

--- a/scripts/002_reset_spf_attribute.py
+++ b/scripts/002_reset_spf_attribute.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from napps.kytos.mef_eline.controllers import ELineController
+import os
+import sys
+
+
+def reset_primary_constraints_spf_attr(controller: ELineController, value: str) -> int:
+    """Reset primary_constraints.spf_attribute."""
+    db = controller.db
+    return db.evcs.update_many(
+        {"primary_constraints.spf_attribute": "hop"},
+        {"$set": {"primary_constraints.spf_attribute": value}},
+    ).modified_count
+
+
+def reset_secondary_constraints_spf_attr(
+    controller: ELineController, value: str
+) -> int:
+    """Reset secondary_constraints.spf_attribute."""
+    db = controller.db
+    return db.evcs.update_many(
+        {"secondary_constraints.spf_attribute": "hop"},
+        {"$set": {"secondary_constraints.spf_attribute": value}},
+    ).modified_count
+
+
+def main() -> None:
+    """Main function."""
+    controller = ELineController()
+    value = os.getenv("SPF_ATTRIBUTE")
+    expected_values = {"hop", "priority", "delay"}
+    if not value or value not in expected_values:
+        print(
+            f"'SPF_ATTRIBUTE' env: '{value}', "
+            f"expected one of these values: {expected_values}.\n"
+            "Please, set the SPF_ATTRIBUTE env var."
+        )
+        sys.exit(1)
+
+    count = reset_primary_constraints_spf_attr(controller, value)
+    print(f"Updated {count} primary_constraints spf_attribute as {value}")
+    count = reset_secondary_constraints_spf_attr(controller, value)
+    print(f"Updated {count} secondary_constraints spf_attribute as {value}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -51,3 +51,17 @@ And then, to insert (or update) the EVCs:
 ```
 CMD=insert_evcs python3 scripts/storehouse_to_mongo.py
 ```
+
+### Reset default spf_attribute value
+
+[`002_reset_spf_attribute.py`](./002_reset_spf_attribute.py) is a script to reset both `primary_constraints.spf_attribute` and `secondary_constraints.spf_attribute` from `"hop"` to any of the supported values `"priority"` or `"delay"`. You should only use this script, if you wish to change the default values of EVCs that were created on version 2022.3 and you'd like to change the value without having to call `PATCH /v2/evc/{circuit_id}` for each EVC.
+
+#### How to use
+
+- Here's an example, trying to reset any `primary_constraints.spf_attribute` or  `secondary_constraints.spf_attribute` to `"priority"`, this script is idempotent:
+
+```
+SPF_ATTRIBUTE=priority python3 scripts/002_reset_spf_attribute.py
+```
+
+- After that, `kytosd` should be restarted just so `mef_eline` EVCs can get fully reloaded in memory, this would be the safest route.

--- a/settings.py
+++ b/settings.py
@@ -50,3 +50,6 @@ TIME_RECENT_DELETED_FLOWS = 60
 TIME_RECENT_UPDATED = 60
 
 TABLE_GROUP_ALLOWED = {'evpl', 'epl'}
+
+# Default spf_attribute. Allowed values: "hop", "priority", and "delay"
+SPF_ATTRIBUTE = "hop"

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -10,6 +10,7 @@ from kytos.core.interface import UNI, Interface
 from napps.kytos.mef_eline.exceptions import InvalidPath
 from napps.kytos.mef_eline.models import EVC
 from napps.kytos.mef_eline.tests.helpers import get_uni_mocked
+from napps.kytos.mef_eline import settings
 
 
 async def test_on_table_enabled():
@@ -477,8 +478,14 @@ class TestMain:
             uni_a=uni1,
             uni_z=uni2,
             dynamic_backup_path=True,
-            primary_constraints=payload["primary_constraints"],
-            secondary_constraints=payload["secondary_constraints"],
+            primary_constraints={
+                **{"spf_attribute": settings.SPF_ATTRIBUTE},
+                **payload["primary_constraints"]
+            },
+            secondary_constraints={
+                **{"spf_attribute": settings.SPF_ATTRIBUTE},
+                **payload["secondary_constraints"]
+            },
         )
         # verify save method is called
         mongo_controller_upsert_mock.assert_called_once()

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -298,7 +298,8 @@ module.exports = {
        * Method to build option items for spf attribute.
        */
       let _result = [
-        {value: "hop", description: "hop", selected: true},
+        {value: null, description: "default", selected: true},
+        {value: "hop", description: "hop"},
         {value: "delay", description: "delay"},
         {value: "priority", description: "priority"},
       ];


### PR DESCRIPTION
Closes #351 

I'll send a backport for 2022.3 shortly

### Summary

See updated changelog file

### Notes

For the backported PR, after following `scripts/README.md` instructions of the `002_reset_spf_attribute.py` script, you'll probably want the EVC to converge, just so the new value can be used accordingly, at that point it's up to you'll expect a link down event to eventually make it to converge or force a redeploy.

### Local Tests

I ran the following tests:

- Created a new EVC via the UI using the `default` spf_attribute, confirming that it wouldn't set it as expected
- Create a new EVC via the UI setting the `spf_attribute` to any other explicit value and it set as expected too
- I executed the DB scripts with EVCs that still had `primary_constraints.spf_attribute = "hop"` to confirm the script would run correctly

![20230712_105017](https://github.com/kytos-ng/mef_eline/assets/1010796/bd9440d6-d607-441c-8a4b-d52688df828e)
![20230712_105032](https://github.com/kytos-ng/mef_eline/assets/1010796/3d6720f8-936b-4bba-88c6-4835b4ca6dec)
![20230712_105110](https://github.com/kytos-ng/mef_eline/assets/1010796/ebfcc1c9-4050-4970-be29-950d7253c8a2)

Before running the script using some EVCs in the DB:

```
rs0 [direct: primary] napps> db.evcs.find({}, {"primary_constraints": 1, "secondary_constraints": 1})
[
  {
    _id: 'bb8e1f1aca954e',
    primary_constraints: { spf_attribute: 'priority' },
    secondary_constraints: { spf_attribute: 'priority' }
  },
  {
    _id: '2ac2be8a75cd4d',
    primary_constraints: { spf_attribute: 'hop', spf_max_path_cost: 11 },
    secondary_constraints: { spf_attribute: 'priority' }
  }
]
```

```
❯ SPF_ATTRIBUTE=priority python3 scripts/002_reset_spf_attribute.py
Updated 1 primary_constraints spf_attribute as priority
Updated 0 secondary_constraints spf_attribute as priority

❯ SPF_ATTRIBUTE=priority python3 scripts/002_reset_spf_attribute.py
Updated 0 primary_constraints spf_attribute as priority
Updated 0 secondary_constraints spf_attribute as priority
```

After running the script:

```
rs0 [direct: primary] napps> db.evcs.find({}, {"primary_constraints": 1, "secondary_constraints": 1})
[
  {
    _id: 'bb8e1f1aca954e',
    primary_constraints: { spf_attribute: 'priority' },
    secondary_constraints: { spf_attribute: 'priority' }
  },
  {
    _id: '2ac2be8a75cd4d',
    primary_constraints: { spf_attribute: 'priority', spf_max_path_cost: 11 },
    secondary_constraints: { spf_attribute: 'priority' }
  }
]

```

- Also created via API, after changing `settings.SPF_ATTRIBUTE = "priority"`:

```
❯ echo '{ "name": "epl", "service_level": 7, "dynamic_backup_path": true, "uni_a": { "interface_id": "00:00:00:00:00:00:00:01:1" }, "uni_z": { "interface_id": "00:00:00:00:00:00:00:03:1"
 } }' | http http://127.0.0.1:8181/api/kytos/mef_eline/v2/evc/
HTTP/1.1 201 Created
content-length: 31
content-type: application/json
date: Wed, 12 Jul 2023 13:54:30 GMT
server: uvicorn

{
    "circuit_id": "bb8e1f1aca954e"
}

❯ http http://127.0.0.1:8181/api/kytos/mef_eline/v2/evc/ | jq | grep 'spf_attribute'
      "spf_attribute": "priority"
      "spf_attribute": "priority"

```



### End-to-End Tests

I'll dispatch e2e execution shortly, I don't expect surprises though since it's not breaking compatibility. I'll post the results here later.