### PR TITLE
Add in support for not_ownership for 2023.1.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [Unreleased]
 ************
 
+Added
+=====
+- Added support for ``not_ownership`` to dynamic path constraints.
+
 [2023.1.3] - 2023-11-01
 ***********************
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,9 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [Unreleased]
 ************
 
+[2023.1.4] - 2024-01-16
+***********************
+
 Added
 =====
 - Added support for ``not_ownership`` to dynamic path constraints.

--- a/db/models.py
+++ b/db/models.py
@@ -65,6 +65,7 @@ class LinkConstraints(BaseModel):
     utilization: Optional[float]
     delay: Optional[float]
     priority: Optional[int]
+    not_ownership: Optional[str]
 
 
 class PathConstraints(BaseModel):

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2023.1.3",
+  "version": "2023.1.4",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],


### PR DESCRIPTION
Add in support for not_ownership to the `PathConstraints` model on the db. This is necessary for using `not_ownership` with `mef_eline`.