### PR TITLE
Enhance link down handler to avoid race conditions in the failover path

### DIFF
--- a/main.py
+++ b/main.py
@@ -68,7 +68,6 @@ class Main(KytosNApp):
         self._lock_interfaces = defaultdict(Lock)
         self.table_group = {"epl": 0, "evpl": 0}
         self._lock = Lock()
-        self._lock_handle_link_down = Lock()
         self.execute_as_loop(settings.DEPLOY_EVCS_INTERVAL)
 
         self.load_all_evcs()
@@ -808,11 +807,10 @@ class Main(KytosNApp):
                     interface
                 )
 
-    @listen_to("kytos/topology.link_down")
+    @listen_to("kytos/topology.link_down", pool="dynamic_single")
     def on_link_down(self, event):
         """Change circuit when link is down or under_mantenance."""
-        with self._lock_handle_link_down:
-            self.handle_link_down(event)
+        self.handle_link_down(event)
 
     def handle_link_down(self, event):  # pylint: disable=too-many-branches
         """Change circuit when link is down or under_mantenance."""

--- a/main.py
+++ b/main.py
@@ -843,7 +843,8 @@ class Main(KytosNApp):
                     except Exception:
                         err = traceback.format_exc().replace("\n", ", ")
                         log.error(
-                            f"Ignore Failover path for {evc} due to error: {err}"
+                            "Ignore Failover path for "
+                            f"{evc} due to error: {err}"
                         )
                         evcs_normal.append(evc)
                         continue
@@ -881,8 +882,11 @@ class Main(KytosNApp):
             )
 
         for evc in evcs_with_failover:
-            emit_event(self.controller, "redeployed_link_down",
-                       content=map_evc_event_content(evc,  old_path=evc.old_path))
+            emit_event(
+                self.controller,
+                "redeployed_link_down",
+                content=map_evc_event_content(evc,  old_path=evc.old_path)
+            )
             log.info(
                 f"{evc} redeployed with failover due to link down {link.id}"
             )

--- a/main.py
+++ b/main.py
@@ -836,7 +836,6 @@ class Main(KytosNApp):
                         evc.old_path = evc.current_path
                         evc.current_path = evc.failover_path
                         evc.failover_path = Path([])
-                        evc.sync()
                     # pylint: disable=broad-except
                     except Exception:
                         err = traceback.format_exc().replace("\n", ", ")
@@ -880,6 +879,7 @@ class Main(KytosNApp):
             )
 
         for evc in evcs_with_failover:
+            evc.sync()
             emit_event(
                 self.controller,
                 "redeployed_link_down",

--- a/models/evc.py
+++ b/models/evc.py
@@ -872,7 +872,7 @@ class EVCDeploy(EVCBase):
         log.info(f"{self} was deployed.")
         return True
 
-    def setup_failover_path(self, old_path=None):
+    def setup_failover_path(self):
         """Install flows for the failover path of this EVC.
 
         Procedures to deploy:
@@ -892,11 +892,8 @@ class EVCDeploy(EVCBase):
         if not self.is_eligible_for_failover_path():
             return False
 
-        if not old_path:
-            old_path = self.failover_path
-
         reason = ""
-        self.remove_path_flows(old_path)
+        self.remove_path_flows(self.failover_path)
         self.failover_path = Path([])
         for use_path in self.get_failover_path_candidates():
             if not use_path:

--- a/models/evc.py
+++ b/models/evc.py
@@ -872,7 +872,7 @@ class EVCDeploy(EVCBase):
         log.info(f"{self} was deployed.")
         return True
 
-    def setup_failover_path(self):
+    def setup_failover_path(self, old_path=None):
         """Install flows for the failover path of this EVC.
 
         Procedures to deploy:
@@ -892,8 +892,11 @@ class EVCDeploy(EVCBase):
         if not self.is_eligible_for_failover_path():
             return False
 
+        if not old_path:
+            old_path = self.failover_path
+
         reason = ""
-        self.remove_path_flows(self.failover_path)
+        self.remove_path_flows(old_path)
         self.failover_path = Path([])
         for use_path in self.get_failover_path_candidates():
             if not use_path:

--- a/tests/unit/test_controllers.py
+++ b/tests/unit/test_controllers.py
@@ -76,11 +76,19 @@ class TestControllers():
         self.eline.upsert_evc(self.evc_dict)
         assert self.eline.db.evcs.find_one_and_update.call_count == 1
 
-    def test_update_evcs(self):
-        """Test update_evcs"""
+    def test_update_evcs_metadata(self):
+        """Test update_evcs_metadata"""
         circuit_ids = ["123", "456", "789"]
         metadata = {"info": "testing"}
-        self.eline.update_evcs(circuit_ids, metadata, "add")
+        self.eline.update_evcs_metadata(circuit_ids, metadata, "add")
         arg = self.eline.db.evcs.bulk_write.call_args[0][0]
         assert len(arg) == 3
+        assert self.eline.db.evcs.bulk_write.call_count == 1
+
+    def test_update_evcs(self):
+        """Test update_evcs"""
+        evc2 = dict(self.evc_dict | {"id": "456"})
+        self.eline.update_evcs([self.evc_dict, evc2])
+        arg = self.eline.db.evcs.bulk_write.call_args[0][0]
+        assert len(arg) == 2
         assert self.eline.db.evcs.bulk_write.call_count == 1

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2088,7 +2088,7 @@ class TestMain:
         """Test handle_cleanup_evcs_old_path method."""
         evc1 = create_autospec(EVC, id="1", old_path=["1"])
         evc2 = create_autospec(EVC, id="2", old_path=["2"])
-        evc3 = create_autospec(EVC, id="3")
+        evc3 = create_autospec(EVC, id="3", old_path=[])
 
         event = KytosEvent(name="e1", content={"evcs": [evc1, evc2, evc3]})
         self.napp.handle_cleanup_evcs_old_path(event)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1897,6 +1897,7 @@ class TestMain:
             "2": ["flow1", "flow2"],
             "3": ["flow3", "flow4", "flow5", "flow6"],
         }
+        evc4_current_path = evc4.current_path
         evc5 = MagicMock(id="5", service_level=7, creation_time=1)
         evc5.is_affected_by_link.return_value = True
         evc5.is_failover_path_affected_by_link.return_value = False
@@ -1974,7 +1975,7 @@ class TestMain:
         # evc3 should be handled before evc1
         emit_event_mock.assert_has_calls([
             call(self.napp.controller, event_name, content={
-                "link_id": "123",
+                "link": link,
                 "evc_id": "6",
                 "name": "name",
                 "metadata": "mock",
@@ -1984,7 +1985,7 @@ class TestMain:
                 "uni_z": uni.as_dict(),
             }),
             call(self.napp.controller, event_name, content={
-                "link_id": "123",
+                "link": link,
                 "evc_id": "3",
                 "name": "name",
                 "metadata": "mock",
@@ -1994,7 +1995,7 @@ class TestMain:
                 "uni_z": uni.as_dict(),
             }),
             call(self.napp.controller, event_name, content={
-                "link_id": "123",
+                "link": link,
                 "evc_id": "1",
                 "name": "name",
                 "metadata": "mock",
@@ -2008,6 +2009,7 @@ class TestMain:
         event_name = "redeployed_link_down"
         emit_event_mock.assert_has_calls([
             call(self.napp.controller, event_name, content={
+                "old_path": evc4_current_path,
                 "evc_id": "4",
                 "name": "name",
                 "metadata": "mock",
@@ -2046,7 +2048,7 @@ class TestMain:
 
         event = KytosEvent(name="e1", content={
             "evc_id": "3",
-            "link_id": "1",
+            "link": MagicMock(),
         })
         self.napp.handle_evc_affected_by_link_down(event)
         emit_event_mock.assert_not_called()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1879,6 +1879,8 @@ class TestMain:
         evc1.failover_path = None
         evc2 = MagicMock(id="2", service_level=6, creation_time=1)
         evc2.is_affected_by_link.return_value = False
+        evc2.is_failover_path_affected_by_link.return_value = True
+        evc2.as_dict.return_value = {"id": "2"}
         evc3 = MagicMock(id="3", service_level=5, creation_time=1,
                          metadata="mock", _active="true", _enabled="true",
                          uni_a=uni, uni_z=uni)
@@ -1897,7 +1899,7 @@ class TestMain:
             "2": ["flow1", "flow2"],
             "3": ["flow3", "flow4", "flow5", "flow6"],
         }
-        evc4_current_path = evc4.current_path
+        evc4.as_dict.return_value = {"id": "4"}
         evc5 = MagicMock(id="5", service_level=7, creation_time=1)
         evc5.is_affected_by_link.return_value = True
         evc5.is_failover_path_affected_by_link.return_value = False
@@ -1906,6 +1908,7 @@ class TestMain:
             "4": ["flow7", "flow8"],
             "5": ["flow9", "flow10"],
         }
+        evc5.as_dict.return_value = {"id": "5"}
         evc6 = MagicMock(id="6", service_level=8, creation_time=1,
                          metadata="mock", _active="true", _enabled="true",
                          uni_a=uni, uni_z=uni)
@@ -2005,11 +2008,12 @@ class TestMain:
                 "uni_z": uni.as_dict(),
             }),
         ])
-        evc4.sync.assert_called_once()
+        self.napp.mongo_controller.update_evcs.assert_called_with(
+            [{"id": "5"}, {"id": "4"}, {"id": "2"}]
+        )
         event_name = "redeployed_link_down"
         emit_event_mock.assert_has_calls([
             call(self.napp.controller, event_name, content={
-                "old_path": evc4_current_path,
                 "evc_id": "4",
                 "name": "name",
                 "metadata": "mock",
@@ -2080,19 +2084,17 @@ class TestMain:
             }
         )
 
-    def test_handle_evc_deployed(self):
-        """Test handle_evc_deployed method."""
-        evc = create_autospec(EVC, id="1")
-        evc.lock = MagicMock()
-        self.napp.circuits = {"1": evc}
+    def test_cleanup_evcs_old_path(self):
+        """Test handle_cleanup_evcs_old_path method."""
+        evc1 = create_autospec(EVC, id="1", old_path=["1"])
+        evc2 = create_autospec(EVC, id="2", old_path=["2"])
+        evc3 = create_autospec(EVC, id="3")
 
-        event = KytosEvent(name="e1", content={"evc_id": "2"})
-        self.napp.handle_evc_deployed(event)
-        evc.setup_failover_path.assert_not_called()
-
-        event.content["evc_id"] = "1"
-        self.napp.handle_evc_deployed(event)
-        evc.setup_failover_path.assert_called()
+        event = KytosEvent(name="e1", content={"evcs": [evc1, evc2, evc3]})
+        self.napp.handle_cleanup_evcs_old_path(event)
+        evc1.remove_path_flows.assert_called_with(["1"])
+        evc2.remove_path_flows.assert_called_with(["2"])
+        evc3.remove_path_flows.assert_not_called()
 
     async def test_add_metadata(self, event_loop):
         """Test method to add metadata"""
@@ -2318,12 +2320,12 @@ class TestMain:
             json=payload
         )
         assert response.status_code == 201
-        args = self.napp.mongo_controller.update_evcs.call_args[0]
+        args = self.napp.mongo_controller.update_evcs_metadata.call_args[0]
         ids = payload.pop("circuit_ids")
         assert args[0] == ids
         assert args[1] == payload
         assert args[2] == "add"
-        calls = self.napp.mongo_controller.update_evcs.call_count
+        calls = self.napp.mongo_controller.update_evcs_metadata.call_count
         assert calls == 1
         evc_mock.extend_metadata.assert_called_with(payload)
 
@@ -2390,11 +2392,11 @@ class TestMain:
             json=payload
         )
         assert response.status_code == 200
-        args = self.napp.mongo_controller.update_evcs.call_args[0]
+        args = self.napp.mongo_controller.update_evcs_metadata.call_args[0]
         assert args[0] == payload["circuit_ids"]
         assert args[1] == {"metadata1": ""}
         assert args[2] == "del"
-        calls = self.napp.mongo_controller.update_evcs.call_count
+        calls = self.napp.mongo_controller.update_evcs_metadata.call_count
         assert calls == 1
         assert evc_mock.remove_metadata.call_count == 1
 


### PR DESCRIPTION
Closes #405

### Summary

See updated changelog file and/or add any other summarized helpful information for reviewers (in fact, the changelog already mentions a fix similar to this one _fixed race condition in ``failover_path`` when handling simultaneous Link Down events leading to inconsistencies on some EVC_)

### Local Tests

Using the topology presented on the issue, I executed tests with and without this change to evaluate how a user (EVC service) would be impacted. Tests consist basically of all nodes pinging to h1 (h2-h1, h3-h1, h4-h1, and h5-h1), and on each step, we disable both interfaces that directly connect the nodes (first disabling h1-h2 links; then h1-h3 links, then h1-h4 links). The link-down event is simulated around 25% of the data transfer on each step. The metric used here was the packet loss, so 0 means no packet loss (good) while 100 means 100% of packet loss (bad), results are presented using average and 95% confidence interval.

1) Without this change/fix :

```
Test h1-h2
--> step 1 mean_95_CI 75.050 +- 0.113
--> step 2 mean_95_CI 100.000 +- 0.000
--> step 3 mean_95_CI 100.000 +- 0.000
--> step 4 mean_95_CI 100.000 +- 0.000
Test h3-h1
--> step 1 mean_95_CI 0.000 +- 0.000
--> step 2 mean_95_CI 75.250 +- 0.189
--> step 3 mean_95_CI 100.000 +- 0.000
--> step 4 mean_95_CI 100.000 +- 0.000
Test h4-h1
--> step 1 mean_95_CI 0.000 +- 0.000
--> step 2 mean_95_CI 0.000 +- 0.000
--> step 3 mean_95_CI 75.300 +- 0.185
--> step 4 mean_95_CI 100.000 +- 0.000
Test h5-h1
--> step 1 mean_95_CI 0.000 +- 0.000
--> step 2 mean_95_CI 0.000 +- 0.000
--> step 3 mean_95_CI 0.000 +- 0.000
--> step 4 mean_95_CI 75.400 +- 0.151
```

2) With the change/fix :

```
Test h1-h2
--> step 1 mean_95_CI 2.500 +- 0.000
--> step 2 mean_95_CI 9.000 +- 0.000
--> step 3 mean_95_CI 8.500 +- 0.000
--> step 4 mean_95_CI 13.500 +- 0.000
Test h3-h1
--> step 1 mean_95_CI 0.100 +- 0.278
--> step 2 mean_95_CI 8.900 +- 0.278
--> step 3 mean_95_CI 8.500 +- 0.000
--> step 4 mean_95_CI 13.500 +- 0.000
Test h4-h1
--> step 1 mean_95_CI 2.000 +- 2.105
--> step 2 mean_95_CI 0.000 +- 0.000
--> step 3 mean_95_CI 8.500 +- 0.000
--> step 4 mean_95_CI 13.500 +- 0.000
Test h5-h1
--> step 1 mean_95_CI 0.000 +- 0.000
--> step 2 mean_95_CI 0.000 +- 0.000
--> step 3 mean_95_CI 0.000 +- 0.000
--> step 4 mean_95_CI 13.500 +- 0.000
```

The results above mean basically that 1) without the change, tests from h2 to h1 will have a 75% pkt loss on the first step and then 100% of packet loss in all other steps -- this basically means that EVC got stuck after the first failover routine because path was wrongly provisioned;  same happens for tests from h3 to h1, but step 1 does not have an impact because those links do not affect communication from h3 to h1, but starting on step 2 we see pretty much the same behavior; 2) with the change we do see some packet loss, but no EVC get stuck -- we can confirm this because the packet loss is lower than the time duration from when the event happen and the end of the data transfer (in other words, packet loss is way lower than 75%). One could expect 0% of packet loss, but that is not possible in this scenario because, unfortunately, the failover path is chosen from a link that is subject to failures (the hypothesis here is that those two links share the underlying physical media (e.g., optical system)) -- see Issue kytos-ng/mef_eline#439 for more info on this context.


Another evaluation I executed was a performance test on Link failover convergence, to understand if the changes here would impact the performance in ideal scenarios (where we can really benefit from the failover_path) and below are the results (the test is basically measuring how long does it takes for Kytos to failover a Link with 100 EVCs):

Without this change:
```
min 0.376 / 25pct 0.597 / 50pct 1.099 / 90pcl 1.499 / max 1.757 / mean_95_CI 0.996 +- 0.036
```

With this change:
```
min 0.376 / 25pct 0.552 / 50pct 0.889 / 90pcl 1.469 / max 1.547 / mean_95_CI 0.933 +- 0.036
```

We can see that the values are very similar, but with the change, the performance was slightly better.

### End-to-End Tests

Results from the end-to-end tests using this branch (Job #59047):

```
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.4.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 257 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ....................                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 24%]
tests/test_e2e_11_mef_eline.py ......                                    [ 26%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 45%]
.                                                                        [ 45%]
tests/test_e2e_14_mef_eline.py x                                         [ 46%]
tests/test_e2e_15_mef_eline.py .....                                     [ 48%]
tests/test_e2e_16_mef_eline.py .                                         [ 48%]
tests/test_e2e_20_flow_manager.py .....................                  [ 56%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 63%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ...                                         [ 71%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ..............                             [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
tests/test_e2e_50_maintenance.py ........................                [ 91%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py ........                                [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]

=============================== warnings summary ===============================
= 233 passed, 8 skipped, 9 xfailed, 7 xpassed, 1143 warnings in 12324.60s (3:25:24) =

```