### PR TITLE
Remove the early return with `type==last`

### DIFF
--- a/models/evc.py
+++ b/models/evc.py
@@ -1218,27 +1218,10 @@ class EVCDeploy(EVCBase):
             return {"result": []}
         return response.json()
 
-    @staticmethod
-    def trace_invalid(trace):
-        """Auxiliar function to check traces"""
-        if not trace or trace[-1]['type'] != 'last':
-            return True
-        return False
-
     # pylint: disable=too-many-return-statements
     @staticmethod
     def check_trace(circuit, trace_a, trace_z):
         """Auxiliar function to check an individual trace"""
-        if EVCDeploy.trace_invalid(trace_a):
-            log.warning(
-                f"Invalid trace from trace_a: {trace_a}"
-            )
-            return False
-        if EVCDeploy.trace_invalid(trace_z):
-            log.warning(
-                f"Invalid trace from trace_z: {trace_z}"
-            )
-            return False
         if (
             len(trace_a) != len(circuit.current_path) + 1
             or not compare_uni_out_trace(circuit.uni_z, trace_a[-1])

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -1810,7 +1810,7 @@ class TestEVC():
                 "dpid": 1,
                 "port": 9,
                 "time": "t3",
-                "type": "incomplete",
+                "type": "last",
                 "vlan": 5
             },
         ]
@@ -1819,8 +1819,8 @@ class TestEVC():
                                                 "result": [trace_a, trace_z]
                                             }
         result = EVCDeploy.check_list_traces([evc])
-        # type incomplete
-        assert result[evc.id] is False
+
+        assert result[evc.id] is True
 
         trace_z = [
             {
@@ -1834,10 +1834,9 @@ class TestEVC():
                 "dpid": 2,
                 "port": 11,
                 "time": "t2",
-                "type": "intermediary",
+                "type": "loop",
                 "vlan": 6
             },
-            {"dpid": 1, "port": 9, "time": "t3", "type": "loop", "vlan": 5},
         ]
 
         run_bulk_sdntraces_mock.return_value = {


### PR DESCRIPTION
Related to [issue 102](https://github.com/kytos-ng/sdntrace_cp/issues/102)

### Summary

`type==last` is not checked anymore in `check_trace`.

### Local Test

See [related PR in `sdntrace_cp`](https://github.com/kytos-ng/sdntrace_cp/pull/106)

### End-to-end Test

In progress.