### PR TITLE
chore: updated changelog for pr 360

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [Unreleased]
 ************
 
+Added
+=====
+- Added a UI button for redeploying an EVC
+
 [2023.1.0] - 2023-06-27
 ***********************
 
@@ -22,7 +26,6 @@ Added
 - Added ui support for primary and secondary constraints
 - Added ``QUEUE_ID`` to ``settings.py`` to be the default value for EVCs ``"queue_id"``
 - Exposed default ``SPF_ATTRIBUTE`` on settings.py, the default value is still `"hop"`. This value will be parametrized whenever ``primary_constraints.spf_attribute`` or ``secondary_constraints.spf_attribute`` isn't set
-- Added a button for redeploying EVC
 
 Changed
 =======


### PR DESCRIPTION
Due to lack of remote write permission on PR #360, I had to open this new PR to update changelog

### Local tests

```
2023-08-29 16:25:20,533 - INFO [uvicorn.access] (MainThread) 127.0.0.1:36898 - "PATCH /api/kytos/mef_eline/v2/evc/e511f8c9068546/redeploy HTTP/1.1" 202
```

![20230829_162529](https://github.com/kytos-ng/mef_eline/assets/1010796/7fb1890a-609d-46f3-9e0c-de62cf4c6874)
