### PR TITLE
Set timer to reduce load

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Added
 - EVCs now listen to ``switch.interface.(link_up|link_down|created|deleted)`` events for activation/deactivation
 - Circuits with a vlan range are supported now. The ranges follows ``list[list[int]]`` format and both UNIs vlan should have the same ranges.
 - Usage of special vlans ``"untagged"`` and ``"any"`` now send an event to each Interface.
+- Added ``UNI_STATE_CHANGE_DELAY`` which configures the time for ``mef_eline`` to wait on link state flaps and update EVCs with last updated event.
 
 Changed
 =======

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ from pydantic import ValidationError
 from kytos.core import KytosNApp, log, rest
 from kytos.core.events import KytosEvent
 from kytos.core.exceptions import KytosTagError
-from kytos.core.helpers import (alisten_to, listen_to, load_spec,
+from kytos.core.helpers import (alisten_to, listen_to, load_spec, now,
                                 validate_openapi)
 from kytos.core.interface import TAG, UNI, TAGRange
 from kytos.core.link import Link
@@ -64,7 +64,7 @@ class Main(KytosNApp):
         # Every create/update/delete must be synced to mongodb.
         self.circuits = {}
 
-        self.intf_events = defaultdict(dict)
+        self._intf_events = defaultdict(dict)
         self.lock_interfaces = defaultdict(Lock)
         self.table_group = {"epl": 0, "evpl": 0}
         self._lock = Lock()
@@ -767,11 +767,17 @@ class Main(KytosNApp):
     def on_interface_link_change(self, event: KytosEvent):
         """
         Handler for interface link_up and link_down events.
+        """
+        self.handle_on_interface_link_change(event)
+
+    def handle_on_interface_link_change(self, event: KytosEvent):
+        """
+        Handler to sort interface events {link_(up, down), create, deleted}
 
         To avoid multiple database updated (link flap):
         Every interface is identfied and processed in parallel.
         Once an interface event is received a time is started.
-        While time is running self.intf_events will be updated.
+        While time is running self._intf_events will be updated.
         After time has passed last received event will be processed.
         """
         iface = event.content.get("interface")
@@ -779,30 +785,23 @@ class Main(KytosNApp):
             _now = event.timestamp
             # Return out of order events
             if (
-                iface.id in self.intf_events
-                and self.intf_events[iface.id]["event"].timestamp > _now
+                iface.id in self._intf_events
+                and self._intf_events[iface.id]["event"].timestamp > _now
             ):
                 return
-            self.intf_events[iface.id].update({"event": event})
-            if self.intf_events[iface.id].get("time_lock"):
+            self._intf_events[iface.id].update({"event": event})
+            if "last_acquired" in self._intf_events[iface.id]:
                 return
-            self.intf_events[iface.id].update({"time_lock": True})
-        time.sleep(settings.TIME_INTERFACE)
+            self._intf_events[iface.id].update({"last_acquired": now()})
+        time.sleep(settings.UNI_STATE_CHANGE_DELAY)
         with self.lock_interfaces[iface.id]:
-            event = self.intf_events[iface.id]["event"]
-            self.intf_events[iface.id].update({"time_lock": False})
-            self.handle_on_interface_link_change(event)
-
-    def handle_on_interface_link_change(self, event: KytosEvent):
-        """
-        Handler to sort interface events {link_(up, down), create, deleted}
-        """
-        _, _, event_type = event.name.rpartition('.')
-        iface = event.content.get("interface")
-        if event_type in ('link_up', 'created'):
-            self.handle_interface_link_up(iface)
-        elif event_type in ('link_down', 'deleted'):
-            self.handle_interface_link_down(iface)
+            event = self._intf_events[iface.id]["event"]
+            self._intf_events[iface.id].pop('last_acquired', None)
+            _, _, event_type = event.name.rpartition('.')
+            if event_type in ('link_up', 'created'):
+                self.handle_interface_link_up(iface)
+            elif event_type in ('link_down', 'deleted'):
+                self.handle_interface_link_down(iface)
 
     def handle_interface_link_up(self, interface):
         """

--- a/main.py
+++ b/main.py
@@ -65,7 +65,7 @@ class Main(KytosNApp):
         self.circuits = {}
 
         self._intf_events = defaultdict(dict)
-        self.lock_interfaces = defaultdict(Lock)
+        self._lock_interfaces = defaultdict(Lock)
         self.table_group = {"epl": 0, "evpl": 0}
         self._lock = Lock()
         self.execute_as_loop(settings.DEPLOY_EVCS_INTERVAL)
@@ -781,7 +781,7 @@ class Main(KytosNApp):
         After time has passed last received event will be processed.
         """
         iface = event.content.get("interface")
-        with self.lock_interfaces[iface.id]:
+        with self._lock_interfaces[iface.id]:
             _now = event.timestamp
             # Return out of order events
             if (
@@ -794,7 +794,7 @@ class Main(KytosNApp):
                 return
             self._intf_events[iface.id].update({"last_acquired": now()})
         time.sleep(settings.UNI_STATE_CHANGE_DELAY)
-        with self.lock_interfaces[iface.id]:
+        with self._lock_interfaces[iface.id]:
             event = self._intf_events[iface.id]["event"]
             self._intf_events[iface.id].pop('last_acquired', None)
             _, _, event_type = event.name.rpartition('.')

--- a/settings.py
+++ b/settings.py
@@ -58,4 +58,4 @@ SPF_ATTRIBUTE = "hop"
 
 # Time (seconds) to update EVC after interface event
 # ".*.switch.interface.(link_up|link_down|created|deleted)"
-TIME_INTERFACE = 0.1
+UNI_STATE_CHANGE_DELAY = 0.1

--- a/settings.py
+++ b/settings.py
@@ -55,3 +55,7 @@ TABLE_GROUP_ALLOWED = {'evpl', 'epl'}
 QUEUE_ID = None
 # Default spf_attribute. Allowed values: "hop", "priority", and "delay"
 SPF_ATTRIBUTE = "hop"
+
+# Time (seconds) to update EVC after interface event
+# ".*.switch.interface.(link_up|link_down|created|deleted)"
+TIME_INTERFACE = 0.1

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2565,3 +2565,19 @@ class TestMain:
 
         self.napp._check_no_tag_duplication(evc_id, None, None)
         assert evc.check_no_tag_duplicate.call_count == 3
+
+    @patch("napps.kytos.mef_eline.main.Main.handle_interface_link_up")
+    @patch("napps.kytos.mef_eline.main.Main.handle_interface_link_down")
+    def test_handle_on_interface_link_change(self, mock_down, mock_up):
+        """Test handle_on_interface_link_change"""
+        content = {"interface": "mock_intf"}
+        name = '.*.switch.interface.created'
+        event = KytosEvent(name=name, content=content)
+        self.napp.handle_on_interface_link_change(event)
+        assert mock_down.call_count == 0
+        assert mock_up.call_count == 1
+        name = '.*.switch.interface.deleted'
+        event = KytosEvent(name=name, content=content)
+        self.napp.handle_on_interface_link_change(event)
+        assert mock_down.call_count == 1
+        assert mock_up.call_count == 1


### PR DESCRIPTION
Close #373

### Summary

Set a timer to reduce load to database.
The timer will stop first event, while updating last received interface event. When timer ends, the last event will be applied.
Example in used:
```
2024-01-30 07:20:56,482 - WARNING [kytos.napps.kytos/mef_eline] (thread_pool_sb_155) TIMING -> 00:00:00:00:00:00:00:02:3 -> kytos/of_core.switch.interface.link_down            <----- Start time here for 02:3
2024-01-30 07:20:56,487 - WARNING [kytos.napps.kytos/mef_eline] (thread_pool_sb_130) RETURN -> 00:00:00:00:00:00:00:02:3 -> kytos/of_core.switch.interface.link_up
2024-01-30 07:20:56,487 - WARNING [kytos.napps.kytos/mef_eline] (thread_pool_sb_14) TIMING -> 00:00:00:00:00:00:00:01:4 -> kytos/of_core.switch.interface.link_down             <----- Start time here for 01:4
2024-01-30 07:20:56,489 - WARNING [kytos.napps.kytos/mef_eline] (thread_pool_sb_112) RETURN -> 00:00:00:00:00:00:00:01:4 -> kytos/of_core.switch.interface.link_up
2024-01-30 07:20:56,506 - WARNING [kytos.napps.kytos/mef_eline] (thread_pool_sb_63) RETURN -> 00:00:00:00:00:00:00:02:3 -> kytos/of_core.switch.interface.link_down
2024-01-30 07:20:56,506 - WARNING [kytos.napps.kytos/mef_eline] (thread_pool_sb_39) RETURN -> 00:00:00:00:00:00:00:02:3 -> kytos/of_core.switch.interface.link_up
2024-01-30 07:20:56,508 - WARNING [kytos.napps.kytos/mef_eline] (thread_pool_sb_22) RETURN -> 00:00:00:00:00:00:00:01:4 -> kytos/of_core.switch.interface.link_down
2024-01-30 07:20:56,509 - WARNING [kytos.napps.kytos/mef_eline] (thread_pool_sb_73) RETURN -> 00:00:00:00:00:00:00:01:4 -> kytos/of_core.switch.interface.link_up
2024-01-30 07:20:56,533 - WARNING [kytos.napps.kytos/mef_eline] (thread_pool_sb_6) RETURN -> 00:00:00:00:00:00:00:01:4 -> kytos/of_core.switch.interface.link_down
2024-01-30 07:20:56,533 - WARNING [kytos.napps.kytos/mef_eline] (thread_pool_sb_9) RETURN -> 00:00:00:00:00:00:00:02:3 -> kytos/of_core.switch.interface.link_down
2024-01-30 07:20:56,535 - WARNING [kytos.napps.kytos/mef_eline] (thread_pool_sb_54) RETURN -> 00:00:00:00:00:00:00:02:3 -> kytos/of_core.switch.interface.link_up
2024-01-30 07:20:56,566 - WARNING [kytos.napps.kytos/mef_eline] (thread_pool_sb_54) RETURN -> 00:00:00:00:00:00:00:01:4 -> kytos/of_core.switch.interface.link_up
2024-01-30 07:20:56,583 - WARNING [kytos.napps.kytos/mef_eline] (thread_pool_sb_155) PROCESS -> 00:00:00:00:00:00:00:02:3 -> kytos/of_core.switch.interface.link_up             <----- Finnished 02:3
2024-01-30 07:20:56,589 - WARNING [kytos.napps.kytos/mef_eline] (thread_pool_sb_14) PROCESS -> 00:00:00:00:00:00:00:01:4 -> kytos/of_core.switch.interface.link_up              <----- Finnished 01:4
```

### End-To-End Tests
```
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.4.0
rootdir: /tests
plugins: timeout-2.1.0, rerunfailures-10.2, anyio-3.6.2
collected 256 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ....................                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 24%]
tests/test_e2e_11_mef_eline.py ......                                    [ 26%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 45%]
.                                                                        [ 46%]
tests/test_e2e_14_mef_eline.py x                                         [ 46%]
tests/test_e2e_15_mef_eline.py .....                                     [ 48%]
tests/test_e2e_20_flow_manager.py .....................                  [ 56%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 63%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ...                                         [ 71%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ..............                             [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
tests/test_e2e_50_maintenance.py ........................                [ 91%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py ........                                [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
```
