### PR TITLE
[backport release 2023.1.3] feat: add `set_vlan` only if UNI A vlan and UNI z vlan are different

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,17 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [Unreleased]
 ************
 
+[2023.1.3] - 2023-11-01
+***********************
+
+Changed
+=======
+- Add ``set_vlan`` only if UNI A vlan and UNI z vlan are different.
+
+General Information
+===================
+- ``scripts/redeploy_evpls_same_vlans.py`` can be used to redeploy symmetric (same UNI vlans) EVPLs in batch.
+
 [2023.1.2] - 2023-10-12
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2023.1.2",
+  "version": "2023.1.3",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],

--- a/models/evc.py
+++ b/models/evc.py
@@ -1240,7 +1240,7 @@ class EVCDeploy(EVCBase):
             # if in_vlan is set, it must be included in the match
             flow_mod["match"]["dl_vlan"] = in_vlan
 
-        if new_c_vlan not in self.special_cases:
+        if new_c_vlan not in self.special_cases and in_vlan != new_c_vlan:
             # new_in_vlan is an integer but zero, action to set is required
             new_action = {"action_type": "set_vlan", "vlan_id": new_c_vlan}
             flow_mod["actions"].insert(0, new_action)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -71,3 +71,103 @@ EVC_IDS='d33539656d8b40,095e1d6f43c745' priority python3 scripts/002_unset_spf_a
 ```
 
 - After that, `kytosd` should be restarted just so `mef_eline` EVCs can get fully reloaded in memory with the expected primary and secondary constraints, this would be the safest route.
+
+<details><summary><h3>Redeploy symmetric UNI vlans EVPLs </h3></summary>
+
+[`redeploy_evpls_same_vlans.py`](./redeploy_evpls_same_vlans.py) is a CLI script to list and redeploy symmetric (same vlan on both UNIs) EVPLs.
+
+You should use this script if you want to avoid a redundant `set_vlan` instruction that used to be present in the instruction set. This script by triggering an EVC redeploy will force that all flows get pushed and overwritten again, it'll temporarily create traffic disruption. The redeploy in this case is just to force that the flows are pushed right away instead of waiting for a network convergence that might result in the flows getting pushed again.
+
+#### Pre-requisites
+
+- There's no additional dependency other than the existing core ones
+
+#### How to use
+
+This script exposes two commands: `list` and `update`.
+
+- First you want to `list` to double check which symmetric EVPLs have been found. If you need to just include a subset you can use the ``--included_evcs_filter`` string passing a string of evc ids separated by comma value.
+
+```shell
+python scripts/redeploy_evpls_same_vlans.py list --included_evcs_filter 'dc533ac942a541,eab1fedf3d654f' | jq
+
+{
+  "dc533ac942a541": {
+    "name": "1046-1046",
+    "uni_a": {
+      "tag": {
+        "tag_type": "vlan",
+        "value": 1046
+      },
+      "interface_id": "00:00:00:00:00:00:00:01:1"
+    },
+    "uni_z": {
+      "tag": {
+        "tag_type": "vlan",
+        "value": 1046
+      },
+      "interface_id": "00:00:00:00:00:00:00:03:1"
+    }
+  },
+  "eab1fedf3d654f": {
+    "name": "1070-1070",
+    "uni_a": {
+      "tag": {
+        "tag_type": "vlan",
+        "value": 1070
+      },
+      "interface_id": "00:00:00:00:00:00:00:01:1"
+    },
+    "uni_z": {
+      "tag": {
+        "tag_type": "vlan",
+        "value": 1070
+      },
+      "interface_id": "00:00:00:00:00:00:00:03:1"
+    }
+  }
+}
+```
+
+- If you're OK with the EVPLs listed on `list`, then you can proceed to `update` to trigger a redeploy. You can also set ``--batch_size`` and ``--batch_sleep_secs`` to control respectively how many EVPLs will be redeployed concurrently and how long to wait after each batch is sent:
+
+```
+python scripts/redeploy_evpls_same_vlans.py update --batch_size 10 --batch_sleep_secs 5 --included_evcs_filter 'dc533ac942a541,eab1fedf3d654f'
+
+2023-11-01 16:29:45,980 - INFO - It'll redeploy 2 EVPL(s) using batch_size 10 and batch_sleep 5
+2023-11-01 16:29:46,123 - INFO - Redeployed evc_id dc533ac942a541
+2023-11-01 16:29:46,143 - INFO - Redeployed evc_id eab1fedf3d654f
+```
+
+- If you want to redeploy all symmetric EVPLs batching 10 EVCs concurrently and waiting for 5 seconds per batch:
+
+```
+python scripts/redeploy_evpls_same_vlans.py update --batch_size 10 --batch_sleep_secs 5
+
+
+2023-11-01 16:23:11,081 - INFO - It'll redeploy 100 EVPL(s) using batch_size 10 and batch_sleep 5
+2023-11-01 16:23:11,724 - INFO - Redeployed evc_id 0ca460bafb7442
+2023-11-01 16:23:11,725 - INFO - Redeployed evc_id 0645d179d9174f
+2023-11-01 16:23:11,752 - INFO - Redeployed evc_id 0b45959b6a484b
+2023-11-01 16:23:11,763 - INFO - Redeployed evc_id 0a270fd5a2ce47
+2023-11-01 16:23:11,779 - INFO - Redeployed evc_id 08a72e3c1ecb40
+2023-11-01 16:23:11,780 - INFO - Redeployed evc_id 09a5a3b14f9048
+2023-11-01 16:23:11,780 - INFO - Redeployed evc_id 0e658df33a9d46
+2023-11-01 16:23:11,783 - INFO - Redeployed evc_id 1096fff414c649
+2023-11-01 16:23:11,789 - INFO - Redeployed evc_id 0a5702d65da64c
+2023-11-01 16:23:11,802 - INFO - Redeployed evc_id 07e3c962346947
+2023-11-01 16:23:11,802 - INFO - Sleeping for 5...
+2023-11-01 16:23:17,498 - INFO - Redeployed evc_id 1b884a1dd8f147
+2023-11-01 16:23:17,538 - INFO - Redeployed evc_id 23270946ce1044
+2023-11-01 16:23:17,541 - INFO - Redeployed evc_id 18610fbbcfe54e
+2023-11-01 16:23:17,543 - INFO - Redeployed evc_id 1a10cb2638d746
+2023-11-01 16:23:17,543 - INFO - Redeployed evc_id 25f2269466cc42
+2023-11-01 16:23:17,544 - INFO - Redeployed evc_id 2c332447842b42
+2023-11-01 16:23:17,546 - INFO - Redeployed evc_id 2ddf3e33b5fd4b
+2023-11-01 16:23:17,547 - INFO - Redeployed evc_id 168346ab0be845
+2023-11-01 16:23:17,554 - INFO - Redeployed evc_id 21aff155f11e49
+2023-11-01 16:23:17,555 - INFO - Redeployed evc_id 215aeb07f34543
+2023-11-01 16:23:17,555 - INFO - Sleeping for 5...
+
+```
+</details>

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -76,7 +76,7 @@ EVC_IDS='d33539656d8b40,095e1d6f43c745' priority python3 scripts/002_unset_spf_a
 
 [`redeploy_evpls_same_vlans.py`](./redeploy_evpls_same_vlans.py) is a CLI script to list and redeploy symmetric (same vlan on both UNIs) EVPLs.
 
-You should use this script if you want to avoid a redundant `set_vlan` instruction that used to be present in the instruction set and if you are upgrading from `2023.1.0`. This script by triggering an EVC redeploy will force that all flows get pushed and overwritten again, it'll temporarily create traffic disruption. The redeploy in this case is just to force that the flows are pushed right away instead of waiting for a network convergence that might result in the flows getting pushed again.
+You should use this script if you want to avoid a redundant `set_vlan` instruction that used to be present in the instruction set and if you are upgrading from `2023.1.2` or earlier versions. This script by triggering an EVC redeploy will force that all flows get pushed and overwritten again, it'll temporarily create traffic disruption. The redeploy in this case is just to force that the flows are pushed right away instead of waiting for a network convergence that might result in the flows getting pushed again.
 
 #### Pre-requisites
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -76,7 +76,7 @@ EVC_IDS='d33539656d8b40,095e1d6f43c745' priority python3 scripts/002_unset_spf_a
 
 [`redeploy_evpls_same_vlans.py`](./redeploy_evpls_same_vlans.py) is a CLI script to list and redeploy symmetric (same vlan on both UNIs) EVPLs.
 
-You should use this script if you want to avoid a redundant `set_vlan` instruction that used to be present in the instruction set. This script by triggering an EVC redeploy will force that all flows get pushed and overwritten again, it'll temporarily create traffic disruption. The redeploy in this case is just to force that the flows are pushed right away instead of waiting for a network convergence that might result in the flows getting pushed again.
+You should use this script if you want to avoid a redundant `set_vlan` instruction that used to be present in the instruction set and if you are upgrading from `2023.1.0`. This script by triggering an EVC redeploy will force that all flows get pushed and overwritten again, it'll temporarily create traffic disruption. The redeploy in this case is just to force that the flows are pushed right away instead of waiting for a network convergence that might result in the flows getting pushed again.
 
 #### Pre-requisites
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -80,6 +80,7 @@ You should use this script if you want to avoid a redundant `set_vlan` instructi
 
 #### Pre-requisites
 
+- `kytosd` must be running
 - There's no additional dependency other than the existing core ones
 
 #### How to use

--- a/scripts/redeploy_evpls_same_vlans.py
+++ b/scripts/redeploy_evpls_same_vlans.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import json
+import sys
+import logging
+
+import argparse
+import asyncio
+import httpx
+
+logging.basicConfig(
+    format="%(asctime)s - %(levelname)s - %(message)s", level=logging.INFO
+)
+logger = logging.getLogger(__name__)
+
+
+def is_symmetric_evpl(evc: dict) -> bool:
+    """Check whether it's a symmetric (same UNIs vlans) evpl."""
+    uni_a, uni_z = evc["uni_a"], evc["uni_z"]
+    return (
+        "tag" in uni_a
+        and "tag" in uni_z
+        and uni_a["tag"]["tag_type"] == "vlan"
+        and uni_z["tag"]["tag_type"] == "vlan"
+        and isinstance(uni_a["tag"]["value"], int)
+        and isinstance(uni_z["tag"]["value"], int)
+        and uni_a["tag"]["value"] == uni_z["tag"]["value"]
+    )
+
+
+async def redeploy(evc_id: str, base_url: str):
+    """Redeploy."""
+    endpoint = "/mef_eline/v2/evc"
+    async with httpx.AsyncClient(base_url=base_url) as client:
+        res = await client.patch(f"{endpoint}/{evc_id}/redeploy")
+        logger.info(f"Redeployed evc_id {evc_id}")
+        assert (
+            res.status_code == 202
+        ), f"failed to redeploy evc_id: {evc_id} {res.status_code} {res.text}"
+
+
+async def list_symmetric_evpls(base_url: str, included_evcs_filter: str = "") -> dict:
+    """List symmetric (same UNI vlan) evpls."""
+    endpoint = "/mef_eline/v2/evc"
+    async with httpx.AsyncClient(base_url=base_url) as client:
+        resp = await client.get(endpoint, timeout=20)
+        evcs = {
+            evc_id: evc for evc_id, evc in resp.json().items() if is_symmetric_evpl(evc)
+        }
+        if included_evcs_filter:
+            included = set(included_evcs_filter.split(","))
+            evcs = {evc_id: evc for evc_id, evc in evcs.items() if evc_id in included}
+        return evcs
+
+
+async def update_command(args: argparse.Namespace) -> None:
+    """update command.
+
+    It'll list all symmetric EVPLs (same UNIs vlans) and redeploy them
+    concurrently. The concurrency slot and wait time can be controlled with
+    batch_size and batch_sleep_secs
+
+    If any coroutine fails its exception will be bubbled up.
+    """
+    evcs = await list_symmetric_evpls(args.base_url, args.included_evcs_filter)
+    coros = [redeploy(evc_id, args.base_url) for evc_id, evc in evcs.items()]
+    batch_size = args.batch_size if args.batch_size > 0 else len(coros)
+    batch_sleep = args.batch_sleep_secs if args.batch_sleep_secs >= 0 else 0
+
+    logger.info(
+        f"It'll redeploy {len(coros)} EVPL(s) using batch_size {batch_size} "
+        f"and batch_sleep {batch_sleep}"
+    )
+
+    for i in range(0, len(coros), batch_size):
+        sliced = coros[i : i + batch_size]
+        if i > 0 and batch_sleep:
+            logger.info(f"Sleeping for {batch_sleep}...")
+            await asyncio.sleep(batch_sleep)
+        await asyncio.gather(*sliced)
+
+
+async def list_command(args: argparse.Namespace) -> None:
+    """list command."""
+    evcs = await list_symmetric_evpls(args.base_url, args.included_evcs_filter)
+    evcs = {
+        evc_id: {
+            "name": evc["name"],
+            "uni_a": evc["uni_a"],
+            "uni_z": evc["uni_z"],
+        }
+        for evc_id, evc in evcs.items()
+    }
+    print(json.dumps(evcs))
+
+
+async def main() -> None:
+    """Main function."""
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(title="commands", dest="command")
+
+    update_parser = subparsers.add_parser("update", help="Update command")
+    update_parser.add_argument(
+        "--batch_sleep_secs", type=int, help="Batch sleep in seconds", default=5
+    )
+    update_parser.add_argument("--batch_size", type=int, help="Batch size", default=10)
+    update_parser.add_argument(
+        "--included_evcs_filter",
+        type=str,
+        help="Included filtered EVC ids separated by comma",
+        default="",
+    )
+    update_parser.add_argument(
+        "--base_url",
+        type=str,
+        default="http://localhost:8181/api/kytos",
+        help="Kytos-ng API base url",
+    )
+
+    list_parser = subparsers.add_parser("list", help="List command")
+    list_parser.add_argument(
+        "--base_url",
+        type=str,
+        default="http://localhost:8181/api/kytos",
+        help="Kytos-ng API base url",
+    )
+    list_parser.add_argument(
+        "--included_evcs_filter",
+        type=str,
+        help="Included filtered EVC ids separated by comma",
+        default="",
+    )
+    args = parser.parse_args()
+
+    try:
+        if args.command == "update":
+            await update_command(args)
+        elif args.command == "list":
+            await list_command(args)
+    except (httpx.HTTPError, AssertionError) as exc:
+        logger.exception(f"Error when running '{args.command}': {exc}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -232,6 +232,7 @@ class TestEVC():
         "in_vlan_a,in_vlan_z",
         [
             (100, 50),
+            (100, 100),
             (100, "4096/4096"),
             (100, 0),
             (100, None),
@@ -286,7 +287,7 @@ class TestEVC():
         expected_flow_mod["priority"] = evc.get_priority(in_vlan_a)
         if in_vlan_a is not None:
             expected_flow_mod['match']['dl_vlan'] = in_vlan_a
-        if in_vlan_z not in evc.special_cases:
+        if in_vlan_z not in evc.special_cases and in_vlan_a != in_vlan_z:
             new_action = {"action_type": "set_vlan",
                           "vlan_id": in_vlan_z}
             expected_flow_mod["actions"].insert(0, new_action)


### PR DESCRIPTION
Closes #391 

Backporting https://github.com/kytos-ng/mef_eline/pull/390 to `2023.1.3`. and bumping the version. 

Local tests and e2e tests were run in the original linked PR.