### PR TITLE
Add in support for not_ownership

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Added
 - EVCs now listen to ``switch.interface.(link_up|link_down|created|deleted)`` events for activation/deactivation
 - Circuits with a vlan range are supported now. The ranges follows ``list[list[int]]`` format and both UNIs vlan should have the same ranges.
 - Usage of special vlans ``"untagged"`` and ``"any"`` now send an event to each Interface.
+- Added support for ``not_ownership`` to dynamic path constraints.
 
 Changed
 =======

--- a/db/models.py
+++ b/db/models.py
@@ -68,6 +68,7 @@ class LinkConstraints(BaseModel):
     utilization: Optional[float]
     delay: Optional[float]
     priority: Optional[int]
+    not_ownership: Optional[str]
 
 
 class PathConstraints(BaseModel):

--- a/db/models.py
+++ b/db/models.py
@@ -68,7 +68,7 @@ class LinkConstraints(BaseModel):
     utilization: Optional[float]
     delay: Optional[float]
     priority: Optional[int]
-    not_ownership: Optional[str]
+    not_ownership: Optional[List[str]]
 
 
 class PathConstraints(BaseModel):

--- a/openapi.yml
+++ b/openapi.yml
@@ -586,6 +586,12 @@ components:
           type: string
           description: The exact user who should have ownership or be authorized to use the link.
           example: "Bill"
+        not_ownership:
+          type: array
+          items:
+            type: string
+          description: The list of users whose links should not be used.
+          example: ["Ted"]
     Circuit: # Can be referenced via '#/components/schemas/Circuit'
       type: object
       properties:

--- a/tests/unit/test_db_models.py
+++ b/tests/unit/test_db_models.py
@@ -2,7 +2,8 @@
 import pytest
 from pydantic import ValidationError
 
-from db.models import EVCBaseDoc, DocumentBaseModel, TAGDoc, EVCUpdateDoc
+from db.models import (DocumentBaseModel, EVCBaseDoc, EVCUpdateDoc,
+                       LinkConstraints, TAGDoc)
 
 
 class TestDBModels():
@@ -118,3 +119,61 @@ class TestDBModels():
         tag_fail = {"tag_type": 'vlan', "value": "test_fail"}
         with pytest.raises(ValueError):
             TAGDoc(**tag_fail)
+
+    @pytest.mark.parametrize(
+        'attribute,acceptable_value',
+        [
+            ('bandwidth', 1.0),
+            ('bandwidth', 1),
+            ('ownership', 'Test A'),
+            ('reliability', 0.9),
+            ('reliability', 1),
+            ('utilization', 30.0),
+            ('utilization', 30),
+            ('delay', 10.0),
+            ('delay', 10),
+            ('priority', 1),
+            ('not_ownership', []),
+            ('not_ownership', ['Test B']),
+            ('not_ownership', ['Test B', 'Test C']),
+        ]
+    )
+    def test_link_metrics(
+        self,
+        attribute,
+        acceptable_value,
+    ):
+        """
+        Test attributes of link constraints across
+        various acceptable values
+        """
+        constraints = {
+            attribute: acceptable_value
+        }
+        LinkConstraints(**constraints)
+
+    @pytest.mark.parametrize(
+        'attribute,unacceptable_value',
+        [
+            ('bandwidth', 'E'),
+            ('reliability', 'D'),
+            ('utilization', 'C'),
+            ('delay', 'B'),
+            ('priority', 'A'),
+            ('not_ownership', 'Yo'),
+        ]
+    )
+    def test_link_unacceptable_metrics(
+        self,
+        attribute,
+        unacceptable_value,
+    ):
+        """
+        Test attributes of link constraints across
+        various unacceptable values
+        """
+        constraints = {
+            attribute: unacceptable_value
+        }
+        with pytest.raises(ValidationError):
+            LinkConstraints(**constraints)


### PR DESCRIPTION
Add in support for not_ownership to the `PathConstraints` model on the db. This is necessary for using `not_ownership` with `mef_eline`.