### PR TITLE
fixed: fixed `DynamicPathManager.get_paths` return value when pathfinder returns a request error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,7 @@ Fixed
 - required at least one circuit_id on ``POST v2/evc/metadata``
 - fixed race condition in ``failover_path`` when handling simultaneous Link Down events leading to inconsistencies on some EVC
 - fixed sdntrace_cp check_trace ``current_path`` comparison with the expected UNI order
+- fixed ``DynamicPathManager.get_paths`` return value when ``pathfinder`` returns a request error
 
 [2023.1.0] - 2023-06-27
 ***********************

--- a/models/path.py
+++ b/models/path.py
@@ -134,7 +134,7 @@ class DynamicPathManager:
         cls.controller = controller
 
     @staticmethod
-    def get_paths(circuit, max_paths=2, **kwargs):
+    def get_paths(circuit, max_paths=2, **kwargs) -> list[dict]:
         """Get a valid path for the circuit from the Pathfinder."""
         endpoint = settings.PATHFINDER_URL
         spf_attribute = kwargs.get("spf_attribute") or settings.SPF_ATTRIBUTE
@@ -149,13 +149,15 @@ class DynamicPathManager:
 
         if api_reply.status_code != getattr(requests.codes, "ok"):
             log.error(
-                "Failed to get paths at %s. Returned %s",
+                "Failed to get paths at %s. Returned %s. Payload %s. EVC %s",
                 endpoint,
                 api_reply.text,
+                request_data,
+                circuit,
             )
-            return None
+            return []
         reply_data = api_reply.json()
-        return reply_data.get("paths")
+        return reply_data.get("paths", [])
 
     @staticmethod
     def _clear_path(path):

--- a/tests/unit/models/test_path.py
+++ b/tests/unit/models/test_path.py
@@ -466,6 +466,28 @@ class TestDynamicPathManager():
         )
         mock_requests_post.assert_has_calls([expected_call])
 
+    @patch("napps.kytos.mef_eline.models.path.log")
+    @patch("requests.post")
+    def test_get_best_paths_error(self, mock_requests_post, mock_log):
+        """Test get_best_paths method."""
+        controller = MagicMock()
+        DynamicPathManager.set_controller(controller)
+        circuit = MagicMock()
+        circuit.id = "id"
+        circuit.uni_a.interface.id = "1"
+        circuit.uni_z.interface.id = "2"
+        circuit.name = "some_name"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.json.return_value = {}
+        mock_requests_post.return_value = mock_response
+
+        res_paths = list(DynamicPathManager.get_best_paths(circuit))
+        assert not res_paths
+        assert isinstance(res_paths, list)
+        assert mock_log.error.call_count == 1
+
     @patch("requests.post")
     def test_get_disjoint_paths(self, mock_requests_post):
         """Test get_disjoint_paths method."""


### PR DESCRIPTION
Closes #417 (I went ahead fixed it, since I had the scenario already available)

### Summary

See updated changelog file

### Local Tests

Same as the one reported in the issue, now it no longer crashes:

```
kytos $> 2023-12-13 11:13:42,914 - INFO [kytos.napps.kytos/flow_manager] [utils.py:196:flows_to_log_info] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:03, 
command: delete, force: True,  flows[0, 1]: [{'cookie': 12254910601279224650, 'cookie_mask': 18446744073709551615}]
2023-12-13 11:13:42,916 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:59562 - "POST /api/kytos/flow_manager/v2/delete/00%3A00%3A00%3A00%3A00%3A00%3A00%3A03
 HTTP/1.1" 202
2023-12-13 11:13:42,922 - INFO [kytos.napps.kytos/flow_manager] [utils.py:196:flows_to_log_info] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: 
delete, force: True,  flows[0, 1]: [{'cookie': 12254910601279224650, 'cookie_mask': 18446744073709551615}]
2023-12-13 11:13:42,924 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:59566 - "POST /api/kytos/flow_manager/v2/delete/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01
 HTTP/1.1" 202
2023-12-13 11:13:42,932 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:59574 - "POST /api/kytos/pathfinder/v3/ HTTP/1.1" 400
2023-12-13 11:13:42,932 - ERROR [kytos.napps.kytos/mef_eline] [path.py:151:get_paths] (AnyIO worker thread) Failed to get paths at http://localhost:8181/api/kytos/pathfinder/v3/. Return
ed {"description":"argument of type 'int' is not iterable","code":400}. Payload {'source': '00:00:00:00:00:00:00:01:1', 'destination': '00:00:00:00:00:00:00:03:1', 'spf_max_paths': 2, '
spf_attribute': 'hop', 'mandatory_metrics': {'ownership': 'blue'}}. EVC EVC(123043376abb4a, epl)
2023-12-13 11:13:42,933 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:59550 - "POST /api/kytos/mef_eline/v2/evc/ HTTP/1.1" 201
2023-12-13 11:13:42,933 - WARNING [kytos.napps.kytos/mef_eline] [evc.py:859:deploy_to_path] (AnyIO worker thread) EVC(123043376abb4a, epl) was not deployed. No available path was found.
kytos $>                                                                                                                                                                                 

```

### End-to-End Tests

I'll dispatch an e2e exec, I don't expect surprises though:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.3.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 255 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 26%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 45%]
.                                                                        [ 45%]
tests/test_e2e_14_mef_eline.py x                                         [ 46%]
tests/test_e2e_15_mef_eline.py .....                                     [ 48%]
tests/test_e2e_20_flow_manager.py .....................                  [ 56%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 63%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ...                                         [ 71%]
tests/test_e2e_32_of_lldp.py ...                                         [ 72%]
tests/test_e2e_40_sdntrace.py ..............                             [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
tests/test_e2e_50_maintenance.py ........................                [ 91%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py ........                                [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
=============================== warnings summary ===============================
------------------------------- start/stop times -------------------------------
= 231 passed, 8 skipped, 9 xfailed, 7 xpassed, 1109 warnings in 12156.05s (3:22:36) =
```
