### PR TITLE
Stable EVCs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,9 +10,11 @@ Added
 =====
 - Added a UI button for redeploying an EVC.
 - UNI tag_type are now accepted as string.
+- EVCs now listen to ``switch.interface.(link_up|link_down|created|deleted)`` events for activation/deactivation
 
 Changed
 =======
+- EVCs will try to maintain their current_path on link status changes
 - UNIs now will use and free tags from ``Interface.available_tags``.
 - UNI tag_type is changed to string from 1, 2 and 3 values to ``"vlan"``, ``"vlan_qinq"`` and ``"mpls"`` respectively.
 

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ from threading import Lock
 from pydantic import ValidationError
 
 from kytos.core import KytosNApp, log, rest
+from kytos.core.events import KytosEvent
 from kytos.core.helpers import (alisten_to, listen_to, load_spec,
                                 validate_openapi)
 from kytos.core.interface import TAG, UNI
@@ -731,6 +732,43 @@ class Main(KytosNApp):
             if evc.is_enabled() and not evc.archived:
                 with evc.lock:
                     evc.handle_link_up(event.content["link"])
+
+    # Possibly replace this with interruptions?
+    @listen_to(
+        '.*.switch.interface.(link_up|link_down)',
+        pool='dynamic_single'
+    )
+    def on_interface_link_change(self, event: KytosEvent):
+        """
+        Handler for interface link_up and link_down events
+        """
+        with self._lock:
+            _, _, event_type = event.name.rpartition('.')
+            iface = event.content.get("interface")
+            if event_type in ('link_up',):
+                self.handle_interface_link_up(iface)
+            elif event_type in ('link_down', 'deleted'):
+                self.handle_interface_link_down(iface)
+
+    def handle_interface_link_up(self, interface):
+        """
+        Handler for interface link_up events
+        """
+        for evc in self.get_evcs_by_svc_level():
+            log.info("Event handle_interface_link_up %s", interface)
+            evc.handle_interface_link_up(
+                interface
+            )
+
+    def handle_interface_link_down(self, interface):
+        """
+        Handler for interface link_down events
+        """
+        for evc in self.get_evcs_by_svc_level():
+            log.info("Event handle_interface_link_down %s", interface)
+            evc.handle_interface_link_down(
+                interface
+            )
 
     @listen_to("kytos/topology.updated")
     def on_topology_update(self, event):

--- a/main.py
+++ b/main.py
@@ -770,27 +770,6 @@ class Main(KytosNApp):
                 interface
             )
 
-    @listen_to("kytos/topology.updated")
-    def on_topology_update(self, event):
-        """Capture topology update event"""
-        self.handle_topology_update(event)
-
-    def handle_topology_update(self, event):
-        """Handle topology update"""
-        with self._lock:
-            if (
-                self._topology_updated_at
-                and self._topology_updated_at > event.timestamp
-            ):
-                return
-            self._topology_updated_at = event.timestamp
-            for evc in self.get_evcs_by_svc_level():
-                if evc.is_enabled() and not evc.archived:
-                    with evc.lock:
-                        evc.handle_topology_update(
-                            event.content["topology"].switches
-                        )
-
     @listen_to("kytos/topology.link_down")
     def on_link_down(self, event):
         """Change circuit when link is down or under_mantenance."""

--- a/main.py
+++ b/main.py
@@ -87,26 +87,21 @@ class Main(KytosNApp):
             self.execute_consistency()
         log.debug("Finished consistency routine")
 
-    def should_be_checked(self, circuit: EVC):
+    def should_be_checked(self, circuit):
         "Verify if the circuit meets the necessary conditions to be checked"
         # pylint: disable=too-many-boolean-expressions
-        log.info(f'Checking if {circuit} should be checked')
-        conditions = (
-            circuit.is_enabled(),
-            not circuit.is_active(),
-            not circuit.lock.locked(),
-            not circuit.has_recent_removed_flow(),
-            not circuit.is_recent_updated(),
-            circuit.are_unis_active(self.controller.switches),
-            # if a inter-switch EVC does not have current_path, it does not
-            # make sense to run sdntrace on it
-            circuit.is_intra_switch() or circuit.current_path,
-        )
-        log.info(f'{conditions}')
-        if all(conditions):
-            log.info(f'Running consistency check on {circuit}')
+        if (
+                circuit.is_enabled()
+                and not circuit.is_active()
+                and not circuit.lock.locked()
+                and not circuit.has_recent_removed_flow()
+                and not circuit.is_recent_updated()
+                and circuit.are_unis_active(self.controller.switches)
+                # if a inter-switch EVC does not have current_path, it does not
+                # make sense to run sdntrace on it
+                and (circuit.is_intra_switch() or circuit.current_path)
+                ):
             return True
-        log.info(f'Not running consistency check on {circuit}')
         return False
 
     def execute_consistency(self):
@@ -953,7 +948,7 @@ class Main(KytosNApp):
                 try:
                     data[attribute] = self._uni_from_dict(value)
                 except ValueError as exception:
-                    result = f"Error creating UNI: {exception}"
+                    result = "Error creating UNI: Invalid value"
                     raise ValueError(result) from exception
 
             if attribute == "circuit_scheduler":

--- a/main.py
+++ b/main.py
@@ -735,7 +735,7 @@ class Main(KytosNApp):
 
     # Possibly replace this with interruptions?
     @listen_to(
-        '.*.switch.interface.(link_up|link_down)',
+        '.*.switch.interface.(link_up|link_down|created|deleted)',
         pool='dynamic_single'
     )
     def on_interface_link_change(self, event: KytosEvent):
@@ -745,7 +745,7 @@ class Main(KytosNApp):
         with self._lock:
             _, _, event_type = event.name.rpartition('.')
             iface = event.content.get("interface")
-            if event_type in ('link_up',):
+            if event_type in ('link_up','created'):
                 self.handle_interface_link_up(iface)
             elif event_type in ('link_down', 'deleted'):
                 self.handle_interface_link_down(iface)

--- a/main.py
+++ b/main.py
@@ -877,8 +877,7 @@ class Main(KytosNApp):
 
         if evc.archived:
             return None
-        evc.deactivate()
-        evc.sync()
+
         self.circuits.setdefault(evc.id, evc)
         self.sched.add(evc)
         return evc

--- a/main.py
+++ b/main.py
@@ -745,7 +745,7 @@ class Main(KytosNApp):
         with self._lock:
             _, _, event_type = event.name.rpartition('.')
             iface = event.content.get("interface")
-            if event_type in ('link_up','created'):
+            if event_type in ('link_up', 'created'):
                 self.handle_interface_link_up(iface)
             elif event_type in ('link_down', 'deleted'):
                 self.handle_interface_link_down(iface)

--- a/models/evc.py
+++ b/models/evc.py
@@ -1443,7 +1443,7 @@ class LinkProtection(EVCDeploy):
                        content=map_evc_event_content(self))
             return True
 
-        return True
+        return False
 
     def handle_link_down(self):
         """Handle circuit when link down.

--- a/models/evc.py
+++ b/models/evc.py
@@ -1367,10 +1367,13 @@ class LinkProtection(EVCDeploy):
             link(Link): Link affected by link.up event.
 
         """
-        if self.is_intra_switch():
-            return True
-
-        if self.is_using_primary_path():
+        if any(
+            (
+                self.is_enabled() and self.is_active(),
+                self.is_intra_switch(),
+                self.is_using_primary_path(),
+            )
+        ):
             return True
 
         success = False

--- a/models/evc.py
+++ b/models/evc.py
@@ -1487,16 +1487,14 @@ class LinkProtection(EVCDeploy):
 
     @staticmethod
     def is_uni_interface_active(
-        *interfaces: Interface,
-        ignore=frozenset(),
+        *interfaces: Interface
     ) -> tuple[bool, dict]:
         """Determine whether a UNI should be active"""
         active = True
         bad_interfaces = [
             interface
             for interface in interfaces
-            if interface.status_reason - ignore
-            or interface.status != EntityStatus.UP
+            if interface.status != EntityStatus.UP
         ]
         if bad_interfaces:
             active = False

--- a/models/evc.py
+++ b/models/evc.py
@@ -1523,7 +1523,7 @@ class LinkProtection(EVCDeploy):
         """
         Handler for interface link_up events
         """
-        if self.archived:
+        if self.archived:  # TODO: Remove when addressing issue #369
             return
         if self.is_active():
             return

--- a/models/evc.py
+++ b/models/evc.py
@@ -1513,6 +1513,8 @@ class LinkProtection(EVCDeploy):
         """
         Handler for interface link_up events
         """
+        if self.archived:
+            return
         if self.is_active():
             return
         interfaces = (self.uni_a.interface, self.uni_z.interface)
@@ -1543,6 +1545,8 @@ class LinkProtection(EVCDeploy):
         """
         Handler for interface link_down events
         """
+        if self.archived:
+            return
         if not self.is_active():
             return
         interfaces = (self.uni_a.interface, self.uni_z.interface)

--- a/tests/unit/models/test_link_protection.py
+++ b/tests/unit/models/test_link_protection.py
@@ -697,6 +697,7 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
         self.evc.deploy_to_path = return_false_mock
         assert not self.evc.handle_link_up(MagicMock())
 
+    # pylint: disable=too-many-statements
     async def test_handle_link_up_case_6(self):
         """Test handle_link_up method."""
         # not possible to deploy this evc (it will not benefit from link up)
@@ -708,31 +709,125 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
         self.evc.is_using_dynamic_path = return_false_mock
         self.evc.backup_path.is_affected_by_link = return_false_mock
         self.evc.dynamic_backup_path = True
-        self.evc.deploy_to_path = return_false_mock
+
+        self.evc.deploy_to_primary_path = MagicMock(return_value=False)
+        self.evc.deploy_to_backup_path = MagicMock(return_value=False)
+        self.evc.deploy_to_path = MagicMock(return_value=False)
+
         assert not self.evc.handle_link_up(MagicMock())
+        assert self.evc.deploy_to_path.call_count == 1
 
-        self.evc.is_enabled = return_true_mock
-        self.evc.is_active = return_false_mock
-        assert not self.evc.handle_link_up(MagicMock())
-
-        self.evc.is_enabled = return_false_mock
-        self.evc.is_active = return_true_mock
-        assert not self.evc.handle_link_up(MagicMock())
-
-        self.evc.is_enabled = return_true_mock
-        self.evc.is_active = return_true_mock
-        assert self.evc.handle_link_up(MagicMock())
-
-        self.evc.is_enabled = return_false_mock
-        self.evc.is_active = return_false_mock
-        self.evc.is_intra_switch = return_true_mock
-        assert self.evc.handle_link_up(MagicMock())
-
-        self.evc.is_enabled = return_false_mock
-        self.evc.is_active = return_false_mock
-        self.evc.is_intra_switch = return_false_mock
         self.evc.is_using_primary_path = return_true_mock
         assert self.evc.handle_link_up(MagicMock())
+        assert self.evc.deploy_to_path.call_count == 1
+
+        self.evc.is_using_primary_path = return_false_mock
+        self.evc.is_intra_switch = return_true_mock
+        assert self.evc.handle_link_up(MagicMock())
+        assert self.evc.deploy_to_path.call_count == 1
+
+        self.evc.is_using_primary_path = return_false_mock
+        self.evc.is_intra_switch = return_false_mock
+        self.evc.primary_path.is_affected_by_link = return_true_mock
+        assert not self.evc.handle_link_up(MagicMock())
+        assert self.evc.deploy_to_primary_path.call_count == 1
+        assert self.evc.deploy_to_path.call_count == 2
+
+        self.evc.is_using_primary_path = return_false_mock
+        self.evc.is_intra_switch = return_false_mock
+        self.evc.primary_path.is_affected_by_link = return_true_mock
+        self.evc.deploy_to_primary_path.return_value = True
+        assert self.evc.handle_link_up(MagicMock())
+        assert self.evc.deploy_to_primary_path.call_count == 2
+        assert self.evc.deploy_to_path.call_count == 2
+
+        self.evc.is_using_primary_path = return_false_mock
+        self.evc.is_intra_switch = return_false_mock
+        self.evc.primary_path.is_affected_by_link = return_false_mock
+        self.evc.deploy_to_primary_path.return_value = False
+        self.evc.is_using_backup_path = return_true_mock
+        assert self.evc.handle_link_up(MagicMock())
+        assert self.evc.deploy_to_primary_path.call_count == 2
+        assert self.evc.deploy_to_path.call_count == 2
+
+        self.evc.is_using_primary_path = return_false_mock
+        self.evc.is_intra_switch = return_false_mock
+        self.evc.primary_path.is_affected_by_link = return_false_mock
+        self.evc.deploy_to_primary_path.return_value = False
+        self.evc.is_using_backup_path = return_false_mock
+        self.evc.is_using_dynamic_path = return_true_mock
+        assert self.evc.handle_link_up(MagicMock())
+        assert self.evc.deploy_to_primary_path.call_count == 2
+        assert self.evc.deploy_to_path.call_count == 2
+
+        self.evc.is_using_primary_path = return_false_mock
+        self.evc.is_intra_switch = return_false_mock
+        self.evc.primary_path.is_affected_by_link = return_false_mock
+        self.evc.deploy_to_primary_path.return_value = False
+        self.evc.is_using_backup_path = return_false_mock
+        self.evc.is_using_dynamic_path = return_false_mock
+        self.evc.backup_path.is_affected_by_link = return_true_mock
+        assert not self.evc.handle_link_up(MagicMock())
+        assert self.evc.deploy_to_primary_path.call_count == 2
+        assert self.evc.deploy_to_backup_path.call_count == 1
+        assert self.evc.deploy_to_path.call_count == 3
+
+        self.evc.is_using_primary_path = return_false_mock
+        self.evc.is_intra_switch = return_false_mock
+        self.evc.primary_path.is_affected_by_link = return_false_mock
+        self.evc.deploy_to_primary_path.return_value = False
+        self.evc.is_using_backup_path = return_false_mock
+        self.evc.is_using_dynamic_path = return_false_mock
+        self.evc.backup_path.is_affected_by_link = return_true_mock
+        self.evc.deploy_to_backup_path.return_value = True
+        assert self.evc.handle_link_up(MagicMock())
+        assert self.evc.deploy_to_primary_path.call_count == 2
+        assert self.evc.deploy_to_backup_path.call_count == 2
+        assert self.evc.deploy_to_path.call_count == 3
+
+        self.evc.is_using_primary_path = return_false_mock
+        self.evc.is_intra_switch = return_false_mock
+        self.evc.primary_path.is_affected_by_link = return_false_mock
+        self.evc.deploy_to_primary_path.return_value = False
+        self.evc.is_using_backup_path = return_false_mock
+        self.evc.is_using_dynamic_path = return_false_mock
+        self.evc.backup_path.is_affected_by_link = return_false_mock
+        self.evc.deploy_to_backup_path.return_value = False
+        self.evc.dynamic_backup_path = True
+        assert not self.evc.handle_link_up(MagicMock())
+        assert self.evc.deploy_to_primary_path.call_count == 2
+        assert self.evc.deploy_to_backup_path.call_count == 2
+        assert self.evc.deploy_to_path.call_count == 4
+
+        self.evc.is_using_primary_path = return_false_mock
+        self.evc.is_intra_switch = return_false_mock
+        self.evc.primary_path.is_affected_by_link = return_false_mock
+        self.evc.deploy_to_primary_path.return_value = False
+        self.evc.is_using_backup_path = return_false_mock
+        self.evc.is_using_dynamic_path = return_false_mock
+        self.evc.backup_path.is_affected_by_link = return_false_mock
+        self.evc.deploy_to_backup_path.return_value = False
+        self.evc.dynamic_backup_path = True
+        self.evc.deploy_to_path.return_value = True
+        assert self.evc.handle_link_up(MagicMock())
+        assert self.evc.deploy_to_primary_path.call_count == 2
+        assert self.evc.deploy_to_backup_path.call_count == 2
+        assert self.evc.deploy_to_path.call_count == 5
+
+        self.evc.is_using_primary_path = return_false_mock
+        self.evc.is_intra_switch = return_false_mock
+        self.evc.primary_path.is_affected_by_link = return_false_mock
+        self.evc.deploy_to_primary_path.return_value = False
+        self.evc.is_using_backup_path = return_false_mock
+        self.evc.is_using_dynamic_path = return_false_mock
+        self.evc.backup_path.is_affected_by_link = return_false_mock
+        self.evc.deploy_to_backup_path.return_value = False
+        self.evc.dynamic_backup_path = False
+        self.evc.deploy_to_path.return_value = False
+        assert not self.evc.handle_link_up(MagicMock())
+        assert self.evc.deploy_to_primary_path.call_count == 2
+        assert self.evc.deploy_to_backup_path.call_count == 2
+        assert self.evc.deploy_to_path.call_count == 5
 
     async def test_get_interface_from_switch(self):
         """Test get_interface_from_switch"""

--- a/tests/unit/models/test_link_protection.py
+++ b/tests/unit/models/test_link_protection.py
@@ -708,51 +708,6 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
         actual_interface = self.evc.get_interface_from_switch(uni, switches)
         assert interface == actual_interface
 
-    @patch("napps.kytos.mef_eline.models.evc.EVCBase.sync")
-    async def test_handle_topology_update(self, mock_sync):
-        """Test handle_topology_update"""
-        self.evc.get_interface_from_switch = MagicMock()
-        self.evc.is_uni_interface_active = MagicMock()
-        self.evc.activate = MagicMock()
-        self.evc.deactivate = MagicMock()
-        interface = id_to_interface_mock('00:01:1')
-
-        self.evc.is_uni_interface_active.return_value = (True, {})
-        self.evc._active = False
-        self.evc.handle_topology_update('mocked_switches')
-        assert self.evc.activate.call_count == 1
-        assert self.evc.deactivate.call_count == 0
-        assert mock_sync.call_count == 1
-
-        self.evc.is_uni_interface_active.return_value = (
-            False,
-            {interface.id: {
-                'status': interface.status.value,
-                'status_reason': interface.status_reason
-            }}
-        )
-        self.evc._active = True
-        self.evc.handle_topology_update('mocked_switches')
-        assert self.evc.activate.call_count == 1
-        assert self.evc.deactivate.call_count == 1
-        assert mock_sync.call_count == 2
-
-        self.evc.is_uni_interface_active.return_value = (True, {})
-        self.evc._active = True
-        self.evc.handle_topology_update('mocked_switches')
-        assert self.evc.activate.call_count == 1
-        assert self.evc.deactivate.call_count == 1
-        assert mock_sync.call_count == 2
-
-    async def test_handle_topology_update_error(self):
-        """Test handle_topology_update with error and early return"""
-        self.evc.get_interface_from_switch = MagicMock()
-        self.evc.get_interface_from_switch.side_effect = KeyError
-        self.evc.is_uni_interface_active = MagicMock()
-
-        self.evc.handle_topology_update('mocked_switches')
-        assert self.evc.is_uni_interface_active.call_count == 0
-
     async def test_are_unis_active(self):
         """Test are_unis_active"""
         interface = id_to_interface_mock('00:01:1')

--- a/tests/unit/models/test_link_protection.py
+++ b/tests/unit/models/test_link_protection.py
@@ -754,14 +754,12 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
             'custom_switch_dpid': interface.switch
         }
 
-        interface.status_reason = set()
         interface.status = EntityStatus.UP
         assert self.evc.are_unis_active(switches) is True
 
-        interface.status_reason = {'disabled'}
+        interface.status = EntityStatus.DOWN
         assert self.evc.are_unis_active(switches) is False
 
-        interface.status_reason = set()
         interface.status = EntityStatus.DISABLED
         assert self.evc.are_unis_active(switches) is False
 

--- a/tests/unit/models/test_link_protection.py
+++ b/tests/unit/models/test_link_protection.py
@@ -798,3 +798,50 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
         }
         expected = (False, interfaces)
         assert actual == expected
+
+    async def test_handle_interface_link(self):
+        """
+        Test Interface Link Up
+        """
+        return_false_mock = MagicMock(return_value=False)
+        return_true_mock = MagicMock(return_value=True)
+        interface_a = self.evc.uni_a.interface
+        interface_a.enable()
+        interface_b = self.evc.uni_z.interface
+        interface_b.enable()
+
+        self.evc.activate = MagicMock()
+        self.evc.deactivate = MagicMock()
+        self.evc.sync = MagicMock()
+
+        # Test do nothing
+        self.evc.is_active = return_true_mock
+
+        self.evc.handle_interface_link_up(interface_a)
+
+        self.evc.activate.assert_not_called()
+        self.evc.sync.assert_not_called()
+
+        # Test deactivating
+        interface_a.deactivate()
+
+        self.evc.handle_interface_link_down(interface_a)
+
+        self.evc.deactivate.assert_called_once()
+        self.evc.sync.assert_called_once()
+
+        # Test do nothing
+        self.evc.is_active = return_false_mock
+
+        self.evc.handle_interface_link_down(interface_a)
+
+        self.evc.deactivate.assert_called_once()
+        self.evc.sync.assert_called_once()
+
+        # Test activating
+        interface_a.activate()
+
+        self.evc.handle_interface_link_up(interface_a)
+
+        self.evc.activate.assert_called_once()
+        assert self.evc.sync.call_count == 2

--- a/tests/unit/models/test_link_protection.py
+++ b/tests/unit/models/test_link_protection.py
@@ -717,21 +717,27 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
         self.evc.deactivate = MagicMock()
         interface = id_to_interface_mock('00:01:1')
 
-        self.evc.is_uni_interface_active.return_value = (True, None)
+        self.evc.is_uni_interface_active.return_value = (True, {})
         self.evc._active = False
         self.evc.handle_topology_update('mocked_switches')
         assert self.evc.activate.call_count == 1
         assert self.evc.deactivate.call_count == 0
         assert mock_sync.call_count == 1
 
-        self.evc.is_uni_interface_active.return_value = (False, interface)
+        self.evc.is_uni_interface_active.return_value = (
+            False,
+            {interface.id: {
+                'status': interface.status.value,
+                'status_reason': interface.status_reason
+            }}
+        )
         self.evc._active = True
         self.evc.handle_topology_update('mocked_switches')
         assert self.evc.activate.call_count == 1
         assert self.evc.deactivate.call_count == 1
         assert mock_sync.call_count == 2
 
-        self.evc.is_uni_interface_active.return_value = (True, None)
+        self.evc.is_uni_interface_active.return_value = (True, {})
         self.evc._active = True
         self.evc.handle_topology_update('mocked_switches')
         assert self.evc.activate.call_count == 1

--- a/tests/unit/models/test_link_protection.py
+++ b/tests/unit/models/test_link_protection.py
@@ -695,6 +695,43 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
         self.evc.backup_path.is_affected_by_link = return_false_mock
         self.evc.dynamic_backup_path = True
         self.evc.deploy_to_path = return_false_mock
+        assert not self.evc.handle_link_up(MagicMock())
+
+    async def test_handle_link_up_case_6(self):
+        """Test handle_link_up method."""
+        # not possible to deploy this evc (it will not benefit from link up)
+        return_false_mock = MagicMock(return_value=False)
+        return_true_mock = MagicMock(return_value=True)
+        self.evc.is_using_primary_path = return_false_mock
+        self.evc.primary_path.is_affected_by_link = return_false_mock
+        self.evc.is_using_backup_path = return_false_mock
+        self.evc.is_using_dynamic_path = return_false_mock
+        self.evc.backup_path.is_affected_by_link = return_false_mock
+        self.evc.dynamic_backup_path = True
+        self.evc.deploy_to_path = return_false_mock
+        assert not self.evc.handle_link_up(MagicMock())
+
+        self.evc.is_enabled = return_true_mock
+        self.evc.is_active = return_false_mock
+        assert not self.evc.handle_link_up(MagicMock())
+
+        self.evc.is_enabled = return_false_mock
+        self.evc.is_active = return_true_mock
+        assert not self.evc.handle_link_up(MagicMock())
+
+        self.evc.is_enabled = return_true_mock
+        self.evc.is_active = return_true_mock
+        assert self.evc.handle_link_up(MagicMock())
+
+        self.evc.is_enabled = return_false_mock
+        self.evc.is_active = return_false_mock
+        self.evc.is_intra_switch = return_true_mock
+        assert self.evc.handle_link_up(MagicMock())
+
+        self.evc.is_enabled = return_false_mock
+        self.evc.is_active = return_false_mock
+        self.evc.is_intra_switch = return_false_mock
+        self.evc.is_using_primary_path = return_true_mock
         assert self.evc.handle_link_up(MagicMock())
 
     async def test_get_interface_from_switch(self):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2175,8 +2175,6 @@ class TestMain:
 
         result = self.napp._load_evc(evc_dict)
         assert result == evc
-        evc.deactivate.assert_called()
-        evc.sync.assert_called()
         self.napp.sched.add.assert_called_with(evc)
         assert self.napp.circuits[1] == evc
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2361,20 +2361,3 @@ class TestMain:
             self.napp._use_uni_tags(evc_mock)
         assert evc_mock._use_uni_vlan.call_count == 5
         assert evc_mock.make_uni_vlan_available.call_count == 1
-
-    async def test_handle_topology_update(self):
-        """Test handle_topology_update"""
-        evc_mock = create_autospec(EVC)
-        evc_mock.service_level, evc_mock.creation_time = 0, 1
-        evc_mock.is_enabled = MagicMock(side_effect=[True, False, True])
-        evc_mock.lock = MagicMock()
-        type(evc_mock).archived = PropertyMock(
-            side_effect=[True, False, False]
-        )
-        evcs = [evc_mock, evc_mock, evc_mock]
-        topology = MagicMock()
-        topology.switches = "mock"
-        event = KytosEvent(name="test", content={"topology": topology})
-        self.napp.circuits = dict(zip(["1", "2", "3"], evcs))
-        self.napp.handle_topology_update(event)
-        evc_mock.handle_topology_update.assert_called_once_with("mock")


### PR DESCRIPTION
Closes #365, closes #218

This PR does the following:
 - Prevent Link up events from rerouting active EVCs
 - Prevents EVCs from being rerouted on startup due to automatically deactivating the EVC

# Local Test Results

Playing around with this, I found that disconnecting a switch from kytos between resets, would no longer result in EVCs being rerouted, which from discussions with @italovalcy, and @viniarck is the desired behaviour. Previously, if a switch did not reconnect during startup, an EVC which used that switch was likely to be rerouted.

# E2E Test Results

Here are the E2E test results. I had accidentally ran the E2E tests without the patch applied, but got the same results before and after applying the patch.

```
kytos-end-to-end-tests-kytos-1  | Starting enhanced syslogd: rsyslogd.
kytos-end-to-end-tests-kytos-1  | /etc/openvswitch/conf.db does not exist ... (warning).
kytos-end-to-end-tests-kytos-1  | Creating empty database /etc/openvswitch/conf.db.
kytos-end-to-end-tests-kytos-1  | Starting ovsdb-server.
kytos-end-to-end-tests-kytos-1  | Configuring Open vSwitch system IDs.
kytos-end-to-end-tests-kytos-1  | Starting ovs-vswitchd.
kytos-end-to-end-tests-kytos-1  | Enabling remote OVSDB managers.
kytos-end-to-end-tests-kytos-1  | + sed -i 's/STATS_INTERVAL = 60/STATS_INTERVAL = 7/g' /var/lib/kytos/napps/kytos/of_core/settings.py
kytos-end-to-end-tests-kytos-1  | + sed -i 's/CONSISTENCY_MIN_VERDICT_INTERVAL =.*/CONSISTENCY_MIN_VERDICT_INTERVAL = 60/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
kytos-end-to-end-tests-kytos-1  | + sed -i 's/LINK_UP_TIMER = 10/LINK_UP_TIMER = 1/g' /var/lib/kytos/napps/kytos/topology/settings.py
kytos-end-to-end-tests-kytos-1  | + sed -i 's/DEPLOY_EVCS_INTERVAL = 60/DEPLOY_EVCS_INTERVAL = 5/g' /var/lib/kytos/napps/kytos/mef_eline/settings.py
kytos-end-to-end-tests-kytos-1  | + sed -i 's/LLDP_LOOP_ACTIONS = \["log"\]/LLDP_LOOP_ACTIONS = \["disable","log"\]/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos-end-to-end-tests-kytos-1  | + sed -i 's/LLDP_IGNORED_LOOPS = {}/LLDP_IGNORED_LOOPS = {"00:00:00:00:00:00:00:01": \[\[4, 5\]\]}/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos-end-to-end-tests-kytos-1  | + sed -i 's/CONSISTENCY_COOKIE_IGNORED_RANGE =.*/CONSISTENCY_COOKIE_IGNORED_RANGE = [(0xdd00000000000000, 0xdd00000000000009)]/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
kytos-end-to-end-tests-kytos-1  | + sed -i 's/LIVENESS_DEAD_MULTIPLIER =.*/LIVENESS_DEAD_MULTIPLIER = 3/g' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos-end-to-end-tests-kytos-1  | + kytosd --help
kytos-end-to-end-tests-kytos-1  | + sed -i s/WARNING/INFO/g /etc/kytos/logging.ini
kytos-end-to-end-tests-kytos-1  | + test -z ''
kytos-end-to-end-tests-kytos-1  | + TESTS=tests/
kytos-end-to-end-tests-kytos-1  | + test -z ''
kytos-end-to-end-tests-kytos-1  | + RERUNS=2
kytos-end-to-end-tests-kytos-1  | + python3 scripts/wait_for_mongo.py
kytos-end-to-end-tests-kytos-1  | Trying to run hello command on MongoDB...
kytos-end-to-end-tests-kytos-1  | Trying to run 'hello' command on MongoDB...
kytos-end-to-end-tests-kytos-1  | Trying to run 'hello' command on MongoDB...
kytos-end-to-end-tests-kytos-1  | Ran 'hello' command on MongoDB successfully. It's ready!
kytos-end-to-end-tests-kytos-1  | + python3 -m pytest tests/ --reruns 2 -r fEr
kytos-end-to-end-tests-kytos-1  | ============================= test session starts ==============================
kytos-end-to-end-tests-kytos-1  | platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.2.0
kytos-end-to-end-tests-kytos-1  | rootdir: /tests
kytos-end-to-end-tests-kytos-1  | plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
kytos-end-to-end-tests-kytos-1  | collected 241 items
kytos-end-to-end-tests-kytos-1  | 
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_05_topology.py ..................                         [  8%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 24%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_11_mef_eline.py ......                                    [ 27%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 30%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_13_mef_eline.py .....xs.s......xs.s.XXxX.xxxx..X......... [ 47%]
kytos-end-to-end-tests-kytos-1  | ...                                                                      [ 48%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_14_mef_eline.py x                                         [ 49%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_15_mef_eline.py ..                                        [ 50%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_20_flow_manager.py ............R..R.......                [ 58%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_21_flow_manager.py ...                                    [ 60%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_22_flow_manager.py ...............                        [ 66%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_23_flow_manager.py ..............                         [ 72%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_30_of_lldp.py ....                                        [ 73%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_31_of_lldp.py ...                                         [ 75%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_32_of_lldp.py ...                                         [ 76%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_40_sdntrace.py ............RRF                            [ 81%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_41_kytos_auth.py ........                                 [ 85%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_50_maintenance.py ........................                [ 95%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_60_of_multi_table.py .....                                [ 97%]
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_70_kytos_stats.py .......                                 [100%]
kytos-end-to-end-tests-kytos-1  | 
kytos-end-to-end-tests-kytos-1  | =================================== FAILURES ===================================
kytos-end-to-end-tests-kytos-1  | _____________ TestE2ESDNTrace.test_090_test_flows_with_instruction _____________
kytos-end-to-end-tests-kytos-1  | 
kytos-end-to-end-tests-kytos-1  | cls = <tests.test_e2e_40_sdntrace.TestE2ESDNTrace object at 0x7fae3361f580>
kytos-end-to-end-tests-kytos-1  | 
kytos-end-to-end-tests-kytos-1  |     def test_090_test_flows_with_instruction(cls):
kytos-end-to-end-tests-kytos-1  |         "Test flows with instruction"
kytos-end-to-end-tests-kytos-1  |         payload_stored_flow = {
kytos-end-to-end-tests-kytos-1  |             "flows": [
kytos-end-to-end-tests-kytos-1  |                 {
kytos-end-to-end-tests-kytos-1  |                     "match": {
kytos-end-to-end-tests-kytos-1  |                         "in_port": 2,
kytos-end-to-end-tests-kytos-1  |                         "dl_vlan": 100
kytos-end-to-end-tests-kytos-1  |                     },
kytos-end-to-end-tests-kytos-1  |                     "instructions": [
kytos-end-to-end-tests-kytos-1  |                         {
kytos-end-to-end-tests-kytos-1  |                             "instruction_type": "apply_actions",
kytos-end-to-end-tests-kytos-1  |                             "actions": [
kytos-end-to-end-tests-kytos-1  |                                 {"action_type": "output", "port": 1}
kytos-end-to-end-tests-kytos-1  |                             ]
kytos-end-to-end-tests-kytos-1  |                         }
kytos-end-to-end-tests-kytos-1  |                     ]
kytos-end-to-end-tests-kytos-1  |                 }
kytos-end-to-end-tests-kytos-1  |             ]
kytos-end-to-end-tests-kytos-1  |         }
kytos-end-to-end-tests-kytos-1  |         api_url = KYTOS_API + '/kytos/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
kytos-end-to-end-tests-kytos-1  |         response = requests.post(api_url, json = payload_stored_flow)
kytos-end-to-end-tests-kytos-1  |         assert response.status_code == 202, response.text
kytos-end-to-end-tests-kytos-1  |         time.sleep(10)
kytos-end-to-end-tests-kytos-1  |     
kytos-end-to-end-tests-kytos-1  |         payload = [
kytos-end-to-end-tests-kytos-1  |                     {
kytos-end-to-end-tests-kytos-1  |                         "trace": {
kytos-end-to-end-tests-kytos-1  |                             "switch": {
kytos-end-to-end-tests-kytos-1  |                                 "dpid": "00:00:00:00:00:00:00:01",
kytos-end-to-end-tests-kytos-1  |                                 "in_port": 2,
kytos-end-to-end-tests-kytos-1  |                             },
kytos-end-to-end-tests-kytos-1  |                             "eth": {
kytos-end-to-end-tests-kytos-1  |                                 "dl_vlan": 100
kytos-end-to-end-tests-kytos-1  |                             }
kytos-end-to-end-tests-kytos-1  |                         }
kytos-end-to-end-tests-kytos-1  |                     }
kytos-end-to-end-tests-kytos-1  |                 ]
kytos-end-to-end-tests-kytos-1  |     
kytos-end-to-end-tests-kytos-1  |         api_url = KYTOS_API + '/amlight/sdntrace_cp/v1/traces'
kytos-end-to-end-tests-kytos-1  |         response = requests.put(api_url, json=payload)
kytos-end-to-end-tests-kytos-1  |         assert response.status_code == 200, response.text
kytos-end-to-end-tests-kytos-1  | >       data = response.json()["result"][0][0]
kytos-end-to-end-tests-kytos-1  | E       IndexError: list index out of range
kytos-end-to-end-tests-kytos-1  | 
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_40_sdntrace.py:1037: IndexError
kytos-end-to-end-tests-kytos-1  | ---------------------------- Captured stdout setup -----------------------------
kytos-end-to-end-tests-kytos-1  | FAIL to stop kytos after 5 seconds -- Kytos pid still exists.. Force stop!
kytos-end-to-end-tests-kytos-1  | ---------------------------- Captured stdout setup -----------------------------
kytos-end-to-end-tests-kytos-1  | FAIL to stop kytos after 5 seconds -- Kytos pid still exists.. Force stop!
kytos-end-to-end-tests-kytos-1  | FAIL to stop kytos after 5 seconds -- Kytos pid still exists.. Force stop!
kytos-end-to-end-tests-kytos-1  | FAIL to stop kytos after 5 seconds -- Kytos pid still exists.. Force stop!
kytos-end-to-end-tests-kytos-1  | ---------------------------- Captured stdout setup -----------------------------
kytos-end-to-end-tests-kytos-1  | FAIL to stop kytos after 5 seconds -- Kytos pid still exists.. Force stop!
kytos-end-to-end-tests-kytos-1  | FAIL to stop kytos after 5 seconds -- Kytos pid still exists.. Force stop!
kytos-end-to-end-tests-kytos-1  | FAIL to stop kytos after 5 seconds -- Kytos pid still exists.. Force stop!
kytos-end-to-end-tests-kytos-1  | =============================== warnings summary ===============================
kytos-end-to-end-tests-kytos-1  | usr/local/lib/python3.9/dist-packages/kytos/core/config.py:187
kytos-end-to-end-tests-kytos-1  |   /usr/local/lib/python3.9/dist-packages/kytos/core/config.py:187: UserWarning: Unknown arguments: ['tests/', '--reruns', '2', '-r', 'fEr']
kytos-end-to-end-tests-kytos-1  |     warnings.warn(f"Unknown arguments: {unknown}")
kytos-end-to-end-tests-kytos-1  | 
kytos-end-to-end-tests-kytos-1  | test_e2e_01_kytos_startup.py: 17 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_05_topology.py: 17 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_10_mef_eline.py: 17 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_11_mef_eline.py: 25 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_12_mef_eline.py: 17 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_13_mef_eline.py: 17 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_14_mef_eline.py: 76 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_15_mef_eline.py: 17 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_20_flow_manager.py: 17 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_21_flow_manager.py: 17 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_22_flow_manager.py: 17 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_23_flow_manager.py: 17 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_30_of_lldp.py: 17 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_31_of_lldp.py: 17 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_32_of_lldp.py: 11 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_40_sdntrace.py: 147 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_41_kytos_auth.py: 17 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_50_maintenance.py: 17 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_60_of_multi_table.py: 17 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_70_kytos_stats.py: 17 warnings
kytos-end-to-end-tests-kytos-1  |   /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
kytos-end-to-end-tests-kytos-1  |     return ( StrictVersion( cls.OVSVersion ) <
kytos-end-to-end-tests-kytos-1  | 
kytos-end-to-end-tests-kytos-1  | test_e2e_01_kytos_startup.py: 17 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_05_topology.py: 17 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_10_mef_eline.py: 17 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_11_mef_eline.py: 25 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_12_mef_eline.py: 17 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_13_mef_eline.py: 17 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_14_mef_eline.py: 76 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_15_mef_eline.py: 17 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_20_flow_manager.py: 17 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_21_flow_manager.py: 17 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_22_flow_manager.py: 17 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_23_flow_manager.py: 17 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_30_of_lldp.py: 17 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_31_of_lldp.py: 17 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_32_of_lldp.py: 11 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_40_sdntrace.py: 147 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_41_kytos_auth.py: 17 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_50_maintenance.py: 17 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_60_of_multi_table.py: 17 warnings
kytos-end-to-end-tests-kytos-1  | test_e2e_70_kytos_stats.py: 17 warnings
kytos-end-to-end-tests-kytos-1  |   /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
kytos-end-to-end-tests-kytos-1  |     StrictVersion( '1.10' ) )
kytos-end-to-end-tests-kytos-1  | 
kytos-end-to-end-tests-kytos-1  | -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
kytos-end-to-end-tests-kytos-1  | ------------------------------- start/stop times -------------------------------
kytos-end-to-end-tests-kytos-1  | rerun: 0
kytos-end-to-end-tests-kytos-1  | test_e2e_20_flow_manager.py::TestE2EFlowManager::test_040_replace_action_flow: 2023-10-09,22:17:04.631136 - 2023-10-09,22:17:29.937005
kytos-end-to-end-tests-kytos-1  | self = <tests.test_e2e_20_flow_manager.TestE2EFlowManager object at 0x7fae33642700>
kytos-end-to-end-tests-kytos-1  | 
kytos-end-to-end-tests-kytos-1  |     def test_040_replace_action_flow(self):
kytos-end-to-end-tests-kytos-1  | >       self.replace_action_flow()
kytos-end-to-end-tests-kytos-1  | 
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_20_flow_manager.py:826: 
kytos-end-to-end-tests-kytos-1  | _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
kytos-end-to-end-tests-kytos-1  | 
kytos-end-to-end-tests-kytos-1  | self = <tests.test_e2e_20_flow_manager.TestE2EFlowManager object at 0x7fae33642700>
kytos-end-to-end-tests-kytos-1  | restart_kytos = False
kytos-end-to-end-tests-kytos-1  | 
kytos-end-to-end-tests-kytos-1  |     def replace_action_flow(self, restart_kytos=False):
kytos-end-to-end-tests-kytos-1  |     
kytos-end-to-end-tests-kytos-1  |         payload = {
kytos-end-to-end-tests-kytos-1  |             "flows": [
kytos-end-to-end-tests-kytos-1  |                 {
kytos-end-to-end-tests-kytos-1  |                     "priority": 10,
kytos-end-to-end-tests-kytos-1  |                     "idle_timeout": 360,
kytos-end-to-end-tests-kytos-1  |                     "hard_timeout": 1200,
kytos-end-to-end-tests-kytos-1  |                     "match": {
kytos-end-to-end-tests-kytos-1  |                         "in_port": 1
kytos-end-to-end-tests-kytos-1  |                     },
kytos-end-to-end-tests-kytos-1  |                     "actions": [
kytos-end-to-end-tests-kytos-1  |                         {
kytos-end-to-end-tests-kytos-1  |                             "action_type": "output",
kytos-end-to-end-tests-kytos-1  |                             "port": 2
kytos-end-to-end-tests-kytos-1  |                         }
kytos-end-to-end-tests-kytos-1  |                     ]
kytos-end-to-end-tests-kytos-1  |                 }
kytos-end-to-end-tests-kytos-1  |             ]
kytos-end-to-end-tests-kytos-1  |         }
kytos-end-to-end-tests-kytos-1  |     
kytos-end-to-end-tests-kytos-1  |         api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
kytos-end-to-end-tests-kytos-1  |         requests.post(api_url, data=json.dumps(payload),
kytos-end-to-end-tests-kytos-1  |                       headers={'Content-type': 'application/json'})
kytos-end-to-end-tests-kytos-1  |     
kytos-end-to-end-tests-kytos-1  |         # wait for the flow to be installed
kytos-end-to-end-tests-kytos-1  |         time.sleep(10)
kytos-end-to-end-tests-kytos-1  |     
kytos-end-to-end-tests-kytos-1  |         # Verify the flow
kytos-end-to-end-tests-kytos-1  |         s1 = self.net.net.get('s1')
kytos-end-to-end-tests-kytos-1  |         flows_s1 = s1.dpctl('dump-flows')
kytos-end-to-end-tests-kytos-1  |         assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1, flows_s1
kytos-end-to-end-tests-kytos-1  |         assert 'in_port="s1-eth1' in flows_s1
kytos-end-to-end-tests-kytos-1  |     
kytos-end-to-end-tests-kytos-1  |         # Modify the actions and verify its modification
kytos-end-to-end-tests-kytos-1  |         s1.dpctl('mod-flows', 'actions=output:3')
kytos-end-to-end-tests-kytos-1  |         flows_s1 = s1.dpctl('dump-flows')
kytos-end-to-end-tests-kytos-1  |         assert 'actions=output:"s1-eth2"' not in flows_s1
kytos-end-to-end-tests-kytos-1  |         assert 'actions=output:"s1-eth3"' in flows_s1
kytos-end-to-end-tests-kytos-1  |     
kytos-end-to-end-tests-kytos-1  |         if restart_kytos:
kytos-end-to-end-tests-kytos-1  |             # restart controller keeping configuration
kytos-end-to-end-tests-kytos-1  |             self.net.start_controller(enable_all=True)
kytos-end-to-end-tests-kytos-1  |             self.net.wait_switches_connect()
kytos-end-to-end-tests-kytos-1  |         else:
kytos-end-to-end-tests-kytos-1  |             self.net.reconnect_switches()
kytos-end-to-end-tests-kytos-1  |     
kytos-end-to-end-tests-kytos-1  |         time.sleep(10)
kytos-end-to-end-tests-kytos-1  |     
kytos-end-to-end-tests-kytos-1  |         # Check that the flow keeps the original setting
kytos-end-to-end-tests-kytos-1  |         s1 = self.net.net.get('s1')
kytos-end-to-end-tests-kytos-1  |         flows_s1 = s1.dpctl('dump-flows')
kytos-end-to-end-tests-kytos-1  |         assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1, flows_s1
kytos-end-to-end-tests-kytos-1  | >       assert 'actions=output:"s1-eth3"' not in flows_s1
kytos-end-to-end-tests-kytos-1  | E       assert 'actions=output:"s1-eth3"' not in ' cookie=0xa...s1-eth3"\r\n'
kytos-end-to-end-tests-kytos-1  | E         'actions=output:"s1-eth3"' is contained here:
kytos-end-to-end-tests-kytos-1  | E           :ee:ee:03 actions=output:"s1-eth3"
kytos-end-to-end-tests-kytos-1  | E            cookie=0x0, duration=35.626s, table=0, n_packets=0, n_bytes=0, priority=50000,dl_src=ee:ee:ee:ee:ee:02 actions=output:"s1-eth3"
kytos-end-to-end-tests-kytos-1  | E            cookie=0x0, duration=25.277s, table=0, n_packets=0, n_bytes=0, idle_timeout=360, hard_timeout=1200, priority=10,in_port="s1-eth1" actions=output:"s1-eth3"
kytos-end-to-end-tests-kytos-1  | 
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_20_flow_manager.py:822: AssertionError
kytos-end-to-end-tests-kytos-1  | rerun: 0
kytos-end-to-end-tests-kytos-1  | test_e2e_20_flow_manager.py::TestE2EFlowManager::test_050_add_action_flow: 2023-10-09,22:19:44.914196 - 2023-10-09,22:20:09.200442
kytos-end-to-end-tests-kytos-1  | self = <tests.test_e2e_20_flow_manager.TestE2EFlowManager object at 0x7fae33642a00>
kytos-end-to-end-tests-kytos-1  | 
kytos-end-to-end-tests-kytos-1  |     def test_050_add_action_flow(self):
kytos-end-to-end-tests-kytos-1  | >       self.add_action_flow()
kytos-end-to-end-tests-kytos-1  | 
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_20_flow_manager.py:879: 
kytos-end-to-end-tests-kytos-1  | _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
kytos-end-to-end-tests-kytos-1  | 
kytos-end-to-end-tests-kytos-1  | self = <tests.test_e2e_20_flow_manager.TestE2EFlowManager object at 0x7fae33642a00>
kytos-end-to-end-tests-kytos-1  | restart_kytos = False
kytos-end-to-end-tests-kytos-1  | 
kytos-end-to-end-tests-kytos-1  |     def add_action_flow(self, restart_kytos=False):
kytos-end-to-end-tests-kytos-1  |     
kytos-end-to-end-tests-kytos-1  |         payload = {
kytos-end-to-end-tests-kytos-1  |             "flows": [
kytos-end-to-end-tests-kytos-1  |                 {
kytos-end-to-end-tests-kytos-1  |                     "priority": 10,
kytos-end-to-end-tests-kytos-1  |                     "idle_timeout": 360,
kytos-end-to-end-tests-kytos-1  |                     "hard_timeout": 1200,
kytos-end-to-end-tests-kytos-1  |                     "match": {
kytos-end-to-end-tests-kytos-1  |                         "in_port": 1
kytos-end-to-end-tests-kytos-1  |                     },
kytos-end-to-end-tests-kytos-1  |                     "actions": [
kytos-end-to-end-tests-kytos-1  |                         {"action_type": "output", "port": 2}
kytos-end-to-end-tests-kytos-1  |                     ]
kytos-end-to-end-tests-kytos-1  |                 }
kytos-end-to-end-tests-kytos-1  |             ]
kytos-end-to-end-tests-kytos-1  |         }
kytos-end-to-end-tests-kytos-1  |     
kytos-end-to-end-tests-kytos-1  |         api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
kytos-end-to-end-tests-kytos-1  |         requests.post(api_url, data=json.dumps(payload),
kytos-end-to-end-tests-kytos-1  |                       headers={'Content-type': 'application/json'})
kytos-end-to-end-tests-kytos-1  |     
kytos-end-to-end-tests-kytos-1  |         # wait for the flow to be installed
kytos-end-to-end-tests-kytos-1  |         time.sleep(10)
kytos-end-to-end-tests-kytos-1  |     
kytos-end-to-end-tests-kytos-1  |         # Verify the flow
kytos-end-to-end-tests-kytos-1  |         s1 = self.net.net.get('s1')
kytos-end-to-end-tests-kytos-1  |         flows_s1 = s1.dpctl('dump-flows')
kytos-end-to-end-tests-kytos-1  |         assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1, flows_s1
kytos-end-to-end-tests-kytos-1  |         assert 'in_port="s1-eth1' in flows_s1
kytos-end-to-end-tests-kytos-1  |     
kytos-end-to-end-tests-kytos-1  |         s1.dpctl('add-flow', 'in_port=1,idle_timeout=360,hard_timeout=1200,priority=10,actions=strip_vlan,output:2')
kytos-end-to-end-tests-kytos-1  |     
kytos-end-to-end-tests-kytos-1  |         if restart_kytos:
kytos-end-to-end-tests-kytos-1  |             # restart controller keeping configuration
kytos-end-to-end-tests-kytos-1  |             self.net.start_controller(enable_all=True)
kytos-end-to-end-tests-kytos-1  |             self.net.wait_switches_connect()
kytos-end-to-end-tests-kytos-1  |         else:
kytos-end-to-end-tests-kytos-1  |             self.net.reconnect_switches()
kytos-end-to-end-tests-kytos-1  |     
kytos-end-to-end-tests-kytos-1  |         time.sleep(10)
kytos-end-to-end-tests-kytos-1  |     
kytos-end-to-end-tests-kytos-1  |         flows_s1 = s1.dpctl('dump-flows')
kytos-end-to-end-tests-kytos-1  |         assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1, flows_s1
kytos-end-to-end-tests-kytos-1  | >       assert 'actions=strip_vlan,' not in flows_s1
kytos-end-to-end-tests-kytos-1  | E       assert 'actions=strip_vlan,' not in ' cookie=0xa...s1-eth2"\r\n'
kytos-end-to-end-tests-kytos-1  | E         'actions=strip_vlan,' is contained here:
kytos-end-to-end-tests-kytos-1  | E           "s1-eth1" actions=strip_vlan,output:"s1-eth2"
kytos-end-to-end-tests-kytos-1  | 
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_20_flow_manager.py:875: AssertionError
kytos-end-to-end-tests-kytos-1  | rerun: 0
kytos-end-to-end-tests-kytos-1  | test_e2e_40_sdntrace.py::TestE2ESDNTrace::test_090_test_flows_with_instruction: 2023-10-09,23:08:03.284308 - 2023-10-09,23:08:13.340472
kytos-end-to-end-tests-kytos-1  | cls = <tests.test_e2e_40_sdntrace.TestE2ESDNTrace object at 0x7fae3361f580>
kytos-end-to-end-tests-kytos-1  | 
kytos-end-to-end-tests-kytos-1  |     def test_090_test_flows_with_instruction(cls):
kytos-end-to-end-tests-kytos-1  |         "Test flows with instruction"
kytos-end-to-end-tests-kytos-1  |         payload_stored_flow = {
kytos-end-to-end-tests-kytos-1  |             "flows": [
kytos-end-to-end-tests-kytos-1  |                 {
kytos-end-to-end-tests-kytos-1  |                     "match": {
kytos-end-to-end-tests-kytos-1  |                         "in_port": 2,
kytos-end-to-end-tests-kytos-1  |                         "dl_vlan": 100
kytos-end-to-end-tests-kytos-1  |                     },
kytos-end-to-end-tests-kytos-1  |                     "instructions": [
kytos-end-to-end-tests-kytos-1  |                         {
kytos-end-to-end-tests-kytos-1  |                             "instruction_type": "apply_actions",
kytos-end-to-end-tests-kytos-1  |                             "actions": [
kytos-end-to-end-tests-kytos-1  |                                 {"action_type": "output", "port": 1}
kytos-end-to-end-tests-kytos-1  |                             ]
kytos-end-to-end-tests-kytos-1  |                         }
kytos-end-to-end-tests-kytos-1  |                     ]
kytos-end-to-end-tests-kytos-1  |                 }
kytos-end-to-end-tests-kytos-1  |             ]
kytos-end-to-end-tests-kytos-1  |         }
kytos-end-to-end-tests-kytos-1  |         api_url = KYTOS_API + '/kytos/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
kytos-end-to-end-tests-kytos-1  |         response = requests.post(api_url, json = payload_stored_flow)
kytos-end-to-end-tests-kytos-1  |         assert response.status_code == 202, response.text
kytos-end-to-end-tests-kytos-1  |         time.sleep(10)
kytos-end-to-end-tests-kytos-1  |     
kytos-end-to-end-tests-kytos-1  |         payload = [
kytos-end-to-end-tests-kytos-1  |                     {
kytos-end-to-end-tests-kytos-1  |                         "trace": {
kytos-end-to-end-tests-kytos-1  |                             "switch": {
kytos-end-to-end-tests-kytos-1  |                                 "dpid": "00:00:00:00:00:00:00:01",
kytos-end-to-end-tests-kytos-1  |                                 "in_port": 2,
kytos-end-to-end-tests-kytos-1  |                             },
kytos-end-to-end-tests-kytos-1  |                             "eth": {
kytos-end-to-end-tests-kytos-1  |                                 "dl_vlan": 100
kytos-end-to-end-tests-kytos-1  |                             }
kytos-end-to-end-tests-kytos-1  |                         }
kytos-end-to-end-tests-kytos-1  |                     }
kytos-end-to-end-tests-kytos-1  |                 ]
kytos-end-to-end-tests-kytos-1  |     
kytos-end-to-end-tests-kytos-1  |         api_url = KYTOS_API + '/amlight/sdntrace_cp/v1/traces'
kytos-end-to-end-tests-kytos-1  |         response = requests.put(api_url, json=payload)
kytos-end-to-end-tests-kytos-1  |         assert response.status_code == 200, response.text
kytos-end-to-end-tests-kytos-1  | >       data = response.json()["result"][0][0]
kytos-end-to-end-tests-kytos-1  | E       IndexError: list index out of range
kytos-end-to-end-tests-kytos-1  | 
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_40_sdntrace.py:1037: IndexError
kytos-end-to-end-tests-kytos-1  | rerun: 1
kytos-end-to-end-tests-kytos-1  | test_e2e_40_sdntrace.py::TestE2ESDNTrace::test_090_test_flows_with_instruction: 2023-10-09,23:09:18.586291 - 2023-10-09,23:09:28.636801
kytos-end-to-end-tests-kytos-1  | cls = <tests.test_e2e_40_sdntrace.TestE2ESDNTrace object at 0x7fae3361f580>
kytos-end-to-end-tests-kytos-1  | 
kytos-end-to-end-tests-kytos-1  |     def test_090_test_flows_with_instruction(cls):
kytos-end-to-end-tests-kytos-1  |         "Test flows with instruction"
kytos-end-to-end-tests-kytos-1  |         payload_stored_flow = {
kytos-end-to-end-tests-kytos-1  |             "flows": [
kytos-end-to-end-tests-kytos-1  |                 {
kytos-end-to-end-tests-kytos-1  |                     "match": {
kytos-end-to-end-tests-kytos-1  |                         "in_port": 2,
kytos-end-to-end-tests-kytos-1  |                         "dl_vlan": 100
kytos-end-to-end-tests-kytos-1  |                     },
kytos-end-to-end-tests-kytos-1  |                     "instructions": [
kytos-end-to-end-tests-kytos-1  |                         {
kytos-end-to-end-tests-kytos-1  |                             "instruction_type": "apply_actions",
kytos-end-to-end-tests-kytos-1  |                             "actions": [
kytos-end-to-end-tests-kytos-1  |                                 {"action_type": "output", "port": 1}
kytos-end-to-end-tests-kytos-1  |                             ]
kytos-end-to-end-tests-kytos-1  |                         }
kytos-end-to-end-tests-kytos-1  |                     ]
kytos-end-to-end-tests-kytos-1  |                 }
kytos-end-to-end-tests-kytos-1  |             ]
kytos-end-to-end-tests-kytos-1  |         }
kytos-end-to-end-tests-kytos-1  |         api_url = KYTOS_API + '/kytos/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
kytos-end-to-end-tests-kytos-1  |         response = requests.post(api_url, json = payload_stored_flow)
kytos-end-to-end-tests-kytos-1  |         assert response.status_code == 202, response.text
kytos-end-to-end-tests-kytos-1  |         time.sleep(10)
kytos-end-to-end-tests-kytos-1  |     
kytos-end-to-end-tests-kytos-1  |         payload = [
kytos-end-to-end-tests-kytos-1  |                     {
kytos-end-to-end-tests-kytos-1  |                         "trace": {
kytos-end-to-end-tests-kytos-1  |                             "switch": {
kytos-end-to-end-tests-kytos-1  |                                 "dpid": "00:00:00:00:00:00:00:01",
kytos-end-to-end-tests-kytos-1  |                                 "in_port": 2,
kytos-end-to-end-tests-kytos-1  |                             },
kytos-end-to-end-tests-kytos-1  |                             "eth": {
kytos-end-to-end-tests-kytos-1  |                                 "dl_vlan": 100
kytos-end-to-end-tests-kytos-1  |                             }
kytos-end-to-end-tests-kytos-1  |                         }
kytos-end-to-end-tests-kytos-1  |                     }
kytos-end-to-end-tests-kytos-1  |                 ]
kytos-end-to-end-tests-kytos-1  |     
kytos-end-to-end-tests-kytos-1  |         api_url = KYTOS_API + '/amlight/sdntrace_cp/v1/traces'
kytos-end-to-end-tests-kytos-1  |         response = requests.put(api_url, json=payload)
kytos-end-to-end-tests-kytos-1  |         assert response.status_code == 200, response.text
kytos-end-to-end-tests-kytos-1  | >       data = response.json()["result"][0][0]
kytos-end-to-end-tests-kytos-1  | E       IndexError: list index out of range
kytos-end-to-end-tests-kytos-1  | 
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_40_sdntrace.py:1037: IndexError
kytos-end-to-end-tests-kytos-1  | test_e2e_40_sdntrace.py::TestE2ESDNTrace::test_090_test_flows_with_instruction: 2023-10-09,23:10:45.011866 - 2023-10-09,23:10:55.065546
kytos-end-to-end-tests-kytos-1  | =========================== rerun test summary info ============================
kytos-end-to-end-tests-kytos-1  | RERUN test_e2e_20_flow_manager.py::TestE2EFlowManager::test_040_replace_action_flow
kytos-end-to-end-tests-kytos-1  | RERUN test_e2e_20_flow_manager.py::TestE2EFlowManager::test_050_add_action_flow
kytos-end-to-end-tests-kytos-1  | RERUN test_e2e_40_sdntrace.py::TestE2ESDNTrace::test_090_test_flows_with_instruction
kytos-end-to-end-tests-kytos-1  | RERUN test_e2e_40_sdntrace.py::TestE2ESDNTrace::test_090_test_flows_with_instruction
kytos-end-to-end-tests-kytos-1  | =========================== short test summary info ============================
kytos-end-to-end-tests-kytos-1  | FAILED tests/test_e2e_40_sdntrace.py::TestE2ESDNTrace::test_090_test_flows_with_instruction
kytos-end-to-end-tests-kytos-1  | = 1 failed, 218 passed, 6 skipped, 11 xfailed, 5 xpassed, 1063 warnings, 4 rerun in 11268.47s (3:07:48) =
kytos-end-to-end-tests-kytos-1 exited with code 1
```