### PR TITLE
fix: Look for not tag UNI duplication

### DIFF
--- a/exceptions.py
+++ b/exceptions.py
@@ -25,13 +25,10 @@ class DisabledSwitch(MEFELineException):
     """Exception for disabled switch in path"""
 
 
-class DuplicatedNoTagUNI(Exception):
+class DuplicatedNoTagUNI(MEFELineException):
     """Exception for duplicated no TAG UNI"""
     def __init__(self, msg: str) -> None:
         self.msg = msg
-
-    def __str__(self) -> str:
-        return f"DuplicatedNoTagUNI, {self.msg}"
 
     def __repr__(self) -> str:
         return f"DuplicatedNoTagUNI, {self.msg}"

--- a/exceptions.py
+++ b/exceptions.py
@@ -23,3 +23,15 @@ class InvalidPath(MEFELineException):
 
 class DisabledSwitch(MEFELineException):
     """Exception for disabled switch in path"""
+
+
+class DuplicatedNoTagUNI(Exception):
+    """Exception for duplicated no TAG UNI"""
+    def __init__(self, msg: str) -> None:
+        self.msg = msg
+
+    def __str__(self) -> str:
+        return f"DuplicatedNoTagUNI, {self.msg}"
+
+    def __repr__(self) -> str:
+        return f"DuplicatedNoTagUNI, {self.msg}"

--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ from kytos.core.rest_api import (HTTPException, JSONResponse, Request,
                                  get_json_or_400)
 from kytos.core.tag_ranges import get_tag_ranges
 from napps.kytos.mef_eline import controllers, settings
-from napps.kytos.mef_eline.exceptions import DisabledSwitch, InvalidPath
+from napps.kytos.mef_eline.exceptions import DisabledSwitch, InvalidPath, DuplicatedNoTagUNI
 from napps.kytos.mef_eline.models import (EVC, DynamicPathManager, EVCDeploy,
                                           Path)
 from napps.kytos.mef_eline.scheduler import CircuitSchedule, Scheduler
@@ -282,6 +282,13 @@ class Main(KytosNApp):
             raise HTTPException(400, detail=str(exception)) from exception
 
         try:
+            evc_data = {"id": evc.id, "uni_a": evc.uni_a, "uni_z": evc.uni_z}
+            self._check_no_tag_duplication(evc_data)
+        except DuplicatedNoTagUNI as exception:
+            log.debug("create_circuit result %s %s", exception, 400)
+            raise HTTPException(400, detail=str(exception)) from exception
+
+        try:
             self._use_uni_tags(evc)
         except KytosTagError as exception:
             raise HTTPException(400, detail=str(exception)) from exception
@@ -359,10 +366,13 @@ class Main(KytosNApp):
             raise HTTPException(409, detail=result)
 
         try:
-            enable, redeploy = evc.update(
-                **self._evc_dict_with_instances(data)
-            )
-        except (ValueError, KytosTagError, ValidationError) as exception:
+            updated_data = self._evc_dict_with_instances(data)
+            self._check_no_tag_duplication(dict(updated_data, id=circuit_id))
+            enable, redeploy = evc.update(**updated_data)
+        except (
+                ValueError, KytosTagError,
+                ValidationError, DuplicatedNoTagUNI
+            ) as exception:
             log.debug("update result %s %s", exception, 400)
             raise HTTPException(400, detail=str(exception)) from exception
         except DisabledSwitch as exception:
@@ -699,6 +709,28 @@ class Main(KytosNApp):
 
         log.debug("delete_schedule result %s %s", result, status)
         return JSONResponse(result, status_code=status)
+
+    def _check_no_tag_duplication(self, evc_dict: dict):
+        """Check if the given EVC has UNIs with no tag and if these are
+         duplicated. Raise DuplicatedNoTagUNI if duplication is found.
+        Args:
+            evc (dict): EVC to be analyzed.
+        """
+        uni_a, uni_z = evc_dict.get("uni_a"), evc_dict.get("uni_z")
+
+        # No UNIs
+        if not (uni_a or uni_z):
+            return
+
+        if (not (uni_a and not uni_a.user_tag) and
+                not (uni_z and not uni_z.user_tag)):
+            return
+        for circuit in self.circuits.values():
+            if (not circuit.archived and circuit._id != evc_dict["id"]):
+                if uni_a and uni_a.user_tag is None:
+                    circuit.check_no_tag_duplicate(uni_a)
+                if uni_z and uni_z.user_tag is None:
+                    circuit.check_no_tag_duplicate(uni_z)
 
     @listen_to("kytos/topology.link_up")
     def on_link_up(self, event):

--- a/main.py
+++ b/main.py
@@ -286,7 +286,7 @@ class Main(KytosNApp):
         try:
             self._check_no_tag_duplication(evc.id, evc.uni_a, evc.uni_z)
         except DuplicatedNoTagUNI as exception:
-            log.debug("update result %s %s", exception, 409)
+            log.debug("create_circuit result %s %s", exception, 409)
             raise HTTPException(409, detail=str(exception)) from exception
 
         try:

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ import pathlib
 import time
 import traceback
 from threading import Lock
+from typing import Optional
 
 from pydantic import ValidationError
 
@@ -21,7 +22,8 @@ from kytos.core.rest_api import (HTTPException, JSONResponse, Request,
                                  get_json_or_400)
 from kytos.core.tag_ranges import get_tag_ranges
 from napps.kytos.mef_eline import controllers, settings
-from napps.kytos.mef_eline.exceptions import DisabledSwitch, InvalidPath, DuplicatedNoTagUNI
+from napps.kytos.mef_eline.exceptions import (DisabledSwitch,
+                                              DuplicatedNoTagUNI, InvalidPath)
 from napps.kytos.mef_eline.models import (EVC, DynamicPathManager, EVCDeploy,
                                           Path)
 from napps.kytos.mef_eline.scheduler import CircuitSchedule, Scheduler
@@ -282,8 +284,7 @@ class Main(KytosNApp):
             raise HTTPException(400, detail=str(exception)) from exception
 
         try:
-            evc_data = {"id": evc.id, "uni_a": evc.uni_a, "uni_z": evc.uni_z}
-            self._check_no_tag_duplication(evc_data)
+            self._check_no_tag_duplication(evc.id, evc.uni_a, evc.uni_z)
         except DuplicatedNoTagUNI as exception:
             log.debug("create_circuit result %s %s", exception, 400)
             raise HTTPException(400, detail=str(exception)) from exception
@@ -367,12 +368,15 @@ class Main(KytosNApp):
 
         try:
             updated_data = self._evc_dict_with_instances(data)
-            self._check_no_tag_duplication(dict(updated_data, id=circuit_id))
+            self._check_no_tag_duplication(
+                circuit_id, updated_data.get("uni_a"),
+                updated_data.get("uni_z")
+            )
             enable, redeploy = evc.update(**updated_data)
         except (
-                ValueError, KytosTagError,
-                ValidationError, DuplicatedNoTagUNI
-            ) as exception:
+            ValueError, KytosTagError,
+            ValidationError, DuplicatedNoTagUNI
+        ) as exception:
             log.debug("update result %s %s", exception, 400)
             raise HTTPException(400, detail=str(exception)) from exception
         except DisabledSwitch as exception:
@@ -710,13 +714,17 @@ class Main(KytosNApp):
         log.debug("delete_schedule result %s %s", result, status)
         return JSONResponse(result, status_code=status)
 
-    def _check_no_tag_duplication(self, evc_dict: dict):
+    def _check_no_tag_duplication(
+        self,
+        evc_id: str,
+        uni_a: Optional[UNI] = None,
+        uni_z: Optional[UNI] = None
+    ):
         """Check if the given EVC has UNIs with no tag and if these are
          duplicated. Raise DuplicatedNoTagUNI if duplication is found.
         Args:
             evc (dict): EVC to be analyzed.
         """
-        uni_a, uni_z = evc_dict.get("uni_a"), evc_dict.get("uni_z")
 
         # No UNIs
         if not (uni_a or uni_z):
@@ -726,7 +734,7 @@ class Main(KytosNApp):
                 not (uni_z and not uni_z.user_tag)):
             return
         for circuit in self.circuits.values():
-            if (not circuit.archived and circuit._id != evc_dict["id"]):
+            if (not circuit.archived and circuit._id != evc_id):
                 if uni_a and uni_a.user_tag is None:
                     circuit.check_no_tag_duplicate(uni_a)
                 if uni_z and uni_z.user_tag is None:

--- a/models/evc.py
+++ b/models/evc.py
@@ -20,7 +20,7 @@ from kytos.core.interface import UNI, Interface, TAGRange
 from kytos.core.link import Link
 from kytos.core.tag_ranges import range_difference
 from napps.kytos.mef_eline import controllers, settings
-from napps.kytos.mef_eline.exceptions import FlowModException, InvalidPath
+from napps.kytos.mef_eline.exceptions import FlowModException, InvalidPath, DuplicatedNoTagUNI
 from napps.kytos.mef_eline.utils import (check_disabled_component,
                                          compare_endpoint_trace,
                                          compare_uni_out_trace, emit_event,
@@ -353,14 +353,12 @@ class EVCBase(GenericEntity):
         """Check if the UNIs are in the same switch."""
         return self.uni_a.interface.switch == self.uni_z.interface.switch
 
-    def shares_uni(self, other):
-        """Check if two EVCs share an UNI."""
-        if other.uni_a in (self.uni_a, self.uni_z) or other.uni_z in (
-            self.uni_a,
-            self.uni_z,
-        ):
-            return True
-        return False
+    def check_no_tag_duplicate(self, other_uni: UNI):
+        """Check if a no tag UNI is duplicated."""
+        if other_uni in (self.uni_a, self.uni_z):
+            msg = f"UNI with interface {other_uni.interface.id} is"\
+                  f" duplicated with EVC {self.id}."
+            raise DuplicatedNoTagUNI(msg)
 
     def as_dict(self, keys: set = None):
         """Return a dictionary representing an EVC object.

--- a/models/evc.py
+++ b/models/evc.py
@@ -20,7 +20,8 @@ from kytos.core.interface import UNI, Interface, TAGRange
 from kytos.core.link import Link
 from kytos.core.tag_ranges import range_difference
 from napps.kytos.mef_eline import controllers, settings
-from napps.kytos.mef_eline.exceptions import FlowModException, InvalidPath, DuplicatedNoTagUNI
+from napps.kytos.mef_eline.exceptions import (DuplicatedNoTagUNI,
+                                              FlowModException, InvalidPath)
 from napps.kytos.mef_eline.utils import (check_disabled_component,
                                          compare_endpoint_trace,
                                          compare_uni_out_trace, emit_event,

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -405,6 +405,7 @@ class TestMain:
         expected_result = "circuit_id 3 not found"
         assert response.json()["description"] == expected_result
 
+    @patch("napps.kytos.mef_eline.main.Main._check_no_tag_duplication")
     @patch("napps.kytos.mef_eline.models.evc.EVC._tag_lists_equal")
     @patch("napps.kytos.mef_eline.main.Main._use_uni_tags")
     @patch("napps.kytos.mef_eline.models.evc.EVC.deploy")
@@ -423,6 +424,7 @@ class TestMain:
         evc_deploy_mock,
         mock_use_uni_tags,
         mock_tags_equal,
+        mock_check_duplicate,
         event_loop
     ):
         """Test create a new circuit."""
@@ -433,6 +435,7 @@ class TestMain:
         evc_deploy_mock.return_value = True
         mock_use_uni_tags.return_value = True
         mock_tags_equal.return_value = True
+        mock_check_duplicate.return_value = True
         uni1 = create_autospec(UNI)
         uni2 = create_autospec(UNI)
         uni1.interface = create_autospec(Interface)
@@ -624,6 +627,7 @@ class TestMain:
         assert response.status_code == 400
         assert expected_data in current_data["description"]
 
+    @patch("napps.kytos.mef_eline.main.Main._check_no_tag_duplication")
     @patch("napps.kytos.mef_eline.models.evc.EVC._tag_lists_equal")
     @patch("napps.kytos.mef_eline.main.Main._use_uni_tags")
     @patch("napps.kytos.mef_eline.models.evc.EVC.deploy")
@@ -642,6 +646,7 @@ class TestMain:
         evc_deploy_mock,
         mock_use_uni_tags,
         mock_tags_equal,
+        mock_check_duplicate,
         event_loop
     ):
         """Test create an already created circuit."""
@@ -652,6 +657,7 @@ class TestMain:
         sched_add_mock.return_value = True
         evc_deploy_mock.return_value = True
         mock_tags_equal.return_value = True
+        mock_check_duplicate.return_value = True
         mock_use_uni_tags.side_effect = [
             None, KytosTagError("The EVC already exists.")
         ]
@@ -1553,6 +1559,7 @@ class TestMain:
         assert 409 == response.status_code
         assert "Can't update archived EVC" in response.json()["description"]
 
+    @patch("napps.kytos.mef_eline.main.Main._check_no_tag_duplication")
     @patch("napps.kytos.mef_eline.models.evc.EVC._tag_lists_equal")
     @patch("napps.kytos.mef_eline.main.Main._use_uni_tags")
     @patch("napps.kytos.mef_eline.models.evc.EVC.deploy")
@@ -1571,6 +1578,7 @@ class TestMain:
         evc_deploy_mock,
         mock_use_uni_tags,
         mock_tags_equal,
+        mock_check_duplicate,
         event_loop
     ):
         """Test update a circuit circuit."""
@@ -1581,6 +1589,7 @@ class TestMain:
         evc_deploy_mock.return_value = True
         mock_use_uni_tags.return_value = True
         mock_tags_equal.return_value = True
+        mock_check_duplicate.return_value = True
         uni1 = create_autospec(UNI)
         uni2 = create_autospec(UNI)
         uni1.interface = create_autospec(Interface)
@@ -1624,6 +1633,7 @@ class TestMain:
         assert 400 == response.status_code
         assert "must have a primary path or" in current_data["description"]
 
+    @patch("napps.kytos.mef_eline.main.Main._check_no_tag_duplication")
     @patch("napps.kytos.mef_eline.models.evc.EVC._tag_lists_equal")
     @patch("napps.kytos.mef_eline.main.Main._use_uni_tags")
     @patch("napps.kytos.mef_eline.models.evc.EVC.deploy")
@@ -1646,6 +1656,7 @@ class TestMain:
         evc_deploy_mock,
         mock_use_uni_tags,
         mock_tags_equal,
+        mock_check_duplicate,
         event_loop
     ):
         """Test update a circuit circuit."""
@@ -1658,6 +1669,7 @@ class TestMain:
         mock_use_uni_tags.return_value = True
         link_from_dict_mock.return_value = 1
         mock_tags_equal.return_value = True
+        mock_check_duplicate.return_value = True
         uni1 = create_autospec(UNI)
         uni2 = create_autospec(UNI)
         uni1.interface = create_autospec(Interface)
@@ -1799,6 +1811,7 @@ class TestMain:
         with pytest.raises(ValueError):
             self.napp._uni_from_dict(uni_dict)
 
+    @patch("napps.kytos.mef_eline.main.Main._check_no_tag_duplication")
     @patch("napps.kytos.mef_eline.models.evc.EVC._tag_lists_equal")
     @patch("napps.kytos.mef_eline.main.Main._use_uni_tags")
     @patch("napps.kytos.mef_eline.models.evc.EVC.deploy")
@@ -1815,6 +1828,7 @@ class TestMain:
         evc_deploy_mock,
         mock_use_uni_tags,
         mock_tags_equal,
+        mock_check_duplicate,
         event_loop
     ):
         """Test update a circuit with wrong mimetype."""
@@ -1824,6 +1838,7 @@ class TestMain:
         evc_deploy_mock.return_value = True
         mock_use_uni_tags.return_value = True
         mock_tags_equal.return_value = True
+        mock_check_duplicate.return_value = True
         uni1 = create_autospec(UNI)
         uni2 = create_autospec(UNI)
         uni1.interface = create_autospec(Interface)
@@ -1872,6 +1887,7 @@ class TestMain:
         assert current_data["description"] == expected_data
         assert 404 == response.status_code
 
+    @patch("napps.kytos.mef_eline.main.Main._check_no_tag_duplication")
     @patch("napps.kytos.mef_eline.models.evc.EVC._tag_lists_equal")
     @patch("napps.kytos.mef_eline.models.evc.EVC.remove_uni_tags")
     @patch("napps.kytos.mef_eline.main.Main._use_uni_tags")
@@ -1894,6 +1910,7 @@ class TestMain:
         mock_remove_tags,
         mock_use_uni,
         mock_tags_equal,
+        mock_check_duplicate,
         event_loop
     ):
         """Try to delete an archived EVC"""
@@ -1905,6 +1922,7 @@ class TestMain:
         remove_current_flows_mock.return_value = True
         mock_use_uni.return_value = True
         mock_tags_equal.return_value = True
+        mock_check_duplicate.return_value = True
         uni1 = create_autospec(UNI)
         uni2 = create_autospec(UNI)
         uni1.interface = create_autospec(Interface)
@@ -2513,3 +2531,27 @@ class TestMain:
             self.napp._use_uni_tags(evc_mock)
         assert evc_mock._use_uni_vlan.call_count == 5
         assert evc_mock.make_uni_vlan_available.call_count == 1
+
+    def test_check_no_tag_duplication(self):
+        """Test _check_no_tag_duplication"""
+        evc = MagicMock()
+        evc.check_no_tag_duplicate = MagicMock()
+        evc.archived = False
+        evc.id = "1"
+        self.napp.circuits = {"1": evc}
+        evc_id = "2"
+        uni_a = get_uni_mocked(valid=True)
+        uni_z = get_uni_mocked(valid=True)
+        self.napp._check_no_tag_duplication(evc_id, uni_a, uni_z)
+        assert evc.check_no_tag_duplicate.call_count == 0
+
+        uni_a.user_tag = None
+        uni_z.user_tag = None
+        self.napp._check_no_tag_duplication(evc_id, uni_a, uni_z)
+        assert evc.check_no_tag_duplicate.call_count == 2
+
+        self.napp._check_no_tag_duplication(evc_id, uni_a, None)
+        assert evc.check_no_tag_duplicate.call_count == 3
+
+        self.napp._check_no_tag_duplication(evc_id, None, None)
+        assert evc.check_no_tag_duplicate.call_count == 3


### PR DESCRIPTION
Closes #410 

### Summary

Added `_check_no_tag_duplication()` to check for no tag UNIs when necessary
Added `check_no_tag_duplicate()` to check for no tag UNIs with current EVC

### Local Test
Update and create circuits with duplications

### End-To-End Tests
```
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.3.0
rootdir: /tests
plugins: timeout-2.1.0, rerunfailures-10.2, anyio-3.6.2
collected 244 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 24%]
tests/test_e2e_11_mef_eline.py ......                                    [ 27%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 30%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X.....F..... [ 47%]
.                                                                        [ 47%]
tests/test_e2e_14_mef_eline.py x                                         [ 47%]
tests/test_e2e_15_mef_eline.py ....                                      [ 49%]
tests/test_e2e_20_flow_manager.py .....................                  [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 65%]
tests/test_e2e_23_flow_manager.py ..............                         [ 71%]
tests/test_e2e_30_of_lldp.py ....                                        [ 72%]
tests/test_e2e_31_of_lldp.py ...                                         [ 74%]
tests/test_e2e_32_of_lldp.py ...                                         [ 75%]
tests/test_e2e_40_sdntrace.py .............                              [ 80%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 84%]
tests/test_e2e_42_sdntrace.py ..                                         [ 84%]
tests/test_e2e_50_maintenance.py ........................                [ 94%]
tests/test_e2e_60_of_multi_table.py .....                                [ 96%]
tests/test_e2e_70_kytos_stats.py ........                                [100%]
```
Failed on `test_190_post_an_evc_twice()`` because of status_code `400 != 409`. Fixed on [5ada5af92151d37b4de651026dc9974b3b1d3cd0](https://github.com/kytos-ng/mef_eline/pull/411/commits/5ada5af92151d37b4de651026dc9974b3b1d3cd0)
```
+ python3 -m pytest tests/ -k test_190_post_an_evc_twice --reruns 0 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.3.0
rootdir: /tests
plugins: timeout-2.1.0, rerunfailures-10.2, anyio-3.6.2
collected 244 items / 243 deselected / 1 selected

tests/test_e2e_13_mef_eline.py .                                         [100%]
```