### PR TITLE
feat: exposed default `SPF_ATTRIBUTE` on settings.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Added
 - Subscribed to new event ``kytos/of_multi_table.enable_table`` as well as publishing ``kytos/mef_eline.enable_table`` required to set a different ``table_id`` to flows.
 - Added ``settings.TABLE_GROUP_ALLOWED`` set containning the allowed table groups, for now ``'evpl', 'epl'`` are supported.
 - Added ui support for primary and secondary constraints
+- Exposed default ``SPF_ATTRIBUTE`` on settings.py, the default value is still `"hop"`. This value will be parametrized whenever ``primary_constraints.spf_attribute`` or ``secondary_constraints.spf_attribute`` isn't set
 
 Changed
 =======
@@ -31,6 +32,8 @@ Changed
 - Changed ui constraints default values to pass the spec validation
 - Changed intra-switch EVC with a disabled switch or interface is not longer allowed to be created
 - Adapted ``mef_eline`` to ordered endpoints in a link. Endpoints for flow creation are compared with switch ids to overcome ordered endpoint.
+- ``primary_constraints.spf_attribute`` and ``secondary_constraints.spf_attribute`` will only be set in the database if they've been set in the request.
+- Changed UI spf_attribute to allow it to be ``default``, meaning an unset value
 
 General Information
 ===================

--- a/db/models.py
+++ b/db/models.py
@@ -69,7 +69,7 @@ class LinkConstraints(BaseModel):
 
 class PathConstraints(BaseModel):
     """Pathfinder Constraints."""
-    spf_attribute: Literal["hop", "delay", "priority"] = "hop"
+    spf_attribute: Optional[Literal["hop", "delay", "priority"]]
     spf_max_path_cost: Optional[float]
     mandatory_metrics: Optional[LinkConstraints]
     flexible_metrics: Optional[LinkConstraints]

--- a/models/path.py
+++ b/models/path.py
@@ -125,10 +125,12 @@ class DynamicPathManager:
     def get_paths(circuit, max_paths=2, **kwargs):
         """Get a valid path for the circuit from the Pathfinder."""
         endpoint = settings.PATHFINDER_URL
+        spf_attribute = kwargs.get("spf_attribute") or settings.SPF_ATTRIBUTE
         request_data = {
             "source": circuit.uni_a.interface.id,
             "destination": circuit.uni_z.interface.id,
             "spf_max_paths": max_paths,
+            "spf_attribute": spf_attribute
         }
         request_data.update(kwargs)
         api_reply = requests.post(endpoint, json=request_data)

--- a/openapi.yml
+++ b/openapi.yml
@@ -520,7 +520,7 @@ components:
             - "ee8d9017-1efd-49ac-9149-4cbeea86f751"
         spf_attribute:
           type: string
-          description: Link metadata attribute that will be used as link cost by SPF.
+          description: Link metadata attribute that will be used as link cost by SPF. If it's ommited, the default value will be settings.SPF_ATTRIBUTE, which defaults to "hop"
           default: "hop"
           enum: 
             - "hop"

--- a/openapi.yml
+++ b/openapi.yml
@@ -520,7 +520,7 @@ components:
             - "ee8d9017-1efd-49ac-9149-4cbeea86f751"
         spf_attribute:
           type: string
-          description: Link metadata attribute that will be used as link cost by SPF. If it's ommited, the default value will be settings.SPF_ATTRIBUTE, which defaults to "hop"
+          description: Link metadata attribute that will be used as link cost by SPF. If it's not set, the default value will be settings.SPF_ATTRIBUTE, which defaults to "hop"
           default: "hop"
           enum: 
             - "hop"

--- a/scripts/002_unset_spf_attribute.py
+++ b/scripts/002_unset_spf_attribute.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from napps.kytos.mef_eline.controllers import ELineController
+import os
+import sys
+from typing import Iterable
+
+
+def unset_primary_constraints_spf_attr(
+    controller: ELineController, evc_ids: Iterable[str] = None
+) -> int:
+    """Unset primary_constraints.spf_attribute."""
+    db = controller.db
+    filter_expr = {"primary_constraints.spf_attribute": "hop"}
+    if evc_ids:
+        {"_id": {"$in": [evc_ids]}}
+    return db.evcs.update_many(
+        filter_expr,
+        {"$unset": {"primary_constraints.spf_attribute": 1}},
+    ).modified_count
+
+
+def unset_secondary_constraints_spf_attr(
+    controller: ELineController, evc_ids: Iterable[str] = None
+) -> int:
+    """Unset secondary_constraints.spf_attribute."""
+    db = controller.db
+    if evc_ids:
+        {"_id": {"$in": [evc_ids]}}
+    filter_expr = {"secondary_constraints.spf_attribute": "hop"}
+    return db.evcs.update_many(
+        filter_expr,
+        {"$unset": {"secondary_constraints.spf_attribute": 1}},
+    ).modified_count
+
+
+def main() -> None:
+    """Main function."""
+    controller = ELineController()
+    evc_ids = [e for e in os.getenv("EVC_IDS", "").split(",") if e]
+
+    not_found = []
+    circuits = controller.get_circuits()["circuits"]
+    not_found = [e for e in evc_ids if e not in circuits]
+    if not_found:
+        print(
+            f"The following evc_ids weren't found: {not_found}\n"
+            f"Make sure that evc string in EVC_IDS is a valid evc_id "
+            "and it's separated by a comma"
+        )
+        sys.exit(1)
+
+    count = unset_primary_constraints_spf_attr(controller, evc_ids)
+    print(f"Unset {count} primary_constraints spf_attribute, evc_ids: {evc_ids}")
+    count = unset_secondary_constraints_spf_attr(controller, evc_ids)
+    print(f"Unset {count} secondary_constraints spf_attribute, evc_ids: {evc_ids}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -51,3 +51,23 @@ And then, to insert (or update) the EVCs:
 ```
 CMD=insert_evcs python3 scripts/storehouse_to_mongo.py
 ```
+
+### Unset default spf_attribute value
+
+[`002_unset_spf_attribute.py`](./002_unset_spf_attribute.py) is a script to unset both `primary_constraints.spf_attribute` and `secondary_constraints.spf_attribute`. On version 2022.3, this value was explicitly set, so you can use this script to unset this value if you want that spf_attribute follows the default settings.SPF_ATTRIBUTE value.
+
+#### How to use
+
+- Here's an example trying to unset any `primary_constraints.spf_attribute` or  `secondary_constraints.spf_attribute` from all evcs:
+
+```
+priority python3 scripts/002_unset_spf_attribute.py
+```
+
+- Here's an example trying to unset any `primary_constraints.spf_attribute` or  `secondary_constraints.spf_attribute` from all EVCs 'd33539656d8b40,095e1d6f43c745':
+
+```
+EVC_IDS='d33539656d8b40,095e1d6f43c745' priority python3 scripts/002_unset_spf_attribute.py
+```
+
+- After that, `kytosd` should be restarted just so `mef_eline` EVCs can get fully reloaded in memory with the expected primary and secondary constraints, this would be the safest route.

--- a/settings.py
+++ b/settings.py
@@ -50,3 +50,6 @@ TIME_RECENT_DELETED_FLOWS = 60
 TIME_RECENT_UPDATED = 60
 
 TABLE_GROUP_ALLOWED = {'evpl', 'epl'}
+
+# Default spf_attribute. Allowed values: "hop", "priority", and "delay"
+SPF_ATTRIBUTE = "hop"

--- a/tests/unit/models/test_path.py
+++ b/tests/unit/models/test_path.py
@@ -8,7 +8,7 @@ from kytos.core.common import EntityStatus
 from kytos.core.link import Link
 from kytos.core.switch import Switch
 
-# pylint: disable=wrong-import-position
+# pylint: disable=wrong-import-position,ungrouped-imports
 
 sys.path.insert(0, "/var/lib/kytos/napps/..")
 # pylint: enable=wrong-import-position

--- a/tests/unit/models/test_path.py
+++ b/tests/unit/models/test_path.py
@@ -1,7 +1,8 @@
 """Module to test the Path class."""
 import sys
 from unittest import TestCase
-from unittest.mock import call, patch, Mock, MagicMock
+from unittest.mock import MagicMock, Mock, call, patch
+from napps.kytos.mef_eline import settings
 
 from kytos.core.common import EntityStatus
 from kytos.core.link import Link
@@ -12,13 +13,10 @@ from kytos.core.switch import Switch
 sys.path.insert(0, "/var/lib/kytos/napps/..")
 # pylint: enable=wrong-import-position
 from napps.kytos.mef_eline.exceptions import InvalidPath  # NOQA pycodestyle
-from napps.kytos.mef_eline.models import Path, DynamicPathManager  # NOQA pycodestyle
-from napps.kytos.mef_eline.tests.helpers import (
-    MockResponse,
-    id_to_interface_mock,
-    get_link_mocked,
-    get_mocked_requests,
-)  # NOQA pycodestyle
+from napps.kytos.mef_eline.models import (  # NOQA pycodestyle
+    DynamicPathManager, Path)
+from napps.kytos.mef_eline.tests.helpers import (  # NOQA pycodestyle
+    MockResponse, get_link_mocked, get_mocked_requests, id_to_interface_mock)
 
 
 class TestPath(TestCase):
@@ -414,6 +412,7 @@ class TestDynamicPathManager(TestCase):
         mock_response.json.return_value = paths1
         mock_requests_post.return_value = mock_response
         kwargs = {
+            "spf_attribute": settings.SPF_ATTRIBUTE,
             "spf_max_path_cost": 8,
             "mandatory_metrics": {
                 "ownership": "red"
@@ -456,6 +455,7 @@ class TestDynamicPathManager(TestCase):
 
         evc = MagicMock()
         evc.secondary_constraints = {
+            "spf_attribute": "hop",
             "spf_max_path_cost": 20,
             "mandatory_metrics": {
                 "ownership": "red"

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -450,6 +450,7 @@ class TestMain:
                 }
             },
             "secondary_constraints": {
+                "spf_attribute": "priority",
                 "mandatory_metrics": {
                     "ownership": "blue"
                 }

--- a/ui/k-info-panel/show_circuit.kytos
+++ b/ui/k-info-panel/show_circuit.kytos
@@ -316,6 +316,7 @@ module.exports = {
         _spf = this.constraints[type].spf_attribute;
       }
       let _result = [
+        {value: null, description: "default", selected: (_spf == undefined || _spf == '' || _spf == null)},
         {value: "hop", description: "hop", selected: (_spf == 'hop')},
         {value: "delay", description: "delay", selected: (_spf == 'delay')},
         {value: "priority", description: "priority", selected: (_spf == 'priority')},
@@ -777,7 +778,7 @@ module.exports = {
             this.constraints[_type].undesired_links.filter(item => typeof(item) == "string")
           );
         }
-        if(this.constraints[_type].spf_attribute !== undefined && this.constraints[_type].spf_attribute !== "") {
+        if(this.constraints[_type].spf_attribute) {
           _constraint_payload.spf_attribute = this.constraints[_type].spf_attribute;
         }
 

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -298,7 +298,8 @@ module.exports = {
        * Method to build option items for spf attribute.
        */
       let _result = [
-        {value: "hop", description: "hop", selected: true},
+        {value: null, description: "default", selected: true},
+        {value: "hop", description: "hop"},
         {value: "delay", description: "delay"},
         {value: "priority", description: "priority"},
       ];


### PR DESCRIPTION
Closes #351 

This PR supersedes PR #352, due to a new requirement implementation detail 

I'll send a backport for 2022.3 shortly

### Summary

See updated changelog file

### Local Tests

I ran the following tests:

- Created a new EVC via the UI using the `default` spf_attribute, confirming that it wouldn't set it as expected
- Updated an EVC in the UI, changed to a non default value and changed back again to default, and it only set the attr when it was non default in the request to mef_eline
- I executed the DB scripts with EVCs that still had `primary_constraints.spf_attribute = "hop"` to confirm the script would run correctly

```
rs0 [direct: primary] napps> db.evcs.find({}, {"primary_constraints": 1, "secondary_constraints": 1})
[
  {
    _id: '065c4df04a9244',
    primary_constraints: {
      spf_max_path_cost: 10,
      mandatory_metrics: {},
      flexible_metrics: {},
      spf_attribute: 'hop'
    },
    secondary_constraints: { mandatory_metrics: {}, flexible_metrics: {} }
  },
  {
    _id: 'c9f0f61af66b42',
    primary_constraints: { spf_attribute: 'hop', spf_max_path_cost: 11 },
    secondary_constraints: {}
  },
  {
    _id: '30da2c6564ed47',
    primary_constraints: { spf_attribute: 'priority', spf_max_path_cost: 11 },
    secondary_constraints: {}
  }
]
```

```
❯ EVC_IDS='065c4df04a9244,c9f0f61af66b42' python3 scripts/002_unset_spf_attribute.py
Unset 2 primary_constraints spf_attribute, evc_ids: ['065c4df04a9244', 'c9f0f61af66b42']
Unset 0 secondary_constraints spf_attribute, evc_ids: ['065c4df04a9244', 'c9f0f61af66b42']

❯ EVC_IDS='065c4df04a9244,c9f0f61af66b42' python3 scripts/002_unset_spf_attribute.py
Unset 0 primary_constraints spf_attribute, evc_ids: ['065c4df04a9244', 'c9f0f61af66b42']
Unset 0 secondary_constraints spf_attribute, evc_ids: ['065c4df04a9244', 'c9f0f61af66b42']
```

```
rs0 [direct: primary] napps> db.evcs.find({}, {"primary_constraints": 1, "secondary_constraints": 1})
[
  {
    _id: '065c4df04a9244',
    primary_constraints: {
      spf_max_path_cost: 10,
      mandatory_metrics: {},
      flexible_metrics: {}
    },
    secondary_constraints: { mandatory_metrics: {}, flexible_metrics: {} }
  },
  {
    _id: 'c9f0f61af66b42',
    primary_constraints: { spf_max_path_cost: 11 },
    secondary_constraints: {}
  },
  {
    _id: '30da2c6564ed47',
    primary_constraints: { spf_attribute: 'priority', spf_max_path_cost: 11 },
    secondary_constraints: {}
  }
]
```

### End-to-End Tests

I'll dispatch e2e execution shortly, I don't expect surprises though since it's not breaking compatibility. I'll post the results here later.