### PR TITLE
Improved log for invalid trace

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,8 @@ Changed
 - UNI tag_type is changed to string from 1, 2 and 3 values to ``"vlan"``, ``"vlan_qinq"`` and ``"mpls"`` respectively.
 - Add ``set_vlan`` only if UNI A vlan and UNI z vlan are different.
 - Updated ``openapi.yml``, ``Tag`` now can accept ``array`` as ``value``.
-- Updated UI interface to support list of ranges of VLANs
+- Updated UI interface to support list of ranges of VLANs.
+- Improved log for invalid traces by adding ``From EVC(evc_id) named 'evc_name'``
 
 Deprecated
 ==========

--- a/models/evc.py
+++ b/models/evc.py
@@ -1375,6 +1375,8 @@ class EVCDeploy(EVCBase):
     # pylint: disable=too-many-return-statements, too-many-arguments
     @staticmethod
     def check_trace(
+        evc_id: str,
+        evc_name: str,
         tag_a: Union[None, int, str],
         tag_z: Union[None, int, str],
         interface_a: Interface,
@@ -1388,13 +1390,15 @@ class EVCDeploy(EVCBase):
             len(trace_a) != len(current_path) + 1
             or not compare_uni_out_trace(tag_z, interface_z, trace_a[-1])
         ):
-            log.warning(f"Invalid trace from uni_a: {trace_a}")
+            log.warning(f"From EVC({evc_id}) named '{evc_name}'. "
+                        f"Invalid trace from uni_a: {trace_a}")
             return False
         if (
             len(trace_z) != len(current_path) + 1
             or not compare_uni_out_trace(tag_a, interface_a, trace_z[-1])
         ):
-            log.warning(f"Invalid trace from uni_z: {trace_z}")
+            log.warning(f"From EVC({evc_id}) named '{evc_name}'. "
+                        f"Invalid trace from uni_z: {trace_z}")
             return False
 
         for link, trace1, trace2 in zip(current_path,
@@ -1408,14 +1412,16 @@ class EVCDeploy(EVCBase):
                                         metadata_vlan,
                                         trace2
                                     ) is False:
-                log.warning(f"Invalid trace from uni_a: {trace_a}")
+                log.warning(f"From EVC({evc_id}) named '{evc_name}'. "
+                            f"Invalid trace from uni_a: {trace_a}")
                 return False
             if compare_endpoint_trace(
                                         link.endpoint_b,
                                         metadata_vlan,
                                         trace1
                                     ) is False:
-                log.warning(f"Invalid trace from uni_z: {trace_z}")
+                log.warning(f"From EVC({evc_id}) named '{evc_name}'. "
+                            f"Invalid trace from uni_z: {trace_z}")
                 return False
 
         return True
@@ -1428,6 +1434,7 @@ class EVCDeploy(EVCBase):
             trace_a = traces[i*2]
             trace_z = traces[i*2+1]
             check &= EVCDeploy.check_trace(
+                circuit.id, circuit.name,
                 mask, mask,
                 circuit.uni_a.interface,
                 circuit.uni_z.interface,
@@ -1467,8 +1474,8 @@ class EVCDeploy(EVCBase):
                     if circuit.uni_z.user_tag:
                         tag_z = circuit.uni_z.user_tag.value
                     circuits_checked[circuit.id] = EVCDeploy.check_trace(
-                        tag_a,
-                        tag_z,
+                        circuit.id, circuit.name,
+                        tag_a, tag_z,
                         circuit.uni_a.interface,
                         circuit.uni_z.interface,
                         circuit.current_path,

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -2082,6 +2082,7 @@ class TestEVC():
         call_list = []
         for i in range(0, 3):
             call_list.append(call(
+                circuit.id, circuit.name,
                 mask_list[i], mask_list[i],
                 uni_a.interface,
                 uni_z.interface,


### PR DESCRIPTION
Closes #366

### Summary

Enhanced log by adding EVC ID and name to the log
`
2023-12-05 10:58:33,582 - WARNING [kytos.napps.kytos/mef_eline] (mef_eline) From EVC(4781ad8f491444) named 'EVC_2'. Invalid trace from uni_a: [{'dpid': '00:00:00:00:00:00:00:01', 'port': 1, 'time': '2023-12-05 10:58:33.578736', 'type': 'starting', 'vlan': 100}, {'dpid': '00:00:00:00:00:00:00:02', 'port': 2, 'time': '2023-12-05 10:58:33.578789', 'type': 'last', 'vlan': 1, 'out': {'port': 1, 'vlan': 100}}]
`

### Local test
Update uni test
Forcing invalid trace and consistency check