### PR TITLE
Adding switches to disjointedness algorithm

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,7 @@ Changed
 - Improved log for invalid traces by adding ``From EVC(evc_id) named 'evc_name'``
 - An inactive and enabled EVC will be redeploy if an attribute from ``attributes_requiring_redeploy`` is updated.
 - If a KytosEvent can't be put on ``buffers.app`` during ``setup()``, it'll make the NApp to fail to start
+- Disjointedness algorithm now takes into account switches, excepting the UNIs switches. Unwanted switches have the same value as the unwanted links.
 
 Deprecated
 ==========

--- a/models/path.py
+++ b/models/path.py
@@ -185,16 +185,17 @@ class DynamicPathManager:
         """Computes the maximum disjoint paths from the unwanted_path for a EVC
 
         Maximum disjoint paths from the unwanted_path are the paths from the
-        source node to the target node that share the minimum number os links
-        contained in unwanted_path. In other words, unwanted_path is the path
-        we want to avoid: we want the maximum possible disjoint path from it.
-        The disjointness of a path in regards to unwanted_path is calculated
-        by the complementary percentage of shared links between them. As an
-        example, if the unwanted_path has 3 links, a given path P1 has 1 link
-        shared with unwanted_path, and a given path P2 has 2 links shared with
-        unwanted_path, then the disjointness of P1 is 0.67 and the disjointness
-        of P2 is 0.33. In this example, P1 is preferable over P2 because it
-        offers a better disjoint path. When two paths have the same
+        source node to the target node that share the minimum number of links
+        and switches contained in unwanted_path. In other words, unwanted_path
+        is the path we want to avoid: we want the maximum possible disjoint
+        path from it. The disjointness of a path in regards to unwanted_path
+        is calculated by the complementary percentage of shared links and
+        switches between them. As an example, if the unwanted_path has 3
+        links and 2 switches, a given path P1 has 1 link shared with
+        unwanted_path, and a given path P2 has 2 links and 1 switch shared
+        with unwanted_path, then the disjointness of P1 is 0.8 and the
+        disjointness of P2 is 0.4. In this example, P1 is preferable over P2
+        because it offers a better disjoint path. When two paths have the same
         disjointness they are ordered by 'cost' attributed as returned from
         Pathfinder. When the disjointness of a path is equal to 0 (i.e., it
         shares all the links with unwanted_path), that particular path is not
@@ -222,7 +223,15 @@ class DynamicPathManager:
         unwanted_links = [
             (link.endpoint_a.id, link.endpoint_b.id) for link in unwanted_path
         ]
-        if not unwanted_links:
+        unwanted_switches = set()
+        for link in unwanted_path:
+            unwanted_switches.add(link.endpoint_a.switch.id)
+            unwanted_switches.add(link.endpoint_b.switch.id)
+        unwanted_switches.discard(circuit.uni_a.interface.switch.id)
+        unwanted_switches.discard(circuit.uni_z.interface.switch.id)
+
+        unwanted_components_n = (len(unwanted_links) + len(unwanted_switches))
+        if not unwanted_links or not unwanted_switches:
             return None
 
         paths = cls.get_paths(circuit, max_paths=cutoff,
@@ -230,13 +239,18 @@ class DynamicPathManager:
         for path in paths:
             head = path["hops"][:-1]
             tail = path["hops"][1:]
-            shared_edges = 0
+            copy_switches = unwanted_switches.copy()
+            shared_components = 0
             for (endpoint_a, endpoint_b) in unwanted_links:
                 if ((endpoint_a, endpoint_b) in zip(head, tail)) or (
                     (endpoint_b, endpoint_a) in zip(head, tail)
                 ):
-                    shared_edges += 1
-            path["disjointness"] = 1 - shared_edges / len(unwanted_links)
+                    shared_components += 1
+            for component in path["hops"]:
+                if component in copy_switches:
+                    shared_components += 1
+                    copy_switches.remove(component)
+            path["disjointness"] = 1 - shared_components / unwanted_components_n
         paths = sorted(paths, key=lambda x: (-x['disjointness'], x['cost']))
         for path in paths:
             if path["disjointness"] == 0:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -23,6 +23,7 @@ def id_to_interface_mock(interface_id):
     switch_id = ":".join(interface_id.split(":")[:-1])
     port_id = int(interface_id.split(":")[-1])
     switch = get_switch_mock(switch_id, 0x04)
+    switch.id = switch_id
     interface = get_interface_mock(port_id, port_id, switch)
     return interface
 

--- a/tests/unit/models/test_path.py
+++ b/tests/unit/models/test_path.py
@@ -488,8 +488,14 @@ class TestDynamicPathManager():
         assert isinstance(res_paths, list)
         assert mock_log.error.call_count == 1
 
+    # pylint: disable=too-many-statements, too-many-locals
+    @patch.object(
+        DynamicPathManager,
+        "get_shared_components",
+        side_effect=DynamicPathManager.get_shared_components
+    )
     @patch("requests.post")
-    def test_get_disjoint_paths(self, mock_requests_post):
+    def test_get_disjoint_paths(self, mock_requests_post, mock_shared):
         """Test get_disjoint_paths method."""
 
         controller = MagicMock()
@@ -635,12 +641,25 @@ class TestDynamicPathManager():
                 id_to_interface_mock("00:00:00:00:00:00:00:05:2")
             ),
         ]
+        path_links = [
+            ("00:00:00:00:00:00:00:01:2", "00:00:00:00:00:00:00:02:2"),
+            ("00:00:00:00:00:00:00:02:3", "00:00:00:00:00:00:00:04:2"),
+            ("00:00:00:00:00:00:00:04:3", "00:00:00:00:00:00:00:05:2")
+        ]
+        path_switches = {
+            "00:00:00:00:00:00:00:04",
+            "00:00:00:00:00:00:00:02"
+        }
 
         # only one path available from pathfinder (precesilly the
         # current_path), so the maximum disjoint path will be empty
         mock_response.json.return_value = {"paths": paths1["paths"][0:1]}
         mock_requests_post.return_value = mock_response
         paths = list(DynamicPathManager.get_disjoint_paths(evc, current_path))
+        args = mock_shared.call_args[0]
+        assert args[0] == paths1["paths"][0]
+        assert args[1] == path_links
+        assert args[2] == path_switches
         assert len(paths) == 0
 
         expected_disjoint_path = [
@@ -666,6 +685,13 @@ class TestDynamicPathManager():
         mock_response.json.return_value = paths1
         mock_requests_post.return_value = mock_response
         paths = list(DynamicPathManager.get_disjoint_paths(evc, current_path))
+        args = mock_shared.call_args[0]
+        assert args[0] == paths1["paths"][-1]
+        assert args[1] == path_links
+        assert args[2] == {
+            "00:00:00:00:00:00:00:04",
+            "00:00:00:00:00:00:00:02"
+        }
         assert len(paths) == 4
         # for more information on the paths please refer to EP029
         assert len(paths[0]) == 4  # path S-Z-W-I-D
@@ -694,6 +720,8 @@ class TestDynamicPathManager():
         mock_requests_post.assert_has_calls([expected_call])
 
         # EP029 Topo2
+        evc.uni_a.interface.switch.id = "00:00:00:00:00:00:00:01"
+        evc.uni_z.interface.switch.id = "00:00:00:00:00:00:00:07"
         paths2 = {
             "paths": [
                 {
@@ -760,6 +788,17 @@ class TestDynamicPathManager():
                 id_to_interface_mock("00:00:00:00:00:00:00:07:2")
             ),
         ]
+        path_interfaces = [
+            ("00:00:00:00:00:00:00:01:2", "00:00:00:00:00:00:00:02:1"),
+            ("00:00:00:00:00:00:00:02:2", "00:00:00:00:00:00:00:03:1"),
+            ("00:00:00:00:00:00:00:03:2", "00:00:00:00:00:00:00:04:1"),
+            ("00:00:00:00:00:00:00:04:2", "00:00:00:00:00:00:00:07:2")
+        ]
+        path_switches = {
+            "00:00:00:00:00:00:00:02",
+            "00:00:00:00:00:00:00:03",
+            "00:00:00:00:00:00:00:04"
+        }
 
         expected_disjoint_path = [
             Link(
@@ -787,8 +826,39 @@ class TestDynamicPathManager():
         mock_response.json.return_value = {"paths": paths2["paths"]}
         mock_requests_post.return_value = mock_response
         paths = list(DynamicPathManager.get_disjoint_paths(evc, current_path))
+        args = mock_shared.call_args[0]
+        assert args[0] == paths2["paths"][-1]
+        assert args[1] == path_interfaces
+        assert args[2] == path_switches
         assert len(paths) == 1
         assert (
             [link.id for link in paths[0]] ==
             [link.id for link in expected_disjoint_path]
         )
+
+    def test_get_shared_components(self):
+        """Test get_shared_components"""
+        mock_path = {"hops": [
+            '00:00:00:00:00:00:00:01:1',
+            '00:00:00:00:00:00:00:01',
+            '00:00:00:00:00:00:00:01:4',
+            '00:00:00:00:00:00:00:05:2',
+            '00:00:00:00:00:00:00:05',
+            '00:00:00:00:00:00:00:05:3',
+            '00:00:00:00:00:00:00:02:4',
+            '00:00:00:00:00:00:00:02',
+            '00:00:00:00:00:00:00:02:3',
+            '00:00:00:00:00:00:00:03:2',
+            '00:00:00:00:00:00:00:03',
+            '00:00:00:00:00:00:00:03:1'
+        ]}
+        mock_links = [
+            ("00:00:00:00:00:00:00:01:2", "00:00:00:00:00:00:00:02:2"),
+            ("00:00:00:00:00:00:00:02:3", "00:00:00:00:00:00:00:03:2")
+        ]
+        mock_switches = {"00:00:00:00:00:00:00:02"}
+        actual_lk, actual_sw = DynamicPathManager.get_shared_components(
+            mock_path, mock_links, mock_switches
+        )
+        assert actual_lk == 1
+        assert actual_sw == 1

--- a/tests/unit/models/test_path.py
+++ b/tests/unit/models/test_path.py
@@ -506,6 +506,8 @@ class TestDynamicPathManager():
         }
         evc.uni_a.interface.id = "1"
         evc.uni_z.interface.id = "2"
+        evc.uni_a.interface.switch.id = "00:00:00:00:00:00:00:01"
+        evc.uni_z.interface.switch.id = "00:00:00:00:00:00:00:05"
 
         # Topo0
         paths1 = {


### PR DESCRIPTION
Closes #392 

### Summary

Switches are taken into account when calculating `disjointness` percentage. Switches have the same values as links.

### Local Tests
Used this [topology](https://github.com/Alopalao/Alopalao_miscellaneous/blob/main/topologies/min3.py).
![mn3_topo](https://github.com/kytos-ng/mef_eline/assets/55767214/b9787cc5-ea3e-4a09-acef-5a901fb7fe92)
Created EVC:
```
{
    "name": "EVC SW2",
    "dynamic_backup_path": true,
    "uni_a": {
        "tag": {"value": 200, "tag_type": 1},
        "interface_id": "00:00:00:00:00:00:00:01:1"
    },
    "uni_z": {
        "tag": {"value": 200, "tag_type": 1},
        "interface_id": "00:00:00:00:00:00:00:03:1"
    }
}
```
Printed paths from `models/path.py` line 254. Paths were reordered correctly


### End-to-End Tests
To be added
