### PR TITLE
fix: parametrized timeout=1 when publishing KytosEvent during setup

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Changed
 - Updated UI interface to support list of ranges of VLANs.
 - Improved log for invalid traces by adding ``From EVC(evc_id) named 'evc_name'``
 - An inactive and enabled EVC will be redeploy if an attribute from ``attributes_requiring_redeploy`` is updated.
+- If a KytosEvent can't be put on ``buffers.app`` during ``setup()``, it'll make the NApp to fail to start
 
 Deprecated
 ==========

--- a/main.py
+++ b/main.py
@@ -925,7 +925,8 @@ class Main(KytosNApp):
         for circuit_id, circuit in circuits:
             if circuit_id not in self.circuits:
                 self._load_evc(circuit)
-        emit_event(self.controller, "evcs_loaded", content=dict(circuits))
+        emit_event(self.controller, "evcs_loaded", content=dict(circuits),
+                   timeout=1)
 
     def _load_evc(self, circuit_dict):
         """Load one EVC from mongodb to memory."""

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2317,6 +2317,8 @@ class TestMain:
         call_args = self.napp.controller.buffers.app.put.call_args[0]
         assert call_args[0].name == "kytos/mef_eline.evcs_loaded"
         assert dict(call_args[0].content) == mock_circuits["circuits"]
+        timeout_d = {"timeout": 1}
+        assert self.napp.controller.buffers.app.put.call_args[1] == timeout_d
 
     @patch('napps.kytos.mef_eline.main.Main._evc_from_dict')
     def test_load_evc(self, evc_from_dict_mock):

--- a/utils.py
+++ b/utils.py
@@ -18,11 +18,12 @@ def map_evc_event_content(evc, **kwargs):
                      "uni_z": evc.uni_z.as_dict()}
 
 
-def emit_event(controller, name, context="kytos/mef_eline", content=None):
+def emit_event(controller, name, context="kytos/mef_eline", content=None,
+               timeout=None):
     """Send an event when something happens with an EVC."""
     event_name = f"{context}.{name}"
     event = KytosEvent(name=event_name, content=content)
-    controller.buffers.app.put(event)
+    controller.buffers.app.put(event, timeout=timeout)
 
 
 async def aemit_event(controller, name, content):


### PR DESCRIPTION
Closes #402 

Related to https://github.com/kytos-ng/kytos/pull/429

### Summary

See updated changelog file

### Local Tests

- Loaded this NApp and created an EVC 

### End-to-End Tests

- This had already been tested on the linked PR (but I hadn't opened this PR yet)