### PR TITLE
backport 2023.1.2: Allocating UNI tags

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,17 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [Unreleased]
 ************
 
+[2023.1.2] - 2023-10-12
+***********************
+
+Added
+=====
+- Added published event ``kytos/mef_eline.uni_available_tags`` which is used when UNI tag allocation changes.
+
+Changed
+=======
+- UNIs from created circuits allocate/deallocate TAGs from interfaces when neccessary.
+
 [2023.1.1] - 2023-09-28
 ***********************
 

--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,17 @@ A response from the ``kytos/of_multi_table.enable_table`` event to confirm table
     'table_group': <object>
   }
 
+kytos/mef_eline.uni_available_tags
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Event reporting that a UNI started to use a TAG and ``Interface.available_tags`` in the DB needs to updated
+
+.. code-block:: python3
+
+  {
+    'uni': <object>
+  }
+
 .. TAGs
 
 .. |Stable| image:: https://img.shields.io/badge/stability-stable-green.svg

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2023.1.1",
+  "version": "2023.1.2",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],

--- a/main.py
+++ b/main.py
@@ -278,6 +278,11 @@ class Main(KytosNApp):
         except ValueError as exception:
             raise HTTPException(400, detail=str(exception)) from exception
 
+        try:
+            evc.use_available_uni_tags()
+        except ValueError as err:
+            raise HTTPException(400, detail=str(err)) from err
+
         # save circuit
         try:
             evc.sync()
@@ -405,6 +410,7 @@ class Main(KytosNApp):
             evc.disable()
             self.sched.remove(evc)
             evc.archive()
+            evc.remove_uni_tags()
             evc.sync()
         log.info("EVC removed. %s", evc)
         result = {"response": f"Circuit {circuit_id} removed"}

--- a/models/evc.py
+++ b/models/evc.py
@@ -463,7 +463,7 @@ class EVCBase(GenericEntity):
             success = uni.interface.make_tag_available(uni.user_tag)
             if not success:
                 intf = uni.interface.id
-                log.warning(f"Tag {tag} was already available in {intf}")
+                log.error(f"Tag {tag} was already available in {intf}")
             else:
                 notify_uni_available_tags(self._controller, {"uni": uni})
 

--- a/models/evc.py
+++ b/models/evc.py
@@ -23,7 +23,8 @@ from napps.kytos.mef_eline.utils import (check_disabled_component,
                                          compare_endpoint_trace,
                                          compare_uni_out_trace, emit_event,
                                          map_dl_vlan, map_evc_event_content,
-                                         notify_link_available_tags)
+                                         notify_link_available_tags,
+                                         notify_uni_available_tags)
 
 from .path import DynamicPathManager, Path
 
@@ -172,6 +173,36 @@ class EVCBase(GenericEntity):
             return
         self._mongo_controller.upsert_evc(self.as_dict())
 
+    def update_unis(self, **kwargs) -> tuple[UNI, UNI]:
+        """Update UNIs if neccessary. Allocate and de-allocate
+        UNI tags. Return UNIs (uni_a, uni_z)"""
+        uni_a = kwargs.get("uni_a", None)
+        uni_a_update = False
+        if uni_a and uni_a != self.uni_a:
+            uni_a_update = True
+            try:
+                self._use_uni_vlan(uni_a)
+            except ValueError as err:
+                raise err
+
+        uni_z = kwargs.get("uni_z", None)
+        if uni_z and uni_z != self.uni_z:
+            try:
+                self._use_uni_vlan(uni_z)
+                self.make_uni_vlan_available(self.uni_z)
+            except ValueError as err:
+                if uni_a_update:
+                    self.make_uni_vlan_available(uni_a)
+                raise err
+        else:
+            uni_z = self.uni_z
+
+        if uni_a_update:
+            self.make_uni_vlan_available(self.uni_a)
+        else:
+            uni_a = self.uni_a
+        return uni_a, uni_z
+
     def update(self, **kwargs):
         """Update evc attributes.
 
@@ -188,8 +219,7 @@ class EVCBase(GenericEntity):
 
         """
         enable, redeploy = (None, None)
-        uni_a = kwargs.get("uni_a") or self.uni_a
-        uni_z = kwargs.get("uni_z") or self.uni_z
+        uni_a, uni_z = self.update_unis(**kwargs)
         check_disabled_component(uni_a, uni_z)
         self._validate_has_primary_or_dynamic(
             primary_path=kwargs.get("primary_path"),
@@ -264,14 +294,6 @@ class EVCBase(GenericEntity):
                 uni = kwargs.get(attribute)
                 if not isinstance(uni, UNI):
                     raise ValueError(f"{attribute} is an invalid UNI.")
-
-                if not uni.is_valid():
-                    try:
-                        tag = uni.user_tag.value
-                    except AttributeError:
-                        tag = None
-                    message = f"VLAN tag {tag} is not available in {attribute}"
-                    raise ValueError(message)
 
     def _validate_has_primary_or_dynamic(
         self,
@@ -399,6 +421,56 @@ class EVCBase(GenericEntity):
     def archive(self):
         """Archive this EVC on deletion."""
         self.archived = True
+
+    def use_available_uni_tags(self):
+        """Use UNI tags if available, raise ValueError otherwise
+        This method is used when creating an EVC
+
+        Note:
+            ValueError is not expected to hit because self._validate()
+            ensures uni.tag availability already.
+        """
+        uni_a = self.uni_a
+        try:
+            self._use_uni_vlan(uni_a)
+        except ValueError as err:
+            raise err
+        uni_z = self.uni_z
+        try:
+            self._use_uni_vlan(uni_z)
+        except ValueError as err:
+            self.make_uni_vlan_available(uni_a)
+            raise err
+
+    def _use_uni_vlan(self, uni: UNI):
+        """Use vlan from uni"""
+        if uni.user_tag is None:
+            return
+        tag = uni.user_tag.value
+        if isinstance(tag, int):
+            success = uni.interface.use_tag(uni.user_tag)
+            if not success:
+                intf = uni.interface.id
+                raise ValueError(f"TAG {tag} is not available in {intf}")
+            notify_uni_available_tags(self._controller, {"uni": uni})
+
+    def make_uni_vlan_available(self, uni: UNI):
+        """Make UNI vlan available"""
+        if uni.user_tag is None:
+            return
+        tag = uni.user_tag.value
+        if isinstance(tag, int):
+            success = uni.interface.make_tag_available(uni.user_tag)
+            if not success:
+                intf = uni.interface.id
+                log.warning(f"Tag {tag} was already available in {intf}")
+            else:
+                notify_uni_available_tags(self._controller, {"uni": uni})
+
+    def remove_uni_tags(self):
+        """Remove both UNI use of a tag"""
+        self.make_uni_vlan_available(self.uni_a)
+        self.make_uni_vlan_available(self.uni_z)
 
 
 # pylint: disable=fixme, too-many-public-methods

--- a/tests/unit/models/test_evc_base.py
+++ b/tests/unit/models/test_evc_base.py
@@ -65,18 +65,6 @@ class TestEVC():  # pylint: disable=too-many-public-methods
             EVC(**attributes)
         assert error_message in str(handle_error)
 
-    def test_with_invalid_uni_a(self):
-        """Test if the EVC raises and error with invalid UNI A."""
-        attributes = {
-            "controller": get_controller_mock(),
-            "name": "circuit_name",
-            "uni_a": get_uni_mocked(tag_value=82),
-        }
-        error_message = "VLAN tag 82 is not available in uni_a"
-        with pytest.raises(ValueError) as handle_error:
-            EVC(**attributes)
-        assert error_message in str(handle_error)
-
     def test_without_uni_z(self):
         """Test if the EVC raises and error with UNI Z is required."""
         attributes = {
@@ -85,19 +73,6 @@ class TestEVC():  # pylint: disable=too-many-public-methods
             "uni_a": get_uni_mocked(is_valid=True),
         }
         error_message = "uni_z is required."
-        with pytest.raises(ValueError) as handle_error:
-            EVC(**attributes)
-        assert error_message in str(handle_error)
-
-    def test_with_invalid_uni_z(self):
-        """Test if the EVC raises and error with UNI Z is required."""
-        attributes = {
-            "controller": get_controller_mock(),
-            "name": "circuit_name",
-            "uni_a": get_uni_mocked(is_valid=True),
-            "uni_z": get_uni_mocked(tag_value=83),
-        }
-        error_message = "VLAN tag 83 is not available in uni_z"
         with pytest.raises(ValueError) as handle_error:
             EVC(**attributes)
         assert error_message in str(handle_error)

--- a/utils.py
+++ b/utils.py
@@ -37,6 +37,11 @@ def notify_link_available_tags(controller, link, src_func=None):
     })
 
 
+def notify_uni_available_tags(controller, uni):
+    """Notify uni available tags."""
+    emit_event(controller, "uni_available_tags", content=uni)
+
+
 def compare_endpoint_trace(endpoint, vlan, trace):
     """Compare and endpoint with a trace step."""
     if vlan and "vlan" in trace:


### PR DESCRIPTION
Closes #380

### Summary

This PR needs update on `topology` [PR](https://github.com/kytos-ng/topology/pull/169)
Based on `2023.1.1`
When an EVC is created, updated, or deleted, its UNI tag is now removed and/or added to `uni.interface.available_tags`

### Local Tests

Created, updated, and deleted EVCs.
Tried the previous actions with conflicting TAGs to check on error messages.

### End-To-End Tests
```
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.3.0
rootdir: /tests
plugins: timeout-2.1.0, rerunfailures-10.2, anyio-3.6.2
collected 242 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 24%]
tests/test_e2e_11_mef_eline.py ......                                    [ 27%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 30%]
tests/test_e2e_13_mef_eline.py .....Xs.s......Xs.s.XXxX.xxxx..X......... [ 47%]
...                                                                      [ 48%]
tests/test_e2e_14_mef_eline.py x                                         [ 49%]
tests/test_e2e_15_mef_eline.py ..                                        [ 50%]
tests/test_e2e_20_flow_manager.py .....................                  [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 66%]
tests/test_e2e_23_flow_manager.py ..............                         [ 71%]
tests/test_e2e_30_of_lldp.py ....                                        [ 73%]
tests/test_e2e_31_of_lldp.py ...                                         [ 74%]
tests/test_e2e_32_of_lldp.py ...                                         [ 76%]
tests/test_e2e_40_sdntrace.py .............                              [ 81%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 84%]
tests/test_e2e_50_maintenance.py ........................                [ 94%]
tests/test_e2e_60_of_multi_table.py .....                                [ 96%]
tests/test_e2e_70_kytos_stats.py ........                                [100%]
```


Note: 
New unit tests are missing
Tox test and lint are passing