### PR TITLE
Removed archived evcs from `self.circuits`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Changed
 - An inactive and enabled EVC will be redeploy if an attribute from ``attributes_requiring_redeploy`` is updated.
 - If a KytosEvent can't be put on ``buffers.app`` during ``setup()``, it'll make the NApp to fail to start
 - Disjointedness algorithm now takes into account switches, excepting the UNIs switches. Unwanted switches have the same value as the unwanted links.
+- Archived EVCs are not longer kept in memory. They can only be found in the database.
 
 Deprecated
 ==========

--- a/models/evc.py
+++ b/models/evc.py
@@ -1686,8 +1686,6 @@ class LinkProtection(EVCDeploy):
         """
         Handler for interface link_up events
         """
-        if self.archived:  # TODO: Remove when addressing issue #369
-            return
         if self.is_active():
             return
         interfaces = (self.uni_a.interface, self.uni_z.interface)
@@ -1718,8 +1716,6 @@ class LinkProtection(EVCDeploy):
         """
         Handler for interface link_down events
         """
-        if self.archived:
-            return
         if not self.is_active():
             return
         interfaces = (self.uni_a.interface, self.uni_z.interface)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1286,6 +1286,10 @@ class TestMain:
         for i in range(2):
             assert evcs_by_level[i].creation_time == i
 
+        self.napp.circuits[1].is_enabled = lambda: False
+        evcs_by_level = self.napp.get_evcs_by_svc_level()
+        assert len(evcs_by_level) == 1
+
     async def test_get_circuit_not_found(self):
         """Test /v2/evc/<circuit_id> 404."""
         self.napp.mongo_controller.get_circuit.return_value = None
@@ -1844,7 +1848,9 @@ class TestMain:
         """Test handle_link_up method."""
         evc_mock = create_autospec(EVC)
         evc_mock.service_level, evc_mock.creation_time = 0, 1
-        evc_mock.is_enabled = MagicMock(side_effect=[True, False, True])
+        evc_mock.is_enabled = MagicMock(side_effect=[
+            True, False, True, True, True
+        ])
         evc_mock.lock = MagicMock()
         evc_mock.archived = False
         evcs = [evc_mock, evc_mock, evc_mock]

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1290,6 +1290,10 @@ class TestMain:
         evcs_by_level = self.napp.get_evcs_by_svc_level()
         assert len(evcs_by_level) == 1
 
+        self.napp.circuits[1].is_enabled = lambda: False
+        evcs_by_level = self.napp.get_evcs_by_svc_level(enable_filter=False)
+        assert len(evcs_by_level) == 2
+
     async def test_get_circuit_not_found(self):
         """Test /v2/evc/<circuit_id> 404."""
         self.napp.mongo_controller.get_circuit.return_value = None


### PR DESCRIPTION
Closes #369

### Summary

Removed archived evcs from `self.circuits`.

### Local Tests
Tested `link_down` and `link_up` events.
Tried to delete, patch a deleted EVC.
Tried to create an schedule for a deleted EVC.

### End-to-End Tests
```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.4.0
rootdir: /tests
plugins: timeout-2.1.0, rerunfailures-10.2, anyio-3.6.2
collected 257 items

tests/test_e2e_01_kytos_startup.py RRF.                                  [  0%]
tests/test_e2e_05_topology.py ....................                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 24%]
tests/test_e2e_11_mef_eline.py ......                                    [ 26%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 45%]
.                                                                        [ 45%]
tests/test_e2e_14_mef_eline.py x                                         [ 46%]
tests/test_e2e_15_mef_eline.py .....                                     [ 48%]
tests/test_e2e_16_mef_eline.py .                                         [ 48%]
tests/test_e2e_20_flow_manager.py .......R..............                 [ 56%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 63%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ...                                         [ 71%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ..............                             [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
tests/test_e2e_50_maintenance.py ........................                [ 91%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py ........                                [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
```
The failures are popped because of an outdated `kytos-docker` without the removal of `flow_stats`
```
+ python3 -m pytest tests/test_e2e_01_kytos_startup.py --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.4.0
rootdir: /tests
plugins: timeout-2.1.0, rerunfailures-10.2, anyio-3.6.2
collected 2 items

tests/test_e2e_01_kytos_startup.py ..                                    [100%]

```

