### PR TITLE
feat: published `kytos/mef_eline.evcs_loaded` when loading evcs during setup

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Added
 =====
 - Added a UI button for redeploying an EVC.
 - UNI tag_type are now accepted as string.
+- Event ``kytos/mef_eline.evcs_loaded`` gets published during NApp setup
 
 Changed
 =======

--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,17 @@ A response from the ``kytos/of_multi_table.enable_table`` event to confirm table
     'table_group': <object>
   }
 
+kytos/mef_eline.evcs_loaded
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Event with all evcs that got loaded
+
+.. code-block:: python3
+
+  {
+    '<evc_id>': <dict>
+  }
+
 .. TAGs
 
 .. |Stable| image:: https://img.shields.io/badge/stability-stable-green.svg

--- a/main.py
+++ b/main.py
@@ -884,6 +884,7 @@ class Main(KytosNApp):
         for circuit_id, circuit in circuits:
             if circuit_id not in self.circuits:
                 self._load_evc(circuit)
+        emit_event(self.controller, "evcs_loaded", content=dict(circuits))
 
     def _load_evc(self, circuit_dict):
         """Load one EVC from mongodb to memory."""

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2181,6 +2181,10 @@ class TestMain:
         self.napp.circuits = {2: 'circuit_2', 3: 'circuit_3'}
         self.napp.load_all_evcs()
         load_evc_mock.assert_has_calls([call('circuit_1'), call('circuit_4')])
+        assert self.napp.controller.buffers.app.put.call_count > 1
+        call_args = self.napp.controller.buffers.app.put.call_args[0]
+        assert call_args[0].name == "kytos/mef_eline.evcs_loaded"
+        assert dict(call_args[0].content) == mock_circuits["circuits"]
 
     @patch('napps.kytos.mef_eline.main.Main._evc_from_dict')
     def test_load_evc(self, evc_from_dict_mock):


### PR DESCRIPTION
Closes #400 

### Summary

See updated changelog file

### Local Tests

- Subscribed to it on `telemetry_int` and confirmed EVCs got published:

```
2023-11-14 16:27:39,451 - INFO [kytos.napps.kytos/telemetry_int] [main.py:208:on_mef_eline_evcs_loaded] (MainThread) got evcs_loaded {'4ba2a0bd562c4e': {'active': False, 'archived': Fals
e, 'backup_path': [], 'bandwidth': 0, 'circuit_scheduler': [], 'current_path': [], 'dynamic_backup_path': True, 'enabled': True, 'failover_path': [], 'id': '4ba2a0bd562c4e', 'metadata': 
{}, 'name': 'inter_evpl', 'primary_path': [], 'service_level': 6, 'uni_a': {'tag': {'tag_type': 'vlan', 'value': 301}, 'interface_id': '00:00:00:00:00:00:00:01:1'}, 'uni_z': {'tag': {'ta
g_type': 'vlan', 'value': 302}, 'interface_id': '00:00:00:00:00:00:00:03:1'}, 'sb_priority': None, 'execution_rounds': 0, 'owner': None, 'queue_id': -1, 'primary_constraints': {'mandator
y_metrics': {'ownership': 'blue'}}, 'secondary_constraints': {'mandatory_metrics': {'ownership': 'blue'}}, 'primary_links': [], 'backup_links': [], 'start_date': '2023-11-14T19:23:10', '
creation_time': '2023-11-14T19:23:10', 'request_time': '2023-11-14T19:23:10', 'end_date': None, 'flow_removed_at': None, 'updated_at': '2023-11-14T19:27:39'}, '6a6806a80f4d47': {'active'
: False, 'archived': False, 'backup_path': [], 'bandwidth': 0, 'circuit_scheduler': [], 'current_path': [], 'dynamic_backup_path': True, 'enabled': True, 'failover_path': [], 'id': '6a6806a80f4d47', 'metadata': {}, 'name': 'inter_evpl', 'primary_path': [], 'service_level': 6, 'uni_a': {'tag': {'tag_type': 'vlan', 'value': 302}, 'interface_id': '00:00:00:00:00:00:00:01:1
'}, 'uni_z': {'tag': {'tag_type': 'vlan', 'value': 303}, 'interface_id': '00:00:00:00:00:00:00:03:1'}, 'sb_priority': None, 'execution_rounds': 0, 'owner': None, 'queue_id': -1, 'primary
_constraints': {'mandatory_metrics': {'ownership': 'blue'}}, 'secondary_constraints': {'mandatory_metrics': {'ownership': 'blue'}}, 'primary_links': [], 'backup_links': [], 'start_date':
 '2023-11-14T19:23:16', 'creation_time': '2023-11-14T19:23:16', 'request_time': '2023-11-14T19:23:16', 'end_date': None, 'flow_removed_at': None, 'updated_at': '2023-11-14T19:27:39'}}
```

### End-to-End Tests

Not needed for this PR