### PR TITLE
feat: add `set_vlan` only if UNI A vlan and UNI z vlan are different.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Deprecated
 General Information
 ===================
 - ``scripts/vlan_type_string.py`` can be used to update the collection ``evcs`` by changing ``tag_type`` from integer to string.
+- ``scripts/redeploy_evpls_same_vlans.py`` can be used to redeploy symmetric (same UNI vlans) EVPLs in batch.
 
 Fixed
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Changed
 =======
 - UNIs now will use and free tags from ``Interface.available_tags``.
 - UNI tag_type is changed to string from 1, 2 and 3 values to ``"vlan"``, ``"vlan_qinq"`` and ``"mpls"`` respectively.
+- Add ``set_vlan`` only if UNI A vlan and UNI z vlan are different.
 
 Deprecated
 ==========

--- a/models/evc.py
+++ b/models/evc.py
@@ -1209,7 +1209,7 @@ class EVCDeploy(EVCBase):
             # if in_vlan is set, it must be included in the match
             flow_mod["match"]["dl_vlan"] = in_vlan
 
-        if new_c_vlan not in self.special_cases:
+        if new_c_vlan not in self.special_cases and in_vlan != new_c_vlan:
             # new_in_vlan is an integer but zero, action to set is required
             new_action = {"action_type": "set_vlan", "vlan_id": new_c_vlan}
             flow_mod["actions"].insert(0, new_action)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -108,4 +108,105 @@ CMD=update_database python3 scripts/003_vlan_type_string.py
 ```
 `update_database` changes the value of every outdated TAG from integer to their respective string value.
 
+<details><summary><h3>Redeploy symmetric UNI vlans EVPLs </h3></summary>
+
+[`redeploy_evpls_same_vlans.py`](./redeploy_evpls_same_vlans.py) is a CLI script to list and redeploy symmetric (same vlan on both UNIs) EVPLs.
+
+You should use this script if you want to avoid a redudant `set_vlan` instruction that used to be present in the instruction set. This script by triggering an EVC redeploy will force that all flows get pushed and overwritten again, it'll temporarily create traffic disruption. The redeploy in this case is just to force that the flows are pushed right away instead of waiting for a network convergence that might result in the flows getting pushed again.
+
+#### Pre-requisites
+
+- There's no additional dependency other than the existing core ones
+
+#### How to use
+
+This script exposes two commmands: `list` and `update`.
+
+- First you want to `list` to double check which symmetric EVPLs have been found. If you need to just include a subset you can use the ``--included_evcs_filter`` string passing a string of evc ids separated by comma value.
+
+```shell
+python scripts/redeploy_evpls_same_vlans.py list --included_evcs_filter 'dc533ac942a541,eab1fedf3d654f' | jq
+
+{
+  "dc533ac942a541": {
+    "name": "1046-1046",
+    "uni_a": {
+      "tag": {
+        "tag_type": "vlan",
+        "value": 1046
+      },
+      "interface_id": "00:00:00:00:00:00:00:01:1"
+    },
+    "uni_z": {
+      "tag": {
+        "tag_type": "vlan",
+        "value": 1046
+      },
+      "interface_id": "00:00:00:00:00:00:00:03:1"
+    }
+  },
+  "eab1fedf3d654f": {
+    "name": "1070-1070",
+    "uni_a": {
+      "tag": {
+        "tag_type": "vlan",
+        "value": 1070
+      },
+      "interface_id": "00:00:00:00:00:00:00:01:1"
+    },
+    "uni_z": {
+      "tag": {
+        "tag_type": "vlan",
+        "value": 1070
+      },
+      "interface_id": "00:00:00:00:00:00:00:03:1"
+    }
+  }
+}
+```
+
+- If you're OK with the EVPLs listed on `list`, then you can proceed to `update` to trigger a redeploy. You can also set ``--batch_size`` and ``--batch_sleep_secs`` to control respectively how many EVPLs will be redeployed concurrently and how long to wait after each batch is sent:
+
+```
+python scripts/redeploy_evpls_same_vlans.py update --batch_size 10 --batch_sleep_secs 5 --included_evcs_filter 'dc533ac942a541,eab1fedf3d654f'
+
+2023-11-01 16:29:45,980 - INFO - It'll redeploy 2 EVPL(s) using batch_size 10 and batch_sleep 5
+2023-11-01 16:29:46,123 - INFO - Redeployed evc_id dc533ac942a541
+2023-11-01 16:29:46,143 - INFO - Redeployed evc_id eab1fedf3d654f
+```
+
+- If you want to redeploy all symmetric EVPLs by redeploying 10 EVCs concurrently and waiting for 5 seconds:
+
+```
+python scripts/redeploy_evpls_same_vlans.py update --batch_size 10 --batch_sleep_secs 5
+
+
+2023-11-01 16:23:11,081 - INFO - It'll redeploy 100 EVPL(s) using batch_size 10 and batch_sleep 5
+2023-11-01 16:23:11,724 - INFO - Redeployed evc_id 0ca460bafb7442
+2023-11-01 16:23:11,725 - INFO - Redeployed evc_id 0645d179d9174f
+2023-11-01 16:23:11,752 - INFO - Redeployed evc_id 0b45959b6a484b
+2023-11-01 16:23:11,763 - INFO - Redeployed evc_id 0a270fd5a2ce47
+2023-11-01 16:23:11,779 - INFO - Redeployed evc_id 08a72e3c1ecb40
+2023-11-01 16:23:11,780 - INFO - Redeployed evc_id 09a5a3b14f9048
+2023-11-01 16:23:11,780 - INFO - Redeployed evc_id 0e658df33a9d46
+2023-11-01 16:23:11,783 - INFO - Redeployed evc_id 1096fff414c649
+2023-11-01 16:23:11,789 - INFO - Redeployed evc_id 0a5702d65da64c
+2023-11-01 16:23:11,802 - INFO - Redeployed evc_id 07e3c962346947
+2023-11-01 16:23:11,802 - INFO - Sleeping for 5...
+2023-11-01 16:23:17,498 - INFO - Redeployed evc_id 1b884a1dd8f147
+2023-11-01 16:23:17,538 - INFO - Redeployed evc_id 23270946ce1044
+2023-11-01 16:23:17,541 - INFO - Redeployed evc_id 18610fbbcfe54e
+2023-11-01 16:23:17,543 - INFO - Redeployed evc_id 1a10cb2638d746
+2023-11-01 16:23:17,543 - INFO - Redeployed evc_id 25f2269466cc42
+2023-11-01 16:23:17,544 - INFO - Redeployed evc_id 2c332447842b42
+2023-11-01 16:23:17,546 - INFO - Redeployed evc_id 2ddf3e33b5fd4b
+2023-11-01 16:23:17,547 - INFO - Redeployed evc_id 168346ab0be845
+2023-11-01 16:23:17,554 - INFO - Redeployed evc_id 21aff155f11e49
+2023-11-01 16:23:17,555 - INFO - Redeployed evc_id 215aeb07f34543
+2023-11-01 16:23:17,555 - INFO - Sleeping for 5...
+
+```
+</details>
+
+
 </details>

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -175,7 +175,7 @@ python scripts/redeploy_evpls_same_vlans.py update --batch_size 10 --batch_sleep
 2023-11-01 16:29:46,143 - INFO - Redeployed evc_id eab1fedf3d654f
 ```
 
-- If you want to redeploy all symmetric EVPLs by redeploying 10 EVCs concurrently and waiting for 5 seconds:
+- If you want to redeploy all symmetric EVPLs batching 10 EVCs concurrently and waiting for 5 seconds per batch:
 
 ```
 python scripts/redeploy_evpls_same_vlans.py update --batch_size 10 --batch_sleep_secs 5

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -112,7 +112,7 @@ CMD=update_database python3 scripts/003_vlan_type_string.py
 
 [`redeploy_evpls_same_vlans.py`](./redeploy_evpls_same_vlans.py) is a CLI script to list and redeploy symmetric (same vlan on both UNIs) EVPLs.
 
-You should use this script if you want to avoid a redundant `set_vlan` instruction that used to be present in the instruction set. This script by triggering an EVC redeploy will force that all flows get pushed and overwritten again, it'll temporarily create traffic disruption. The redeploy in this case is just to force that the flows are pushed right away instead of waiting for a network convergence that might result in the flows getting pushed again.
+You should use this script if you want to avoid a redundant `set_vlan` instruction that used to be present in the instruction set and if you are upgrading from `2023.1.0`. This script by triggering an EVC redeploy will force that all flows get pushed and overwritten again, it'll temporarily create traffic disruption. The redeploy in this case is just to force that the flows are pushed right away instead of waiting for a network convergence that might result in the flows getting pushed again.
 
 #### Pre-requisites
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -112,7 +112,7 @@ CMD=update_database python3 scripts/003_vlan_type_string.py
 
 [`redeploy_evpls_same_vlans.py`](./redeploy_evpls_same_vlans.py) is a CLI script to list and redeploy symmetric (same vlan on both UNIs) EVPLs.
 
-You should use this script if you want to avoid a redudant `set_vlan` instruction that used to be present in the instruction set. This script by triggering an EVC redeploy will force that all flows get pushed and overwritten again, it'll temporarily create traffic disruption. The redeploy in this case is just to force that the flows are pushed right away instead of waiting for a network convergence that might result in the flows getting pushed again.
+You should use this script if you want to avoid a redundant `set_vlan` instruction that used to be present in the instruction set. This script by triggering an EVC redeploy will force that all flows get pushed and overwritten again, it'll temporarily create traffic disruption. The redeploy in this case is just to force that the flows are pushed right away instead of waiting for a network convergence that might result in the flows getting pushed again.
 
 #### Pre-requisites
 
@@ -120,7 +120,7 @@ You should use this script if you want to avoid a redudant `set_vlan` instructio
 
 #### How to use
 
-This script exposes two commmands: `list` and `update`.
+This script exposes two commands: `list` and `update`.
 
 - First you want to `list` to double check which symmetric EVPLs have been found. If you need to just include a subset you can use the ``--included_evcs_filter`` string passing a string of evc ids separated by comma value.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -116,6 +116,7 @@ You should use this script if you want to avoid a redundant `set_vlan` instructi
 
 #### Pre-requisites
 
+- `kytosd` must be running
 - There's no additional dependency other than the existing core ones
 
 #### How to use

--- a/scripts/redeploy_evpls_same_vlans.py
+++ b/scripts/redeploy_evpls_same_vlans.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import json
+import sys
+import logging
+
+import argparse
+import asyncio
+import httpx
+
+logging.basicConfig(
+    format="%(asctime)s - %(levelname)s - %(message)s", level=logging.INFO
+)
+logger = logging.getLogger(__name__)
+
+
+def is_symmetric_evpl(evc: dict) -> bool:
+    """Check whether it's a symmetric (same UNIs vlans) evpl."""
+    uni_a, uni_z = evc["uni_a"], evc["uni_z"]
+    return (
+        "tag" in uni_a
+        and "tag" in uni_z
+        and uni_a["tag"]["tag_type"] == "vlan"
+        and uni_z["tag"]["tag_type"] == "vlan"
+        and isinstance(uni_a["tag"]["value"], int)
+        and isinstance(uni_z["tag"]["value"], int)
+        and uni_a["tag"]["value"] == uni_z["tag"]["value"]
+    )
+
+
+async def redeploy(evc_id: str, base_url: str):
+    """Redeploy."""
+    endpoint = "/mef_eline/v2/evc"
+    async with httpx.AsyncClient(base_url=base_url) as client:
+        res = await client.patch(f"{endpoint}/{evc_id}/redeploy")
+        logger.info(f"Redeployed evc_id {evc_id}")
+        assert (
+            res.status_code == 202
+        ), f"failed to redeploy evc_id: {evc_id} {res.status_code} {res.text}"
+
+
+async def list_symmetric_evpls(base_url: str, included_evcs_filter: str = "") -> dict:
+    """List symmetric (same UNI vlan) evpls."""
+    endpoint = "/mef_eline/v2/evc"
+    async with httpx.AsyncClient(base_url=base_url) as client:
+        resp = await client.get(endpoint, timeout=20)
+        evcs = {
+            evc_id: evc for evc_id, evc in resp.json().items() if is_symmetric_evpl(evc)
+        }
+        if included_evcs_filter:
+            included = set(included_evcs_filter.split(","))
+            evcs = {evc_id: evc for evc_id, evc in evcs.items() if evc_id in included}
+        return evcs
+
+
+async def update_command(args: argparse.Namespace) -> None:
+    """update command.
+
+    It'll list all symmetric EVPLs (same UNIs vlans) and redeploy them
+    concurrently. The concurrency slot and wait time can be controlled with
+    batch_size and batch_sleep_secs
+
+    If any coroutine fails its exception will be bubbled up.
+    """
+    evcs = await list_symmetric_evpls(args.base_url, args.included_evcs_filter)
+    coros = [redeploy(evc_id, args.base_url) for evc_id, evc in evcs.items()]
+    batch_size = args.batch_size if args.batch_size > 0 else len(coros)
+    batch_sleep = args.batch_sleep_secs if args.batch_sleep_secs >= 0 else 0
+
+    logger.info(
+        f"It'll redeploy {len(coros)} EVPL(s) using batch_size {batch_size} "
+        f"and batch_sleep {batch_sleep}"
+    )
+
+    for i in range(0, len(coros), batch_size):
+        sliced = coros[i : i + batch_size]
+        if i > 0 and batch_sleep:
+            logger.info(f"Sleeping for {batch_sleep}...")
+            await asyncio.sleep(batch_sleep)
+        await asyncio.gather(*sliced)
+
+
+async def list_command(args: argparse.Namespace) -> None:
+    """list command."""
+    evcs = await list_symmetric_evpls(args.base_url, args.included_evcs_filter)
+    evcs = {
+        evc_id: {
+            "name": evc["name"],
+            "uni_a": evc["uni_a"],
+            "uni_z": evc["uni_z"],
+        }
+        for evc_id, evc in evcs.items()
+    }
+    print(json.dumps(evcs))
+
+
+async def main() -> None:
+    """Main function."""
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(title="commands", dest="command")
+
+    update_parser = subparsers.add_parser("update", help="Update command")
+    update_parser.add_argument(
+        "--batch_sleep_secs", type=int, help="Batch sleep in seconds", default=5
+    )
+    update_parser.add_argument("--batch_size", type=int, help="Batch size", default=10)
+    update_parser.add_argument(
+        "--included_evcs_filter",
+        type=str,
+        help="Included filtered EVC ids separated by comma",
+        default="",
+    )
+    update_parser.add_argument(
+        "--base_url",
+        type=str,
+        default="http://localhost:8181/api/kytos",
+        help="Kytos-ng API base url",
+    )
+
+    list_parser = subparsers.add_parser("list", help="List command")
+    list_parser.add_argument(
+        "--base_url",
+        type=str,
+        default="http://localhost:8181/api/kytos",
+        help="Kytos-ng API base url",
+    )
+    list_parser.add_argument(
+        "--included_evcs_filter",
+        type=str,
+        help="Included filtered EVC ids separated by comma",
+        default="",
+    )
+    args = parser.parse_args()
+
+    try:
+        if args.command == "update":
+            await update_command(args)
+        elif args.command == "list":
+            await list_command(args)
+    except (httpx.HTTPError, AssertionError) as exc:
+        logger.exception(f"Error when running '{args.command}': {exc}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -232,6 +232,7 @@ class TestEVC():
         "in_vlan_a,in_vlan_z",
         [
             (100, 50),
+            (100, 100),
             (100, "4096/4096"),
             (100, 0),
             (100, None),
@@ -286,7 +287,7 @@ class TestEVC():
         expected_flow_mod["priority"] = evc.get_priority(in_vlan_a)
         if in_vlan_a is not None:
             expected_flow_mod['match']['dl_vlan'] = in_vlan_a
-        if in_vlan_z not in evc.special_cases:
+        if in_vlan_z not in evc.special_cases and in_vlan_a != in_vlan_z:
             new_action = {"action_type": "set_vlan",
                           "vlan_id": in_vlan_z}
             expected_flow_mod["actions"].insert(0, new_action)


### PR DESCRIPTION
Closes #389 

### Summary

- See updated changelog
- See updated scripts/README.md

### Local Tests

I created an inter evpl with same vlans on UNI A and Z and confirmed the expected flows and that sdntrace_cp and sdntrace were still tracing as expected:

#### Before

```
cookie=0xaaa73f765873d841, duration=12.858s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=20000,in_port="s3-eth1",dl_vlan=101 actions=set_field:4197->vlan_vid,push_vlan:0x88a8,set_field:4097->vlan_vid,output:"s3-eth3"
```

```
{
            "flow": {
                "owner": "mef_eline",
                "cookie": 12271464045111059785,
                "match": {
                    "in_port": 1,
                    "dl_vlan": 101
                },
                "actions": [
                    {
                        "action_type": "set_vlan",
                        "vlan_id": 101
                    },
                    {
                        "action_type": "push_vlan",
                        "tag_type": "s"
                    },
                    {
                        "action_type": "set_vlan",
                        "vlan_id": 1
                    },
                    {
                        "action_type": "output",
                        "port": 4
                    }
                ],
                "table_id": 0,
                "table_group": "evpl",
                "priority": 20000,
                "idle_timeout": 0,
                "hard_timeout": 0
            },
            "flow_id": "b586365ad419c3a102e23117751a0400",
            "id": "ae60baf217bc417dfdacfd7278210259",
            "inserted_at": "2023-10-31T18:09:14.836000",
            "state": "installed",
            "switch": "00:00:00:00:00:00:00:01",
            "updated_at": "2023-10-31T18:09:14.846000"
        },
```

#### After

```
cookie=0xaa2125e27a604843, duration=12.487s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=20000,in_port="s1-eth1",dl_vlan=101 actions=push_vlan:0x88a8,set_field:4097->vlan_vid,output:"s1-eth4"

```

```
{
            "flow": {
                "owner": "mef_eline",
                "cookie": 12259121315325167683,
                "match": {
                    "in_port": 1,
                    "dl_vlan": 101
                },
                "actions": [
                    {
                        "action_type": "push_vlan",
                        "tag_type": "s"
                    },
                    {
                        "action_type": "set_vlan",
                        "vlan_id": 1
                    },
                    {
                        "action_type": "output",
                        "port": 4
                    }
                ],
                "table_id": 0,
                "table_group": "evpl",
                "priority": 20000,
                "idle_timeout": 0,
                "hard_timeout": 0
            },
            "flow_id": "b5d395eb05316e97559b2e15987aaf26",
            "id": "9e69461fa99f236c580819f0640bc8e0",
            "inserted_at": "2023-10-31T18:01:40.389000",
            "state": "installed",
            "switch": "00:00:00:00:00:00:00:01",
            "updated_at": "2023-10-31T18:01:40.398000"
        }
```

I've also confirmed that both `sdntrace_cp` and `sdntrace` still traced correctly. 

I've also run the ``scripts/redeploy_evpls_same_vlans.py`` script locally with 100 symmetric EVPLs, and confirmed that the redundant `set_vlan` got overwritten as expected:

```
❯ python scripts/redeploy_evpls_same_vlans.py update --batch_size 10 --batch_sleep_secs 5

2023-11-01 16:23:11,081 - INFO - It'll redeploy 100 EVPL(s) using batch_size 10 and batch_sleep 5
2023-11-01 16:23:11,724 - INFO - Redeployed evc_id 0ca460bafb7442
2023-11-01 16:23:11,725 - INFO - Redeployed evc_id 0645d179d9174f
2023-11-01 16:23:11,752 - INFO - Redeployed evc_id 0b45959b6a484b
2023-11-01 16:23:11,763 - INFO - Redeployed evc_id 0a270fd5a2ce47
2023-11-01 16:23:11,779 - INFO - Redeployed evc_id 08a72e3c1ecb40
2023-11-01 16:23:11,780 - INFO - Redeployed evc_id 09a5a3b14f9048
2023-11-01 16:23:11,780 - INFO - Redeployed evc_id 0e658df33a9d46
2023-11-01 16:23:11,783 - INFO - Redeployed evc_id 1096fff414c649
2023-11-01 16:23:11,789 - INFO - Redeployed evc_id 0a5702d65da64c
2023-11-01 16:23:11,802 - INFO - Redeployed evc_id 07e3c962346947
2023-11-01 16:23:11,802 - INFO - Sleeping for 5...
2023-11-01 16:23:17,498 - INFO - Redeployed evc_id 1b884a1dd8f147
2023-11-01 16:23:17,538 - INFO - Redeployed evc_id 23270946ce1044
2023-11-01 16:23:17,541 - INFO - Redeployed evc_id 18610fbbcfe54e
2023-11-01 16:23:17,543 - INFO - Redeployed evc_id 1a10cb2638d746
2023-11-01 16:23:17,543 - INFO - Redeployed evc_id 25f2269466cc42
2023-11-01 16:23:17,544 - INFO - Redeployed evc_id 2c332447842b42
2023-11-01 16:23:17,546 - INFO - Redeployed evc_id 2ddf3e33b5fd4b
2023-11-01 16:23:17,547 - INFO - Redeployed evc_id 168346ab0be845
2023-11-01 16:23:17,554 - INFO - Redeployed evc_id 21aff155f11e49
2023-11-01 16:23:17,555 - INFO - Redeployed evc_id 215aeb07f34543
2023-11-01 16:23:17,555 - INFO - Sleeping for 5...
2023-11-01 16:23:23,221 - INFO - Redeployed evc_id 453ba52e364a43
2023-11-01 16:23:23,224 - INFO - Redeployed evc_id 43bb99f1a41e41
2023-11-01 16:23:23,225 - INFO - Redeployed evc_id 303347f467ae4d
2023-11-01 16:23:23,231 - INFO - Redeployed evc_id 382c722002fe40
2023-11-01 16:23:23,234 - INFO - Redeployed evc_id 392c1868083d44
2023-11-01 16:23:23,235 - INFO - Redeployed evc_id 3539be4b581542
2023-11-01 16:23:23,240 - INFO - Redeployed evc_id 38d1127b26d54a
2023-11-01 16:23:23,242 - INFO - Redeployed evc_id 2eff8264259542
2023-11-01 16:23:23,254 - INFO - Redeployed evc_id 32aa6d0945bb4e
2023-11-01 16:23:23,316 - INFO - Redeployed evc_id 3272125acc324a
2023-11-01 16:23:23,316 - INFO - Sleeping for 5...
2023-11-01 16:23:28,985 - INFO - Redeployed evc_id 6445869c83dc46
2023-11-01 16:23:29,011 - INFO - Redeployed evc_id 5dcb17db105744
2023-11-01 16:23:29,011 - INFO - Redeployed evc_id 6150376c2ac040
2023-11-01 16:23:29,012 - INFO - Redeployed evc_id 62227f0ccb2341
2023-11-01 16:23:29,012 - INFO - Redeployed evc_id 5302d149f3bf4b
2023-11-01 16:23:29,012 - INFO - Redeployed evc_id 570edd4fe09f49
2023-11-01 16:23:29,015 - INFO - Redeployed evc_id 57af119101cc4e
2023-11-01 16:23:29,015 - INFO - Redeployed evc_id 4ed57412821c40
2023-11-01 16:23:29,026 - INFO - Redeployed evc_id 4888e370255f46
2023-11-01 16:23:29,098 - INFO - Redeployed evc_id 5b5daee2effd45
2023-11-01 16:23:29,098 - INFO - Sleeping for 5...
2023-11-01 16:23:34,769 - INFO - Redeployed evc_id 6d9b300d54c242
2023-11-01 16:23:34,792 - INFO - Redeployed evc_id 6f60ac88cf4849
2023-11-01 16:23:34,793 - INFO - Redeployed evc_id 74e5b008ad3245
2023-11-01 16:23:34,794 - INFO - Redeployed evc_id 708e2e3333024b
2023-11-01 16:23:34,796 - INFO - Redeployed evc_id 6bf0abff16f74b
2023-11-01 16:23:34,797 - INFO - Redeployed evc_id 7296353699c44e
2023-11-01 16:23:34,797 - INFO - Redeployed evc_id 6baa00c6e8e444
2023-11-01 16:23:34,800 - INFO - Redeployed evc_id 745e96e8a3a642
2023-11-01 16:23:34,801 - INFO - Redeployed evc_id 747f07d0a1c34a
2023-11-01 16:23:34,804 - INFO - Redeployed evc_id 75cdf24d14d94d
2023-11-01 16:23:34,804 - INFO - Sleeping for 5...
2023-11-01 16:23:40,504 - INFO - Redeployed evc_id 7e42b08824a242
2023-11-01 16:23:40,505 - INFO - Redeployed evc_id 90d85a3dedbb42
2023-11-01 16:23:40,505 - INFO - Redeployed evc_id 906349dbb53c41
2023-11-01 16:23:40,505 - INFO - Redeployed evc_id 8b93820f0c794e
2023-11-01 16:23:40,507 - INFO - Redeployed evc_id 965919b509cd44
2023-11-01 16:23:40,507 - INFO - Redeployed evc_id 80fcfb31f0b747
2023-11-01 16:23:40,507 - INFO - Redeployed evc_id 92da3cd070a14a
2023-11-01 16:23:40,508 - INFO - Redeployed evc_id 8d463740075b4d
2023-11-01 16:23:40,508 - INFO - Redeployed evc_id 916bc9108a994b
2023-11-01 16:23:40,508 - INFO - Redeployed evc_id 93e3020b5fae47
2023-11-01 16:23:40,508 - INFO - Sleeping for 5...
2023-11-01 16:23:46,178 - INFO - Redeployed evc_id a2666be9522440
2023-11-01 16:23:46,179 - INFO - Redeployed evc_id 98bdff07f17543
2023-11-01 16:23:46,182 - INFO - Redeployed evc_id 98942e3e3b584b
2023-11-01 16:23:46,182 - INFO - Redeployed evc_id a216b79f184c44
2023-11-01 16:23:46,183 - INFO - Redeployed evc_id a09096e5556441
2023-11-01 16:23:46,188 - INFO - Redeployed evc_id a383508536ac4e
2023-11-01 16:23:46,188 - INFO - Redeployed evc_id ad2bd780cf514e
2023-11-01 16:23:46,189 - INFO - Redeployed evc_id aa9ff6d571994d
2023-11-01 16:23:46,196 - INFO - Redeployed evc_id 9ac9e6be32c442
2023-11-01 16:23:46,196 - INFO - Redeployed evc_id 989da40ff31e43
2023-11-01 16:23:46,196 - INFO - Sleeping for 5...
2023-11-01 16:23:51,857 - INFO - Redeployed evc_id c049844ccb1c48
2023-11-01 16:23:51,858 - INFO - Redeployed evc_id b917d84f772746
2023-11-01 16:23:51,862 - INFO - Redeployed evc_id be25c510b33c43
2023-11-01 16:23:51,867 - INFO - Redeployed evc_id baeaae03d2cc4b
2023-11-01 16:23:51,867 - INFO - Redeployed evc_id af9c3005d0394b
2023-11-01 16:23:51,868 - INFO - Redeployed evc_id b4a8f2b000c042
2023-11-01 16:23:52,058 - INFO - Redeployed evc_id c209fea4311c49
2023-11-01 16:23:52,059 - INFO - Redeployed evc_id c5fc7f320de440
2023-11-01 16:23:52,184 - INFO - Redeployed evc_id aee58f1dcaaf41
2023-11-01 16:23:52,211 - INFO - Redeployed evc_id c349fd3f87be4d
2023-11-01 16:23:52,212 - INFO - Sleeping for 5...
2023-11-01 16:23:57,904 - INFO - Redeployed evc_id c69449a6c9db4f
2023-11-01 16:23:57,905 - INFO - Redeployed evc_id c6fac95c14014c
2023-11-01 16:23:57,906 - INFO - Redeployed evc_id c8a82526f90a49
2023-11-01 16:23:57,908 - INFO - Redeployed evc_id d310a9ce6e404e
2023-11-01 16:23:57,909 - INFO - Redeployed evc_id d25a345af4dd4e
2023-11-01 16:23:57,909 - INFO - Redeployed evc_id c975a740de7d4d
2023-11-01 16:23:57,910 - INFO - Redeployed evc_id ca76aaa5bc8143
2023-11-01 16:23:57,910 - INFO - Redeployed evc_id d13b674dfd444f
2023-11-01 16:23:57,910 - INFO - Redeployed evc_id c879213a8bf340
2023-11-01 16:23:57,937 - INFO - Redeployed evc_id cbc5ae0ab39641
2023-11-01 16:23:57,937 - INFO - Sleeping for 5...
2023-11-01 16:24:03,643 - INFO - Redeployed evc_id efc8b9cb8f3447
2023-11-01 16:24:03,645 - INFO - Redeployed evc_id ea8e1517a27347
2023-11-01 16:24:03,645 - INFO - Redeployed evc_id db34e8dc256d40
2023-11-01 16:24:03,646 - INFO - Redeployed evc_id ff7659159f4b40
2023-11-01 16:24:03,646 - INFO - Redeployed evc_id f3879e8b244a41
2023-11-01 16:24:03,648 - INFO - Redeployed evc_id f69b403d3b494d
2023-11-01 16:24:03,649 - INFO - Redeployed evc_id daf75a39a7124d
2023-11-01 16:24:03,649 - INFO - Redeployed evc_id ebcd5e777e604a
2023-11-01 16:24:03,649 - INFO - Redeployed evc_id eab1fedf3d654f
2023-11-01 16:24:03,654 - INFO - Redeployed evc_id dc533ac942a541
```

### End-to-End Tests

e2e with this branch:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.3.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 242 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 24%]
tests/test_e2e_11_mef_eline.py ......                                    [ 27%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 30%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 47%]
.                                                                        [ 47%]
tests/test_e2e_14_mef_eline.py x                                         [ 48%]
tests/test_e2e_15_mef_eline.py ....                                      [ 50%]
tests/test_e2e_20_flow_manager.py .....................                  [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 66%]
tests/test_e2e_23_flow_manager.py ..............                         [ 71%]
tests/test_e2e_30_of_lldp.py ....                                        [ 73%]
tests/test_e2e_31_of_lldp.py ...                                         [ 74%]
tests/test_e2e_32_of_lldp.py ...                                         [ 76%]
tests/test_e2e_40_sdntrace.py .............                              [ 81%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 84%]
tests/test_e2e_50_maintenance.py ........................                [ 94%]
tests/test_e2e_60_of_multi_table.py .....                                [ 96%]
tests/test_e2e_70_kytos_stats.py ........                                [100%]
=============================== warnings summary ===============================
------------------------------- start/stop times -------------------------------
= 220 passed, 6 skipped, 9 xfailed, 7 xpassed, 867 warnings in 11536.31s (3:12:16) =
```