### PR TITLE
UI/not ownership

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Added
 - Usage of special vlans ``"untagged"`` and ``"any"`` now send an event to each Interface.
 - Added ``UNI_STATE_CHANGE_DELAY`` which configures the time for ``mef_eline`` to wait on link state flaps and update EVCs with last updated event.
 - Added support for ``not_ownership`` to dynamic path constraints.
+- Added support for ``not_ownership`` on main UI interface.
 
 Changed
 =======

--- a/ui/k-info-panel/show_circuit.kytos
+++ b/ui/k-info-panel/show_circuit.kytos
@@ -665,6 +665,7 @@ module.exports = {
         'mandatory_metrics.delay': 'Delay',
         'mandatory_metrics.reliability': 'Reliability',
         'mandatory_metrics.ownership': 'Ownership',
+        'mandatory_metrics.not_wnership': 'Not ownership',
         'flexible_metrics': 'Flexible metrics',
         'flexible_metrics.bandwidth': 'Bandwidth',
         'flexible_metrics.utilization': 'Utilization',
@@ -672,6 +673,7 @@ module.exports = {
         'flexible_metrics.delay': 'Delay',
         'flexible_metrics.reliability': 'Reliability',
         'flexible_metrics.ownership': 'Ownership',
+        'flexible_metrics.not_ownership': 'Not ownership',
       };
 
       let _constraint = {};
@@ -690,12 +692,14 @@ module.exports = {
             'priority': data['mandatory_metrics']['priority'],
             'delay': data['mandatory_metrics']['delay'],
             'reliability': data['mandatory_metrics']['reliability'],
-            'ownership': data['mandatory_metrics']['ownership']
+            'ownership': data['mandatory_metrics']['ownership'],
+            'not_ownership': JSON.stringify(data['mandatory_metrics']['not_ownership']),
           };
         } else {
           _constraint.mandatory_metrics = {
             'bandwidth': '', 'utilization': '', 'priority': '',
             'delay': '', 'reliability': '', 'ownership': '',
+            'not_ownership': [],
           };
         } 
         if(data['flexible_metrics']) {
@@ -705,12 +709,14 @@ module.exports = {
             'priority': data['flexible_metrics']['priority'],
             'delay': data['flexible_metrics']['delay'],
             'reliability': data['flexible_metrics']['reliability'],
-            'ownership': data['flexible_metrics']['ownership']
+            'ownership': data['flexible_metrics']['ownership'],
+            'not_ownership': JSON.stringify(data['flexible_metrics']['not_ownership']),
           };
         } else {
           _constraint.flexible_metrics = {
             'bandwidth': '', 'utilization': '', 'priority': '',
             'delay': '', 'reliability': '', 'ownership': '',
+            'not_ownership': [],
           };
         }
 
@@ -848,6 +854,9 @@ module.exports = {
             if(metric['ownership'] !== undefined) { // can be empty
               _result_metrics['ownership'] = metric['ownership'];
             }
+            if(metric['not_ownership'] !== undefined && metric['not_ownership'] !== '') {
+              _result_metrics['not_ownership'] = JSON.parse(metric['not_ownership'])
+            }
             if(!$.isEmptyObject(_result_metrics)) {
               _constraint_payload[_metric_type] = _result_metrics;
             } else {
@@ -911,7 +920,8 @@ module.exports = {
             'priority': '',
             'delay': '',
             'reliability': '',
-            'ownership': ''
+            'ownership': '',
+            'not_ownership': [],
           },
           'flexible_metrics': {
             'bandwidth': '',
@@ -919,7 +929,8 @@ module.exports = {
             'priority': '',
             'delay': '',
             'reliability': '',
-            'ownership': ''
+            'ownership': '',
+            'not_ownership': [],
           }
         };
       });

--- a/ui/k-info-panel/show_circuit.kytos
+++ b/ui/k-info-panel/show_circuit.kytos
@@ -855,7 +855,15 @@ module.exports = {
               _result_metrics['ownership'] = metric['ownership'];
             }
             if(metric['not_ownership'] !== undefined && metric['not_ownership'] !== '') {
-              _result_metrics['not_ownership'] = JSON.parse(metric['not_ownership'])
+              try{_result_metrics['not_ownership'] = JSON.parse(metric['not_ownership'])}
+              catch(e){
+                if (e instanceof SyntaxError){
+                  _result_metrics['not_ownership'] = metric['not_ownership']
+                }
+                else{
+                  throw e
+                }
+              }
             }
             if(!$.isEmptyObject(_result_metrics)) {
               _constraint_payload[_metric_type] = _result_metrics;

--- a/ui/k-info-panel/show_circuit.kytos
+++ b/ui/k-info-panel/show_circuit.kytos
@@ -788,7 +788,7 @@ module.exports = {
       */
       var _this = this;
       let id = this.basics["ID"]["value"];
-
+      var parse_error = ""
       let payload = {
         name: this.basics["Name"]["value"],
         enable: this.flags["Enabled"]["value"],
@@ -859,6 +859,7 @@ module.exports = {
               catch(e){
                 if (e instanceof SyntaxError){
                   _result_metrics['not_ownership'] = metric['not_ownership']
+                  parse_error = " Detected error with " + metric['not_ownership'] + ", it could not be parsed."
                 }
                 else{
                   throw e
@@ -893,7 +894,7 @@ module.exports = {
       request.fail(function(data) {
         let notification = {
           title: 'Update EVC failed',
-          description: 'Error updating EVC ' + id +'. ' + data.responseJSON.description
+          description: 'Error updating EVC ' + id +'. ' + data.responseJSON.description + parse_error
         }
         _this.$kytos.$emit("setNotification" , notification);
       });

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -199,6 +199,25 @@
                     :action="function(val) {form_constraints[constraint].metrics.ownership = val}"></k-input>
                   </div>
                 </div>
+
+                <div class="metric">
+                  <div class="metric-dropdown">
+                    <k-dropdown :options="metric_options" 
+                    :title="constraint_titles['not_ownership']"
+                    :value.sync="form_constraints[constraint].is_flexible.not_ownership"
+                    ref="is_flexible"></k-dropdown>
+                  </div>
+                  <div class="metric-field">
+                    <k-input icon="arrow-right"
+                    placeholder='["blue", "red"]'
+                    :value.sync="form_constraints[constraint].not_ownership"
+                    :action="function(val){
+                        try{form_constraints[constraint].metrics.not_ownership = JSON.parse(val)}
+                        catch(e){
+                          if(e instanceof SyntaxError){form_constraints[constraint].metrics.not_ownership=val}
+                          else{throw e}}}"></k-input>
+                  </div>
+                </div>
             </k-accordion-item>
         </span>
         <k-button tooltip="Request Circuit" title="Request Circuit"
@@ -244,6 +263,7 @@ module.exports = {
             metrics: {
               bandwidth: '', utilization: '', priority: '',
               delay: '', reliability: '', ownership: '',
+              not_ownership: [],
             },
             is_flexible: {
               bandwidth: false,
@@ -251,7 +271,8 @@ module.exports = {
               delay: false,
               utilization: false,
               priority: false,
-              ownership: false
+              ownership: false,
+              not_ownership: false,
             },
           },
           secondary_constraints: {
@@ -262,6 +283,7 @@ module.exports = {
             metrics: {
               bandwidth: '', utilization: '', priority: '',
               delay: '', reliability: '', ownership: '',
+              not_ownership: [],
             },
             is_flexible: {
               bandwidth: false,
@@ -269,7 +291,8 @@ module.exports = {
               delay: false,
               utilization: false,
               priority: false,
-              ownership: false
+              ownership: false,
+              not_ownership: false,
             },
           }
         },
@@ -340,6 +363,7 @@ module.exports = {
         'delay': 'Delay',
         'reliability': 'Reliability',
         'ownership': 'Ownership',
+        'not_ownership': 'Not ownership',
       };
 
       this.form_constraints = {
@@ -351,6 +375,7 @@ module.exports = {
             metrics: {
               bandwidth: '', utilization: '', priority: '',
               delay: '', reliability: '', ownership: '',
+              not_ownership: [],
             },
             is_flexible: {
               bandwidth: false,
@@ -358,7 +383,8 @@ module.exports = {
               delay: false,
               utilization: false,
               priority: false,
-              ownership: false
+              ownership: false,
+              not_ownership: false,
             },
           },
           secondary_constraints: {
@@ -369,6 +395,7 @@ module.exports = {
             metrics: {
               bandwidth: '', utilization: '', priority: '',
               delay: '', reliability: '', ownership: '',
+              not_ownership: [],
             },
             is_flexible: {
               bandwidth: false,
@@ -376,7 +403,8 @@ module.exports = {
               delay: false,
               utilization: false,
               priority: false,
-              ownership: false
+              ownership: false,
+              not_ownership: false,
             },
           }
         };
@@ -480,7 +508,7 @@ module.exports = {
           // mandatory and flexible metrics. Filter empty values.
           let _flexible_metrics = {};
           let _mandatory_metrics = {};
-          ['bandwidth', 'utilization', 'priority', 'delay', 'reliability', 'ownership'].forEach(_m => {
+          ['bandwidth', 'utilization', 'priority', 'delay', 'reliability', 'ownership', 'not_ownership'].forEach(_m => {
             if(this.form_constraints[_type].metrics[_m] !== '') {
               if (this.form_constraints[_type].is_flexible[_m]) {
                 _flexible_metrics[_m] = this.form_constraints[_type].metrics[_m];

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -652,8 +652,8 @@ module.exports = {
   }
   .metric-dropdown {width:100%;}
   .metric-dropdown .k-dropdown {height: 20px; width:100%; display:flex;flex-wrap: wrap;}
-  .metric-dropdown .k-dropdown .k-dropdown__title {width:35%;}
-  .metric-dropdown .k-dropdown .k-dropdown__select {width:60%;}
+  .metric-dropdown .k-dropdown .k-dropdown__title {width:42%;}
+  .metric-dropdown .k-dropdown .k-dropdown__select {width:53%;}
   .metric-field {width:100%; display:flex; }
   .metric-field label {width:60%; }
   .metric-field label ~.k-input-wrap {width:40%; }


### PR DESCRIPTION
Closes #431

### Summary

Added `not_ownership` support to main UI interface.
Not parsable values like `['red']` will be sent as it is. But an extra message will appear. Correct ways is `["red"]`

### Local Tests
Created an EVC with `not_ownership`
Modified existent EVC. Deleted, added, erased, modified a `not_ownership` value.

### End-to-End Tests
N/A