### PR TITLE
Prevent race conditions in failover_path

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ Added
 =====
 - Added a UI button for redeploying an EVC
 
+Fixed
+=====
+- fixed race condition in ``failover_path`` when handling simulataneous Link Down events leading to inconsistencies on some EVC
+
 [2023.1.0] - 2023-06-27
 ***********************
 

--- a/main.py
+++ b/main.py
@@ -737,7 +737,7 @@ class Main(KytosNApp):
         """Change circuit when link is down or under_mantenance."""
         self.handle_link_down(event)
 
-    def handle_link_down(self, event):
+    def handle_link_down(self, event):  # pylint: disable=too-many-branches
         """Change circuit when link is down or under_mantenance."""
         link = event.content["link"]
         log.info("Event handle_link_down %s", link)
@@ -757,8 +757,11 @@ class Main(KytosNApp):
                     continue
                 try:
                     dpid_flows = evc.get_failover_flows()
+                # pylint: disable=broad-except
                 except Exception as err:
-                    log.error(f"Ignore Failover path for {evc} due to error: {err}")
+                    log.error(
+                        f"Ignore Failover path for {evc} due to error: {err}"
+                    )
                     evcs_normal.append(evc)
                     continue
                 for dpid, flows in dpid_flows.items():

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ NApp to provision circuits from user request.
 """
 import pathlib
 import time
+import traceback
 from threading import Lock
 
 from pydantic import ValidationError
@@ -758,7 +759,8 @@ class Main(KytosNApp):
                 try:
                     dpid_flows = evc.get_failover_flows()
                 # pylint: disable=broad-except
-                except Exception as err:
+                except Exception:
+                    err = traceback.format_exc().replace("\n", ", ")
                     log.error(
                         f"Ignore Failover path for {evc} due to error: {err}"
                     )

--- a/models/evc.py
+++ b/models/evc.py
@@ -650,7 +650,14 @@ class EVCDeploy(EVCBase):
             return
 
         dpid_flows_match = {}
-        for dpid, flows in self._prepare_nni_flows(path).items():
+
+        try:
+            nni_flows = self._prepare_nni_flows(path)
+        except Exception as err:
+            log.error(f"Fail to remove NNI failover flows for {self}: {err}")
+            nni_flows = {}
+
+        for dpid, flows in nni_flows.items():
             dpid_flows_match.setdefault(dpid, [])
             for flow in flows:
                 dpid_flows_match[dpid].append({
@@ -658,7 +665,14 @@ class EVCDeploy(EVCBase):
                     "match": flow["match"],
                     "cookie_mask": int(0xffffffffffffffff)
                 })
-        for dpid, flows in self._prepare_uni_flows(path, skip_in=True).items():
+
+        try:
+            uni_flows = self._prepare_uni_flows(path, skip_in=True)
+        except Exception as err:
+            log.error(f"Fail to remove UNI failover flows for {self}: {err}")
+            uni_flows = {}
+
+        for dpid, flows in uni_flows.items():
             dpid_flows_match.setdefault(dpid, [])
             for flow in flows:
                 dpid_flows_match[dpid].append({
@@ -787,6 +801,7 @@ class EVCDeploy(EVCBase):
 
         reason = ""
         self.remove_path_flows(self.failover_path)
+        self.failover_path = Path([])
         for use_path in self.get_failover_path_candidates():
             if not use_path:
                 continue

--- a/models/evc.py
+++ b/models/evc.py
@@ -653,6 +653,7 @@ class EVCDeploy(EVCBase):
 
         try:
             nni_flows = self._prepare_nni_flows(path)
+        # pylint: disable=broad-except
         except Exception as err:
             log.error(f"Fail to remove NNI failover flows for {self}: {err}")
             nni_flows = {}
@@ -668,6 +669,7 @@ class EVCDeploy(EVCBase):
 
         try:
             uni_flows = self._prepare_uni_flows(path, skip_in=True)
+        # pylint: disable=broad-except
         except Exception as err:
             log.error(f"Fail to remove UNI failover flows for {self}: {err}")
             uni_flows = {}

--- a/models/evc.py
+++ b/models/evc.py
@@ -1,4 +1,5 @@
 """Classes used in the main application."""  # pylint: disable=too-many-lines
+import traceback
 from collections import OrderedDict
 from datetime import datetime
 from operator import eq, ne
@@ -654,7 +655,8 @@ class EVCDeploy(EVCBase):
         try:
             nni_flows = self._prepare_nni_flows(path)
         # pylint: disable=broad-except
-        except Exception as err:
+        except Exception:
+            err = traceback.format_exc().replace("\n", ", ")
             log.error(f"Fail to remove NNI failover flows for {self}: {err}")
             nni_flows = {}
 
@@ -670,7 +672,8 @@ class EVCDeploy(EVCBase):
         try:
             uni_flows = self._prepare_uni_flows(path, skip_in=True)
         # pylint: disable=broad-except
-        except Exception as err:
+        except Exception:
+            err = traceback.format_exc().replace("\n", ", ")
             log.error(f"Fail to remove UNI failover flows for {self}: {err}")
             uni_flows = {}
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2170,6 +2170,7 @@ class TestMain:
         event.content = {'flow': flow, 'error_command': 'add'}
         evc = create_autospec(EVC)
         evc.remove_current_flows = MagicMock()
+        evc.lock = MagicMock()
         self.napp.circuits = {"00000000000011": evc}
         self.napp.handle_flow_mod_error(event)
         evc.remove_current_flows.assert_called_once()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1851,10 +1851,18 @@ class TestMain:
             "4": ["flow7", "flow8"],
             "5": ["flow9", "flow10"],
         }
+        evc6 = MagicMock(id="6", service_level=8, creation_time=1,
+                         metadata="mock", _active="true", _enabled="true",
+                         uni_a=uni, uni_z=uni)
+        evc6.name = "name"
+        evc6.is_affected_by_link.return_value = True
+        evc6.is_failover_path_affected_by_link.return_value = False
+        evc6.failover_path = ["3"]
+        evc6.get_failover_flows.side_effect = AttributeError("err")
         link = MagicMock(id="123")
         event = KytosEvent(name="test", content={"link": link})
         self.napp.circuits = {"1": evc1, "2": evc2, "3": evc3, "4": evc4,
-                              "5": evc5}
+                              "5": evc5, "6": evc6}
         settings_mock.BATCH_SIZE = 2
         self.napp.handle_link_down(event)
 
@@ -1911,6 +1919,16 @@ class TestMain:
         assert evc3.service_level > evc1.service_level
         # evc3 should be handled before evc1
         emit_event_mock.assert_has_calls([
+            call(self.napp.controller, event_name, content={
+                "link_id": "123",
+                "evc_id": "6",
+                "name": "name",
+                "metadata": "mock",
+                "active": "true",
+                "enabled": "true",
+                "uni_a": uni.as_dict(),
+                "uni_z": uni.as_dict(),
+            }),
             call(self.napp.controller, event_name, content={
                 "link_id": "123",
                 "evc_id": "3",


### PR DESCRIPTION
Closes #374 

## Summary

See updated changelog file

## Local Tests

I simulated the multiple failures described in Issue #374, and repeated the test multiple times. No further error, misbehavior, or race condition was identified.

Script to run the simulation:

```
root@3b9f1397364f:/# for vlan in $(seq 101 101); do curl -H 'Content-type: application/json' -X POST http://127.0.0.1:8181/api/kytos/mef_eline/v2/evc/ -d '{"name": "evc-vlan-'$vlan'", "dynamic_backup_path": true,  "uni_z": {"tag": {"value": '$vlan', "tag_type": 1}, "interface_id": "00:00:00:00:00:00:00:01:1"}, "uni_a": {"tag": {"value": '$vlan', "tag_type": 1}, "interface_id": "00:00:00:00:00:00:00:03:1"}}'; done

root@3b9f1397364f:/# cat /mydata2/run-test-failover.sh
for i in $(seq 1 20); do
	echo "--------" $i $(date);
	tmux send-keys -t mn "sh ip link set down s1-eth2" ENTER; sleep 1; tmux send-keys -t mn "sh ip link set down s1-eth3" ENTER;
	sleep 10;
	egrep -i "err|except" /var/log/syslog;
	/mydata2/mx.sh h1 ping -c4 10.1.1.3 -i 0.05 -W1;
	curl -s http://127.0.0.1:8181/api/kytos/mef_eline/v2/evc/ | jq -r '.[] | .id + " " + (.failover_path[].metadata|tostring)';

	tmux send-keys -t mn "sh ip link set up s1-eth2" ENTER; sleep 4; tmux send-keys -t mn "sh ip link set up s1-eth3" ENTER;
	sleep 3
	ip link| grep state | grep DOWN;
	sleep 13;
	for evc_id in $(curl -s http://127.0.0.1:8181/api/kytos/mef_eline/v2/evc/ | jq -r '.[] | .id'); do date; curl -X PATCH http://127.0.0.1:8181/api/kytos/mef_eline/v2/evc/$evc_id/redeploy; echo; done;
	sleep 3;
	/mydata2/mx.sh h1 ping -c4 10.1.1.3 -i 0.05 -W1;
	cp /var/log/syslog /var/log/syslog.$(date +%s);
	echo > /var/log/syslog;
	sleep 5;
done
```

Topology: Same as reported on Issue #374

Number of executions: 20

Results summary: all 20 tests passed with success, no exception related to inconsistent failover path, all failover worked just fine. Without the changes proposed here, on 20 executions, 17 come out with the same problem reported on the issue (see Typical failure result without the PR below)

Full results:

```
root@3b9f1397364f:/# bash -x /mydata2/run-test-failover.sh
-------- 1 Tue Sep 26 16:20:37 UTC 2023
+ egrep -i 'err|except' /var/log/syslog
Sep 26 16:19:29 3b9f1397364f uvicorn.error:INFO on:48:  Waiting for application startup.
Sep 26 16:19:29 3b9f1397364f uvicorn.error:INFO on:62:  Application startup complete.
+ /mydata2/mx.sh h1 ping -c4 10.1.1.3 -i 0.05 -W1
PING 10.1.1.3 (10.1.1.3) 56(84) bytes of data.
64 bytes from 10.1.1.3: icmp_seq=1 ttl=64 time=0.973 ms
64 bytes from 10.1.1.3: icmp_seq=2 ttl=64 time=0.097 ms
64 bytes from 10.1.1.3: icmp_seq=3 ttl=64 time=0.082 ms
64 bytes from 10.1.1.3: icmp_seq=4 ttl=64 time=0.109 ms

--- 10.1.1.3 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 160ms
rtt min/avg/max/mdev = 0.082/0.315/0.973/0.379 ms
-------- 2 Tue Sep 26 16:21:17 UTC 2023
+ egrep -i 'err|except' /var/log/syslog
+ /mydata2/mx.sh h1 ping -c4 10.1.1.3 -i 0.05 -W1
PING 10.1.1.3 (10.1.1.3) 56(84) bytes of data.
64 bytes from 10.1.1.3: icmp_seq=1 ttl=64 time=0.908 ms
64 bytes from 10.1.1.3: icmp_seq=2 ttl=64 time=0.095 ms
64 bytes from 10.1.1.3: icmp_seq=3 ttl=64 time=0.075 ms
64 bytes from 10.1.1.3: icmp_seq=4 ttl=64 time=0.109 ms

--- 10.1.1.3 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 168ms
rtt min/avg/max/mdev = 0.075/0.296/0.908/0.353 ms
-------- 3 Tue Sep 26 16:21:57 UTC 2023
+ egrep -i 'err|except' /var/log/syslog
+ /mydata2/mx.sh h1 ping -c4 10.1.1.3 -i 0.05 -W1
PING 10.1.1.3 (10.1.1.3) 56(84) bytes of data.
64 bytes from 10.1.1.3: icmp_seq=1 ttl=64 time=1.47 ms
64 bytes from 10.1.1.3: icmp_seq=2 ttl=64 time=0.084 ms
64 bytes from 10.1.1.3: icmp_seq=3 ttl=64 time=0.106 ms
64 bytes from 10.1.1.3: icmp_seq=4 ttl=64 time=0.097 ms

--- 10.1.1.3 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 160ms
rtt min/avg/max/mdev = 0.084/0.438/1.465/0.592 ms
-------- 4 Tue Sep 26 16:22:37 UTC 2023
+ egrep -i 'err|except' /var/log/syslog
+ /mydata2/mx.sh h1 ping -c4 10.1.1.3 -i 0.05 -W1
PING 10.1.1.3 (10.1.1.3) 56(84) bytes of data.
64 bytes from 10.1.1.3: icmp_seq=1 ttl=64 time=0.824 ms
64 bytes from 10.1.1.3: icmp_seq=2 ttl=64 time=0.093 ms
64 bytes from 10.1.1.3: icmp_seq=3 ttl=64 time=0.079 ms
64 bytes from 10.1.1.3: icmp_seq=4 ttl=64 time=0.104 ms

--- 10.1.1.3 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 166ms
rtt min/avg/max/mdev = 0.079/0.275/0.824/0.317 ms
-------- 5 Tue Sep 26 16:23:18 UTC 2023
+ egrep -i 'err|except' /var/log/syslog
+ /mydata2/mx.sh h1 ping -c4 10.1.1.3 -i 0.05 -W1
PING 10.1.1.3 (10.1.1.3) 56(84) bytes of data.
64 bytes from 10.1.1.3: icmp_seq=1 ttl=64 time=0.787 ms
64 bytes from 10.1.1.3: icmp_seq=2 ttl=64 time=0.090 ms
64 bytes from 10.1.1.3: icmp_seq=3 ttl=64 time=0.064 ms
64 bytes from 10.1.1.3: icmp_seq=4 ttl=64 time=0.087 ms

--- 10.1.1.3 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 172ms
rtt min/avg/max/mdev = 0.064/0.257/0.787/0.306 ms
-------- 6 Tue Sep 26 16:23:58 UTC 2023
+ egrep -i 'err|except' /var/log/syslog
+ /mydata2/mx.sh h1 ping -c4 10.1.1.3 -i 0.05 -W1
PING 10.1.1.3 (10.1.1.3) 56(84) bytes of data.
64 bytes from 10.1.1.3: icmp_seq=1 ttl=64 time=0.717 ms
64 bytes from 10.1.1.3: icmp_seq=2 ttl=64 time=0.110 ms
64 bytes from 10.1.1.3: icmp_seq=3 ttl=64 time=0.087 ms
64 bytes from 10.1.1.3: icmp_seq=4 ttl=64 time=0.084 ms

--- 10.1.1.3 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 165ms
rtt min/avg/max/mdev = 0.084/0.249/0.717/0.270 ms
-------- 7 Tue Sep 26 16:24:38 UTC 2023
+ egrep -i 'err|except' /var/log/syslog
+ /mydata2/mx.sh h1 ping -c4 10.1.1.3 -i 0.05 -W1
PING 10.1.1.3 (10.1.1.3) 56(84) bytes of data.
64 bytes from 10.1.1.3: icmp_seq=1 ttl=64 time=1.07 ms
64 bytes from 10.1.1.3: icmp_seq=2 ttl=64 time=0.095 ms
64 bytes from 10.1.1.3: icmp_seq=3 ttl=64 time=0.066 ms
64 bytes from 10.1.1.3: icmp_seq=4 ttl=64 time=0.079 ms

--- 10.1.1.3 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 161ms
rtt min/avg/max/mdev = 0.066/0.327/1.069/0.428 ms
-------- 8 Tue Sep 26 16:25:18 UTC 2023
+ egrep -i 'err|except' /var/log/syslog
+ /mydata2/mx.sh h1 ping -c4 10.1.1.3 -i 0.05 -W1
PING 10.1.1.3 (10.1.1.3) 56(84) bytes of data.
64 bytes from 10.1.1.3: icmp_seq=1 ttl=64 time=0.810 ms
64 bytes from 10.1.1.3: icmp_seq=2 ttl=64 time=0.068 ms
64 bytes from 10.1.1.3: icmp_seq=3 ttl=64 time=0.090 ms
64 bytes from 10.1.1.3: icmp_seq=4 ttl=64 time=0.077 ms

--- 10.1.1.3 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 166ms
rtt min/avg/max/mdev = 0.068/0.261/0.810/0.316 ms
-------- 9 Tue Sep 26 16:25:58 UTC 2023
+ egrep -i 'err|except' /var/log/syslog
+ /mydata2/mx.sh h1 ping -c4 10.1.1.3 -i 0.05 -W1
PING 10.1.1.3 (10.1.1.3) 56(84) bytes of data.
64 bytes from 10.1.1.3: icmp_seq=1 ttl=64 time=1.19 ms
64 bytes from 10.1.1.3: icmp_seq=2 ttl=64 time=0.113 ms
64 bytes from 10.1.1.3: icmp_seq=3 ttl=64 time=0.107 ms
64 bytes from 10.1.1.3: icmp_seq=4 ttl=64 time=0.112 ms

--- 10.1.1.3 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 162ms
rtt min/avg/max/mdev = 0.107/0.380/1.191/0.467 ms
-------- 10 Tue Sep 26 16:26:39 UTC 2023
+ egrep -i 'err|except' /var/log/syslog
+ /mydata2/mx.sh h1 ping -c4 10.1.1.3 -i 0.05 -W1
PING 10.1.1.3 (10.1.1.3) 56(84) bytes of data.
64 bytes from 10.1.1.3: icmp_seq=1 ttl=64 time=1.12 ms
64 bytes from 10.1.1.3: icmp_seq=2 ttl=64 time=0.090 ms
64 bytes from 10.1.1.3: icmp_seq=3 ttl=64 time=0.103 ms
64 bytes from 10.1.1.3: icmp_seq=4 ttl=64 time=0.086 ms

--- 10.1.1.3 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 161ms
rtt min/avg/max/mdev = 0.086/0.349/1.118/0.443 ms
-------- 11 Tue Sep 26 16:27:19 UTC 2023
+ egrep -i 'err|except' /var/log/syslog
+ /mydata2/mx.sh h1 ping -c4 10.1.1.3 -i 0.05 -W1
PING 10.1.1.3 (10.1.1.3) 56(84) bytes of data.
64 bytes from 10.1.1.3: icmp_seq=1 ttl=64 time=0.950 ms
64 bytes from 10.1.1.3: icmp_seq=2 ttl=64 time=0.077 ms
64 bytes from 10.1.1.3: icmp_seq=3 ttl=64 time=0.091 ms
64 bytes from 10.1.1.3: icmp_seq=4 ttl=64 time=0.097 ms

--- 10.1.1.3 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 159ms
rtt min/avg/max/mdev = 0.077/0.303/0.950/0.373 ms
-------- 12 Tue Sep 26 16:27:59 UTC 2023
+ egrep -i 'err|except' /var/log/syslog
+ /mydata2/mx.sh h1 ping -c4 10.1.1.3 -i 0.05 -W1
PING 10.1.1.3 (10.1.1.3) 56(84) bytes of data.
64 bytes from 10.1.1.3: icmp_seq=1 ttl=64 time=1.09 ms
64 bytes from 10.1.1.3: icmp_seq=2 ttl=64 time=0.084 ms
64 bytes from 10.1.1.3: icmp_seq=3 ttl=64 time=0.087 ms
64 bytes from 10.1.1.3: icmp_seq=4 ttl=64 time=0.105 ms

--- 10.1.1.3 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 161ms
rtt min/avg/max/mdev = 0.084/0.340/1.087/0.430 ms
-------- 13 Tue Sep 26 16:28:39 UTC 2023
+ egrep -i 'err|except' /var/log/syslog
+ /mydata2/mx.sh h1 ping -c4 10.1.1.3 -i 0.05 -W1
PING 10.1.1.3 (10.1.1.3) 56(84) bytes of data.
64 bytes from 10.1.1.3: icmp_seq=1 ttl=64 time=0.866 ms
64 bytes from 10.1.1.3: icmp_seq=2 ttl=64 time=0.047 ms
64 bytes from 10.1.1.3: icmp_seq=3 ttl=64 time=0.047 ms
64 bytes from 10.1.1.3: icmp_seq=4 ttl=64 time=0.072 ms

--- 10.1.1.3 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 166ms
rtt min/avg/max/mdev = 0.047/0.258/0.866/0.351 ms
-------- 14 Tue Sep 26 16:29:19 UTC 2023
+ egrep -i 'err|except' /var/log/syslog
+ /mydata2/mx.sh h1 ping -c4 10.1.1.3 -i 0.05 -W1
PING 10.1.1.3 (10.1.1.3) 56(84) bytes of data.
64 bytes from 10.1.1.3: icmp_seq=1 ttl=64 time=0.979 ms
64 bytes from 10.1.1.3: icmp_seq=2 ttl=64 time=0.079 ms
64 bytes from 10.1.1.3: icmp_seq=3 ttl=64 time=0.089 ms
64 bytes from 10.1.1.3: icmp_seq=4 ttl=64 time=0.086 ms

--- 10.1.1.3 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 162ms
rtt min/avg/max/mdev = 0.079/0.308/0.979/0.387 ms
-------- 15 Tue Sep 26 16:29:59 UTC 2023
+ egrep -i 'err|except' /var/log/syslog
+ /mydata2/mx.sh h1 ping -c4 10.1.1.3 -i 0.05 -W1
PING 10.1.1.3 (10.1.1.3) 56(84) bytes of data.
64 bytes from 10.1.1.3: icmp_seq=1 ttl=64 time=0.785 ms
64 bytes from 10.1.1.3: icmp_seq=2 ttl=64 time=0.080 ms
64 bytes from 10.1.1.3: icmp_seq=3 ttl=64 time=0.074 ms
64 bytes from 10.1.1.3: icmp_seq=4 ttl=64 time=0.112 ms

--- 10.1.1.3 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 167ms
rtt min/avg/max/mdev = 0.074/0.262/0.785/0.301 ms
-------- 16 Tue Sep 26 16:30:39 UTC 2023
+ egrep -i 'err|except' /var/log/syslog
+ /mydata2/mx.sh h1 ping -c4 10.1.1.3 -i 0.05 -W1
PING 10.1.1.3 (10.1.1.3) 56(84) bytes of data.
64 bytes from 10.1.1.3: icmp_seq=1 ttl=64 time=0.805 ms
64 bytes from 10.1.1.3: icmp_seq=2 ttl=64 time=0.088 ms
64 bytes from 10.1.1.3: icmp_seq=3 ttl=64 time=0.101 ms
64 bytes from 10.1.1.3: icmp_seq=4 ttl=64 time=0.085 ms

--- 10.1.1.3 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 168ms
rtt min/avg/max/mdev = 0.085/0.269/0.805/0.309 ms
-------- 17 Tue Sep 26 16:31:20 UTC 2023
+ egrep -i 'err|except' /var/log/syslog
+ /mydata2/mx.sh h1 ping -c4 10.1.1.3 -i 0.05 -W1
PING 10.1.1.3 (10.1.1.3) 56(84) bytes of data.
64 bytes from 10.1.1.3: icmp_seq=1 ttl=64 time=0.885 ms
64 bytes from 10.1.1.3: icmp_seq=2 ttl=64 time=0.076 ms
64 bytes from 10.1.1.3: icmp_seq=3 ttl=64 time=0.079 ms
64 bytes from 10.1.1.3: icmp_seq=4 ttl=64 time=0.072 ms

--- 10.1.1.3 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 166ms
rtt min/avg/max/mdev = 0.072/0.278/0.885/0.350 ms
-------- 18 Tue Sep 26 16:32:00 UTC 2023
+ egrep -i 'err|except' /var/log/syslog
+ /mydata2/mx.sh h1 ping -c4 10.1.1.3 -i 0.05 -W1
PING 10.1.1.3 (10.1.1.3) 56(84) bytes of data.
64 bytes from 10.1.1.3: icmp_seq=1 ttl=64 time=0.867 ms
64 bytes from 10.1.1.3: icmp_seq=2 ttl=64 time=0.151 ms
64 bytes from 10.1.1.3: icmp_seq=3 ttl=64 time=0.140 ms
64 bytes from 10.1.1.3: icmp_seq=4 ttl=64 time=0.061 ms

--- 10.1.1.3 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 168ms
rtt min/avg/max/mdev = 0.061/0.304/0.867/0.326 ms
-------- 19 Tue Sep 26 16:32:40 UTC 2023
+ egrep -i 'err|except' /var/log/syslog
+ /mydata2/mx.sh h1 ping -c4 10.1.1.3 -i 0.05 -W1
PING 10.1.1.3 (10.1.1.3) 56(84) bytes of data.
64 bytes from 10.1.1.3: icmp_seq=1 ttl=64 time=1.40 ms
64 bytes from 10.1.1.3: icmp_seq=2 ttl=64 time=0.066 ms
64 bytes from 10.1.1.3: icmp_seq=3 ttl=64 time=0.108 ms
64 bytes from 10.1.1.3: icmp_seq=4 ttl=64 time=0.070 ms

--- 10.1.1.3 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 162ms
rtt min/avg/max/mdev = 0.066/0.410/1.399/0.570 ms
-------- 20 Tue Sep 26 16:33:20 UTC 2023
+ egrep -i 'err|except' /var/log/syslog
+ /mydata2/mx.sh h1 ping -c4 10.1.1.3 -i 0.05 -W1
PING 10.1.1.3 (10.1.1.3) 56(84) bytes of data.
64 bytes from 10.1.1.3: icmp_seq=1 ttl=64 time=1.06 ms
64 bytes from 10.1.1.3: icmp_seq=2 ttl=64 time=0.067 ms
64 bytes from 10.1.1.3: icmp_seq=3 ttl=64 time=0.089 ms
64 bytes from 10.1.1.3: icmp_seq=4 ttl=64 time=0.059 ms

--- 10.1.1.3 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 159ms
rtt min/avg/max/mdev = 0.059/0.318/1.059/0.427 ms
```

Typical failure result without the PR:

```
-------- 2 Thu Sep 28 11:14:41 UTC 2023
+ egrep -i 'err|except' /var/log/syslog
Sep 28 11:14:43 3b9f1397364f kytos.core.helpers:ERROR helpers:147:  listen_to handler: <function Main.on_link_down at 0x7faa884675e0>, args: (<Main(mef_eline, started 140367751984896)>, KytosEvent('kytos/topology.link_down', {'link': Link(Interface('s1-eth3', 3, Switch('00:00:00:00:00:00:00:01')), Interface('s5-eth2', 2, Switch('00:00:00:00:00:00:00:05')), 0301302f6b27835c80fa84720de803ab50289ca31fb733dadb1c7acea2f98f14), 'reason': 'link down'}, 0)) traceback: Traceback (most recent call last):,   File "/usr/local/lib/python3.9/dist-packages/kytos/core/helpers.py", line 143, in handler_context,     result = handler(*args),   File "//var/lib/kytos/napps/kytos/mef_eline/main.py", line 738, in on_link_down,     self.handle_link_down(event),   File "//var/lib/kytos/napps/kytos/mef_eline/main.py", line 758, in handle_link_down,     for dpid, flows in evc.get_failover_flows().items():,   File "//var/lib/kytos/napps/../napps/kytos/mef_eline/models/evc.py", line 837, in get_failover_flows,     return self._prepare_uni_flows(self.failover_path, skip_out=True),   File "//var/lib/kytos/napps/../napps/kytos/mef_eline/models/evc.py", line 961, in _prepare_uni_flows,     out_vlan_a = path[0].get_metadata("s_vlan").value, AttributeError: 'NoneType' object has no attribute 'value',
+ /mydata2/mx.sh h1 ping -c4 10.1.1.3 -i 0.05 -W1
PING 10.1.1.3 (10.1.1.3) 56(84) bytes of data.

--- 10.1.1.3 ping statistics ---
4 packets transmitted, 0 received, 100% packet loss, time 166ms
...
```


## End-to-End Tests

Results from end-to-end tests using the branch of this PR (jobs/51643):

```
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.3.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 242 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 24%]
tests/test_e2e_11_mef_eline.py ......                                    [ 27%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 30%]
tests/test_e2e_13_mef_eline.py .....xs.s......xs.s.XXxX.xxxx..X......... [ 47%]
...                                                                      [ 48%]
tests/test_e2e_14_mef_eline.py x                                         [ 49%]
tests/test_e2e_15_mef_eline.py ..                                        [ 50%]
tests/test_e2e_20_flow_manager.py .....................                  [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 66%]
tests/test_e2e_23_flow_manager.py ..............                         [ 71%]
tests/test_e2e_30_of_lldp.py ....                                        [ 73%]
tests/test_e2e_31_of_lldp.py ...                                         [ 74%]
tests/test_e2e_32_of_lldp.py ...                                         [ 76%]
tests/test_e2e_40_sdntrace.py .............                              [ 81%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 84%]
tests/test_e2e_50_maintenance.py ........................                [ 94%]
tests/test_e2e_60_of_multi_table.py .....                                [ 96%]
tests/test_e2e_70_kytos_stats.py ........                                [100%]

=============================== warnings summary ===============================

```