### PR TITLE
fix: required at least one circuit_id on `POST v2/evc/metadata`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,7 @@ General Information
 Fixed
 =====
 - fixed race condition in ``failover_path`` when handling simulataneous Link Down events leading to inconsistencies on some EVC
+- Required at least one circuit_id on ``POST v2/evc/metadata``
 
 [2023.1.0] - 2023-06-27
 ***********************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,7 +36,6 @@ General Information
 
 Fixed
 =====
-- fixed race condition in ``failover_path`` when handling simulataneous Link Down events leading to inconsistencies on some EVC
 - required at least one circuit_id on ``POST v2/evc/metadata``
 - fixed race condition in ``failover_path`` when handling simultaneous Link Down events leading to inconsistencies on some EVC
 - fixed sdntrace_cp check_trace ``current_path`` comparison with the expected UNI order

--- a/openapi.yml
+++ b/openapi.yml
@@ -309,6 +309,7 @@ paths:
               properties:
                 circuit_ids:
                   type: array
+                  minItems: 1
                   items:
                     type: string
             

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2423,6 +2423,24 @@ class TestMain:
         assert calls == 1
         evc_mock.extend_metadata.assert_called_with(payload)
 
+    async def test_add_bulk_metadata_empty_list(self, event_loop):
+        """Test add_bulk_metadata method empty list"""
+        self.napp.controller.loop = event_loop
+        evc_mock = create_autospec(EVC)
+        evc_mock.id = 1234
+        self.napp.circuits = {"1234": evc_mock}
+        payload = {
+            "circuit_ids": [],
+            "metadata1": 1,
+            "metadata2": 2
+        }
+        response = await self.api_client.post(
+            f"{self.base_endpoint}/v2/evc/metadata",
+            json=payload
+        )
+        assert response.status_code == 400
+        assert "invalid" in response.json()["description"]
+
     async def test_add_bulk_metadata_no_id(self, event_loop):
         """Test add_bulk_metadata with unknown evc id"""
         self.napp.controller.loop = event_loop


### PR DESCRIPTION
Closes #368 

I went ahead and ended up fixing this since for `telemetry_int` it was getting in the way sometimes.

### Summary

See updated changelog file

### Local Tests

```
❯  echo '{ "some_key": "some_value", "circuit_ids": [] }' | http POST http://127.0.0.1:8181/api/kytos/mef_eline/v2/evc/metadata
HTTP/1.1 400 Bad Request
content-length: 111
content-type: application/json
date: Tue, 05 Dec 2023 18:03:27 GMT
server: uvicorn

{
    "code": 400,
    "description": "The request body contains invalid API data. [] is too short for field circuit_ids."
}



❯  echo '{ "some_key": "some_value", "circuit_ids": [1] }' | http POST http://127.0.0.1:8181/api/kytos/mef_eline/v2/evc/metadata
HTTP/1.1 400 Bad Request
content-length: 123
content-type: application/json
date: Tue, 05 Dec 2023 18:03:39 GMT
server: uvicorn

{
    "code": 400,
    "description": "The request body contains invalid API data. 1 is not of type 'string' for field circuit_ids/0."
}



❯  echo '{ "some_key": "some_value", "circuit_ids": ["1"] }' | http POST http://127.0.0.1:8181/api/kytos/mef_eline/v2/evc/metadata
HTTP/1.1 404 Not Found
content-length: 32
content-type: application/json
date: Tue, 05 Dec 2023 18:03:46 GMT
server: uvicorn

{
    "code": 404,
    "description": [
        "1"
    ]
}

```

### End-to-End Tests

I'll dispatch an exec with this branch