### PR TITLE
Added special vlans to Interface events.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Added
 - UNI tag_type are now accepted as string.
 - EVCs now listen to ``switch.interface.(link_up|link_down|created|deleted)`` events for activation/deactivation
 - Circuits with a vlan range are supported now. The ranges follows ``list[list[int]]`` format and both UNIs vlan should have the same ranges.
+- Usage of special vlans ``"untagged"`` and ``"any"`` now send an event to each Interface.
 
 Changed
 =======

--- a/models/evc.py
+++ b/models/evc.py
@@ -445,7 +445,7 @@ class EVCBase(GenericEntity):
         if uni.user_tag is None:
             return
         tag = uni.user_tag.value
-        if not tag or isinstance(tag, str):
+        if not tag:
             return
         tag_type = uni.user_tag.tag_type
         if (uni_dif and isinstance(tag, list) and
@@ -466,7 +466,7 @@ class EVCBase(GenericEntity):
         if uni.user_tag is None:
             return
         tag = uni.user_tag.value
-        if not tag or isinstance(tag, str):
+        if not tag:
             return
         tag_type = uni.user_tag.tag_type
         if (uni_dif and isinstance(tag, list) and

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -5,5 +5,5 @@
 #    pip-compile --output-file requirements/dev.txt requirements/dev.in
 #
 -e git+https://github.com/kytos-ng/python-openflow.git#egg=python-openflow
--e git+https://github.com/kytos-ng/kytos.git@epic/vlan_range#egg=kytos[dev]
+-e git+https://github.com/kytos-ng/kytos.git@epic/vlan_range_special#egg=kytos[dev]
 -e .

--- a/tests/unit/models/test_evc_base.py
+++ b/tests/unit/models/test_evc_base.py
@@ -588,26 +588,26 @@ class TestEVC():  # pylint: disable=too-many-public-methods, no-member
 
         uni.user_tag.value = "any"
         evc._use_uni_vlan(uni)
-        assert uni.interface.use_tags.call_count == 1
+        assert uni.interface.use_tags.call_count == 2
 
         uni.user_tag.value = [[1, 10]]
         uni_dif = get_uni_mocked(tag_value=[[1, 2]])
         mock_difference.return_value = [[3, 10]]
         evc._use_uni_vlan(uni, uni_dif)
-        assert uni.interface.use_tags.call_count == 2
+        assert uni.interface.use_tags.call_count == 3
 
         mock_difference.return_value = []
         evc._use_uni_vlan(uni, uni_dif)
-        assert uni.interface.use_tags.call_count == 2
+        assert uni.interface.use_tags.call_count == 3
 
         uni.interface.use_tags.side_effect = KytosTagError("")
         with pytest.raises(KytosTagError):
             evc._use_uni_vlan(uni)
-        assert uni.interface.use_tags.call_count == 3
+        assert uni.interface.use_tags.call_count == 4
 
         uni.user_tag = None
         evc._use_uni_vlan(uni)
-        assert uni.interface.use_tags.call_count == 3
+        assert uni.interface.use_tags.call_count == 4
 
     @patch("napps.kytos.mef_eline.models.evc.log")
     def test_make_uni_vlan_available(self, mock_log):


### PR DESCRIPTION
Closes #404 

### Summary
Events for vlan usage now include special vlans "untagged" and "any
Related kytos [PR](https://github.com/kytos-ng/kytos/pull/431)

### Local Tests
Tested with UI and API requests. Created, deleted, modified EVCs.

### End-To-End Tests
```
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.3.0
rootdir: /tests
plugins: timeout-2.1.0, rerunfailures-10.2, anyio-3.6.2
collected 244 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 24%]
tests/test_e2e_11_mef_eline.py ......                                    [ 27%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 30%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X.....F..... [ 47%]
.                                                                        [ 47%]
tests/test_e2e_14_mef_eline.py x                                         [ 47%]
tests/test_e2e_15_mef_eline.py ....                                      [ 49%]
tests/test_e2e_20_flow_manager.py .....................                  [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 65%]
tests/test_e2e_23_flow_manager.py ..............                         [ 71%]
tests/test_e2e_30_of_lldp.py ....                                        [ 72%]
tests/test_e2e_31_of_lldp.py ...                                         [ 74%]
tests/test_e2e_32_of_lldp.py ...                                         [ 75%]
tests/test_e2e_40_sdntrace.py .............                              [ 80%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 84%]
tests/test_e2e_42_sdntrace.py ..                                         [ 84%]
tests/test_e2e_50_maintenance.py ........................                [ 94%]
tests/test_e2e_60_of_multi_table.py .....                                [ 96%]
tests/test_e2e_70_kytos_stats.py ........                                [100%]
```

Error from `test_190_post_an_evc_twice()` because the EVC has no tag. Looking into it.
[Issue](https://github.com/kytos-ng/mef_eline/issues/410) created.