### PR TITLE
Redploying when updating an enabled EVC

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Changed
 - Add ``set_vlan`` only if UNI A vlan and UNI z vlan are different.
 - Updated ``openapi.yml``, ``Tag`` now can accept ``array`` as ``value``.
 - Updated UI interface to support list of ranges of VLANs
+- An inactive and enabled EVC will be redeploy if an attribute from ``attributes_requiring_redeploy`` is updated.
 
 Deprecated
 ==========

--- a/main.py
+++ b/main.py
@@ -400,7 +400,7 @@ class Main(KytosNApp):
                     evc.deploy()
             elif evc.is_enabled() and redeploy:
                 with evc.lock:
-                    evc.remove_current_flows()
+                    evc.remove()
                     evc.deploy()
         result = {evc.id: evc.as_dict()}
         status = 200

--- a/main.py
+++ b/main.py
@@ -398,6 +398,10 @@ class Main(KytosNApp):
             if enable is True:  # enable if inactive
                 with evc.lock:
                     evc.deploy()
+            elif evc.is_enabled() and redeploy:
+                with evc.lock:
+                    evc.remove_current_flows()
+                    evc.deploy()
         result = {evc.id: evc.as_dict()}
         status = 200
 

--- a/models/evc.py
+++ b/models/evc.py
@@ -647,8 +647,8 @@ class EVCDeploy(EVCBase):
 
     def remove(self):
         """Remove EVC path and disable it."""
-        self.remove_current_flows()
-        self.remove_failover_flows()
+        self.remove_current_flows(sync=False)
+        self.remove_failover_flows(sync=False)
         self.disable()
         self.sync()
         emit_event(self._controller, "undeployed",
@@ -702,7 +702,8 @@ class EVCDeploy(EVCBase):
         if sync:
             self.sync()
 
-    def remove_current_flows(self, current_path=None, force=True):
+    def remove_current_flows(self, current_path=None, force=True,
+                             sync=True):
         """Remove all flows from current path."""
         switches = set()
 
@@ -733,7 +734,8 @@ class EVCDeploy(EVCBase):
             log.error(f"Error when removing current path flows: {err}")
         self.current_path = Path([])
         self.deactivate()
-        self.sync()
+        if sync:
+            self.sync()
 
     def remove_path_flows(self, path=None, force=True):
         """Remove all flows from path."""
@@ -1610,8 +1612,8 @@ class LinkProtection(EVCDeploy):
         if success:
             log.debug(f"{self} deployed after link down.")
         else:
+            self.remove_current_flows(sync=False)
             self.deactivate()
-            self.current_path = Path([])
             self.sync()
             log.debug(f"Failed to re-deploy {self} after link down.")
 

--- a/tests/unit/models/test_link_protection.py
+++ b/tests/unit/models/test_link_protection.py
@@ -297,6 +297,7 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
         msg = f"{evc} deployed after link down."
         log_mocked.debug.assert_called_once_with(msg)
 
+    @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.remove_current_flows")
     @patch("napps.kytos.mef_eline.controllers.ELineController.upsert_evc")
     @patch("napps.kytos.mef_eline.models.evc.log")
     @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.deploy")
@@ -304,10 +305,12 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
     @patch("napps.kytos.mef_eline.models.path.DynamicPathManager.get_paths")
     @patch("napps.kytos.mef_eline.models.path.Path.status", EntityStatus.DOWN)
     async def test_handle_link_down_case_3(
-        self, get_paths_mocked, deploy_to_mocked, deploy_mocked, log_mocked, _
+        self, get_paths_mocked, deploy_to_mocked, deploy_mocked,
+        log_mocked, _, mock_remove_current
     ):
         """Test if circuit without dynamic path is return failed."""
         deploy_mocked.return_value = False
+        mock_remove_current.return_value = True
         deploy_to_mocked.return_value = False
         primary_path = [
             get_link_mocked(

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1470,26 +1470,7 @@ class TestMain:
                 "enable": True
             },
             {
-                "name": "my evc1",
-                "active": True,
-                "enable": True,
-                "uni_a": {
-                    "interface_id": "00:00:00:00:00:00:00:01:1",
-                    "tag": {
-                        "tag_type": 'vlan',
-                        "value": 80
-                    }
-                },
-                "uni_z": {
-                    "interface_id": "00:00:00:00:00:00:00:02:2",
-                    "tag": {
-                        "tag_type": 'vlan',
-                        "value": 1
-                    }
-                },
-                "priority": 3,
-                "bandwidth": 1000,
-                "dynamic_backup_path": True
+                "sb_priority": 100
             }
         ]
 
@@ -1546,6 +1527,15 @@ class TestMain:
         expected_data = "circuit_id 1234 not found"
         assert current_data["description"] == expected_data
         assert 404 == response.status_code
+
+        self.napp.circuits[circuit_id]._active = False
+        evc_deploy.reset_mock()
+        response = await self.api_client.patch(
+            f"{self.base_endpoint}/v2/evc/{circuit_id}",
+            json=payloads[4]
+        )
+        assert 200 == response.status_code
+        evc_deploy.assert_called_once()
 
         await self.api_client.delete(
             f"{self.base_endpoint}/v2/evc/{circuit_id}"


### PR DESCRIPTION
Closes #398 
Closes #416 

### Summary

Added if statement when an EVC is inactive, enabled and needs to be redeployed

### Local Test
Performed the test from the issue

### End-To-End Tests
```
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.3.0
rootdir: /tests
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 254 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  7%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 45%]
.                                                                        [ 45%]
tests/test_e2e_14_mef_eline.py x                                         [ 46%]
tests/test_e2e_15_mef_eline.py .....                                     [ 48%]
tests/test_e2e_20_flow_manager.py .....................                  [ 56%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 63%]
tests/test_e2e_23_flow_manager.py ..............                         [ 68%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ...                                         [ 71%]
tests/test_e2e_32_of_lldp.py ...                                         [ 72%]
tests/test_e2e_40_sdntrace.py ..............                             [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
tests/test_e2e_50_maintenance.py ........................                [ 91%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
```
Because it stopped there:
```
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.3.0
rootdir: /tests
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 16 items

tests/test_e2e_70_kytos_stats.py ........                                [ 50%]
tests/test_e2e_80_pathfinder.py ........                                 [100%]
```
