### PR TITLE
fix: sdntrace_cp check_trace `current_path` comparison with the expected UNI order

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,7 +35,8 @@ General Information
 
 Fixed
 =====
-- fixed race condition in ``failover_path`` when handling simulataneous Link Down events leading to inconsistencies on some EVC
+- fixed race condition in ``failover_path`` when handling simultaneous Link Down events leading to inconsistencies on some EVC
+- fixed sdntrace_cp check_trace ``current_path`` comparison with the expected UNI order
 
 [2023.1.0] - 2023-06-27
 ***********************

--- a/models/evc.py
+++ b/models/evc.py
@@ -1398,9 +1398,29 @@ class EVCDeploy(EVCBase):
             log.warning(f"Invalid trace from uni_z: {trace_z}")
             return False
 
+        if not current_path:
+            return True
+
+        first_link, trace_path_begin, trace_path_end = current_path[0], [], []
+        if (
+            first_link.endpoint_a.switch.id == trace_a[0]["dpid"]
+        ):
+            trace_path_begin, trace_path_end = trace_a, trace_z
+        elif (
+            first_link.endpoint_a.switch.id == trace_z[0]["dpid"]
+        ):
+            trace_path_begin, trace_path_end = trace_z, trace_a
+        else:
+            msg = (
+                f"first link {first_link} endpoint_a didn't match the first "
+                f"step of trace_a {trace_a} or trace_z {trace_z}"
+            )
+            log.warning(msg)
+            return False
+
         for link, trace1, trace2 in zip(current_path,
-                                        trace_a[1:],
-                                        trace_z[:0:-1]):
+                                        trace_path_begin[1:],
+                                        trace_path_end[:0:-1]):
             metadata_vlan = None
             if link.metadata:
                 metadata_vlan = glom(link.metadata, 's_vlan.value')


### PR DESCRIPTION
Closes https://github.com/kytos-ng/sdntrace_cp/issues/109

### Summary

See updated changelog file

### Local Tests

Created two EVPLs with 'uni_a' and 'uni_z', "inter_evpl" had 'uni_a' and 'uni_z' inverted compared to the expected current_path as @italovalcy has caught on the original issue, then I reran all the checks and they succeeded:

```
❯ curl -H 'Content-type: application/json' -X POST http://127.0.0.1:8181/api/kytos/mef_eline/v2/evc/ -d '{"name": "inter_evpl", "dynamic_backup_path": true, "uni_z": {"interface_id": "00:00:00:00:00:00:00:01:1", "tag": {"tag_type": 1, "value": 2222}}, "uni_a": { "interface_id": "00:00:00:00:00:00:00:03:1", "tag": {"tag_type": 1, "value": 2222}}}'
{"circuit_id":"fc98ecc9f0194a"}

❯ curl -H 'Content-type: application/json' -X POST http://127.0.0.1:8181/api/kytos/mef_eline/v2/evc/ -d '{"name": "inter_evpl_2", "dynamic_backup_path": true, "uni_a": {"interface_id": "00:00:00:00:00:00:00:01:1", "tag": {"tag_type": 1, "value": 2221}}, "uni_z": { "interface_id": "00:00:00:00:00:00:00:03:1", "tag": {"tag_type": 1, "value": 2221}}}'
{"circuit_id":"db720b6469ad41"}
```

```
kytos $> from napps.kytos.mef_eline.models import EVCDeploy                                                                                                                              

kytos $> d = EVCDeploy.check_list_traces(controller.napps[('kytos','mef_eline')].circuits.values())                                                                                     
2023-12-01 09:43:44,951 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:54098 - "GET /api/kytos/flow_manager/v2/stored_flows/?state=installed HTTP/1.1" 200
2023-12-01 09:43:44,953 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:54096 - "PUT /api/amlight/sdntrace_cp/v1/traces HTTP/1.1" 200

kytos $> d                                                                                                                                                                               
Out[3]: {'fc98ecc9f0194a': True, 'db720b6469ad41': True}
```

### End-to-End Tests

I've dispatched an e2e exec with this branch, I'll post the results here later. 