### PR TITLE
Removed client side batching

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,7 +4,6 @@
 NApp to provision circuits from user request.
 """
 import pathlib
-import time
 import traceback
 from threading import Lock
 from typing import Optional
@@ -841,7 +840,7 @@ class Main(KytosNApp):
                 name="flows.install",
                 content={
                     "dpid": dpid,
-                    "flow_dict": {"flows": switch_flows[dpid]},
+                    "flow_dict": {"flows": flows},
                 }
             )
 

--- a/main.py
+++ b/main.py
@@ -834,24 +834,16 @@ class Main(KytosNApp):
             else:
                 check_failover.append(evc)
 
-        while switch_flows:
-            offset = settings.BATCH_SIZE or None
-            switches = list(switch_flows.keys())
-            for dpid in switches:
-                emit_event(
-                    self.controller,
-                    context="kytos.flow_manager",
-                    name="flows.install",
-                    content={
-                        "dpid": dpid,
-                        "flow_dict": {"flows": switch_flows[dpid][:offset]},
-                    }
-                )
-                if offset is None or offset >= len(switch_flows[dpid]):
-                    del switch_flows[dpid]
-                    continue
-                switch_flows[dpid] = switch_flows[dpid][offset:]
-            time.sleep(settings.BATCH_INTERVAL)
+        for dpid, flows in switch_flows.items():
+            emit_event(
+                self.controller,
+                context="kytos.flow_manager",
+                name="flows.install",
+                content={
+                    "dpid": dpid,
+                    "flow_dict": {"flows": switch_flows[dpid]},
+                }
+            )
 
         for evc in evcs_with_failover:
             with evc.lock:

--- a/settings.py
+++ b/settings.py
@@ -28,15 +28,6 @@ COOKIE_PREFIX = 0xAA
 # the maximum disjoint paths from unwanted_path
 DISJOINT_PATH_CUTOFF = 10
 
-# BATCH_INTERVAL: time interval between batch requests that will be sent to
-# flow_manager (in seconds) - zero enable sending all the requests in a row
-BATCH_INTERVAL = 0.5
-
-# BATCH_SIZE: size of a batch request that will be sent to flow_manager, in
-# number of FlowMod requests. Use 0 (zero) to disable BATCH mode, i.e. sends
-# everything at a glance
-BATCH_SIZE = 50
-
 # Default values for EVPL and EPL respectively. They are use when sb_priority
 # is not set in a request
 EVPL_SB_PRIORITY = 20000

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1973,9 +1973,8 @@ class TestMain:
         evc_mock.handle_link_up.assert_called_once_with("abc")
 
     @patch("time.sleep", return_value=None)
-    @patch("napps.kytos.mef_eline.main.settings")
     @patch("napps.kytos.mef_eline.main.emit_event")
-    def test_handle_link_down(self, emit_event_mock, settings_mock, _):
+    def test_handle_link_down(self, emit_event_mock, _):
         """Test handle_link_down method."""
         uni = create_autospec(UNI)
         evc1 = MagicMock(id="1", service_level=0, creation_time=1,
@@ -2025,7 +2024,6 @@ class TestMain:
         event = KytosEvent(name="test", content={"link": link})
         self.napp.circuits = {"1": evc1, "2": evc2, "3": evc3, "4": evc4,
                               "5": evc5, "6": evc6}
-        settings_mock.BATCH_SIZE = 2
         self.napp.handle_link_down(event)
 
         assert evc5.service_level > evc4.service_level
@@ -2064,16 +2062,14 @@ class TestMain:
                 name="flows.install",
                 content={
                     "dpid": "3",
-                    "flow_dict": {"flows": ["flow3", "flow4"]},
-                }
-            ),
-            call(
-                self.napp.controller,
-                context="kytos.flow_manager",
-                name="flows.install",
-                content={
-                    "dpid": "3",
-                    "flow_dict": {"flows": ["flow5", "flow6"]},
+                    "flow_dict": {
+                        "flows": [
+                            "flow3",
+                            "flow4",
+                            "flow5",
+                            "flow6"
+                        ]
+                    },
                 }
             ),
         ])


### PR DESCRIPTION
Closes #372

### Summary

Removes client side batching, and removes the client side batching settings.

### Local Tests

Running this in conjunction with kytos-ng/kytos#453. Everything seems to be in working order.

### End-to-End Tests

Will need to run End to End Tests.