### PR TITLE
Fixed early return

### DIFF
--- a/models/path.py
+++ b/models/path.py
@@ -231,7 +231,7 @@ class DynamicPathManager:
         unwanted_switches.discard(circuit.uni_z.interface.switch.id)
 
         length_unwanted = (len(unwanted_links) + len(unwanted_switches))
-        if not unwanted_links or not unwanted_switches:
+        if not unwanted_links:
             return None
 
         paths = cls.get_paths(circuit, max_paths=cutoff,


### PR DESCRIPTION
Closes #429 

### Summary

For EVC paths with 1 link there are no unwanted switches. For an early return we can trust only in unwanted links

### Local Tests
Sames as E2E [test](https://github.com/kytos-ng/kytos-end-to-end-tests/blob/31269c42a6ace8f8199f6cc3893fd8fbcd396289/tests/test_e2e_10_mef_eline.py#L150-L211)

### End-to-End Tests
```
+ python3 -m pytest tests/ -k test_020_create_evc_inter_switch --reruns 0 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.4.0
rootdir: /tests
plugins: timeout-2.1.0, rerunfailures-10.2, anyio-3.6.2
collected 257 items / 256 deselected / 1 selected

tests/test_e2e_10_mef_eline.py .                                         [100%]
```

```
+ python3 -m pytest tests/ --reruns 0 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.4.0
rootdir: /tests
plugins: timeout-2.1.0, rerunfailures-10.2, anyio-3.6.2
collected 257 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ....................                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 24%]
tests/test_e2e_11_mef_eline.py ......                                    [ 26%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 45%]
.                                                                        [ 45%]
tests/test_e2e_14_mef_eline.py x                                         [ 46%]
tests/test_e2e_15_mef_eline.py .....                                     [ 48%]
tests/test_e2e_16_mef_eline.py .                                         [ 48%]
tests/test_e2e_20_flow_manager.py .....................                  [ 56%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 63%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ...                                         [ 71%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ..............                             [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
tests/test_e2e_50_maintenance.py ........................                [ 91%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .....R...                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]

```
