### PR TITLE
Added uni tag usage

### DIFF
--- a/models/path.py
+++ b/models/path.py
@@ -32,16 +32,19 @@ class Path(list, GenericEntity):
                 return link
         return None
 
-    def choose_vlans(self):
+    def choose_vlans(self, controller):
         """Choose the VLANs to be used for the circuit."""
         for link in self:
-            tag = link.get_next_available_tag()
+            tag = link.get_next_available_tag(controller)
             link.add_metadata("s_vlan", tag)
 
-    def make_vlans_available(self):
+    def make_vlans_available(self, controller):
         """Make the VLANs used in a path available when undeployed."""
         for link in self:
-            link.make_tag_available(link.get_metadata("s_vlan"))
+            tag = link.get_metadata("s_vlan")
+            link.make_tag_available(
+                controller, tag.value, str(tag.tag_type.value)
+            )
             link.remove_metadata("s_vlan")
 
     def is_valid(self, switch_a, switch_z, is_scheduled=False):

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -5,5 +5,5 @@
 #    pip-compile --output-file requirements/dev.txt requirements/dev.in
 #
 -e git+https://github.com/kytos-ng/python-openflow.git#egg=python-openflow
--e git+https://github.com/kytos-ng/kytos.git#egg=kytos[dev]
+-e git+https://github.com/kytos-ng/kytos.git@epic/vlan_pool#egg=kytos[dev]
 -e .

--- a/tests/unit/models/test_link_protection.py
+++ b/tests/unit/models/test_link_protection.py
@@ -148,7 +148,6 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
         assert expected_deployed
 
     # pylint: disable=too-many-arguments
-    @patch("napps.kytos.mef_eline.models.evc.notify_link_available_tags")
     @patch("requests.post")
     @patch("napps.kytos.mef_eline.controllers.ELineController.upsert_evc")
     @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.deploy")
@@ -162,7 +161,6 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
         deploy_mocked,
         _,
         requests_mock,
-        notify_mock
     ):
         """Test deploy with all links up."""
         deploy_mocked.return_value = True
@@ -188,7 +186,6 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
         install_uni_flows_mocked.assert_called_with(evc.primary_path)
         install_nni_flows_mocked.assert_called_with(evc.primary_path)
         assert deployed
-        notify_mock.assert_called()
 
     @patch("requests.get", side_effect=get_mocked_requests)
     async def test_deploy_to_case_3(self, requests_mocked):

--- a/utils.py
+++ b/utils.py
@@ -29,14 +29,6 @@ async def aemit_event(controller, name, content):
     await controller.buffers.app.aput(event)
 
 
-def notify_link_available_tags(controller, link, src_func=None):
-    """Notify link available tags."""
-    emit_event(controller, "link_available_tags", content={
-        "link": link,
-        "src_func": src_func
-    })
-
-
 def compare_endpoint_trace(endpoint, vlan, trace):
     """Compare and endpoint with a trace step."""
     if vlan and "vlan" in trace:


### PR DESCRIPTION
Closes #324 
Closes #367 

### Summary

Delete deprecated `notify_link_available_tags` method from `utils.py`
Adapted NNI tags to `vlan_pool` epic contributions
UNIs now use and make available tags when required (when created, updated, deleted)

### Local tests

Created, updated and deleted EVC, missing doing these actions in mass.
Uni test are missing

### End-to-End Tests
In progress

Note:
- Leaving this PR as draft, until I address other PRs that this one depends on.