### PR TITLE
fix: remove failover flows upfront during redeploy

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -47,6 +47,7 @@ Fixed
 - fixed race condition in ``failover_path`` when handling simultaneous Link Down events leading to inconsistencies on some EVC
 - fixed sdntrace_cp check_trace ``current_path`` comparison with the expected UNI order
 - fixed ``DynamicPathManager.get_paths`` return value when ``pathfinder`` returns a request error
+- ``failover_path`` will get removed if it exists during a redeploy
 
 [2023.1.0] - 2023-06-27
 ***********************

--- a/main.py
+++ b/main.py
@@ -559,7 +559,8 @@ class Main(KytosNApp):
             ) from KeyError
         if evc.is_enabled():
             with evc.lock:
-                evc.remove_current_flows()
+                evc.remove_failover_flows(sync=False)
+                evc.remove_current_flows(sync=True)
                 evc.deploy()
             result = {"response": f"Circuit {circuit_id} redeploy received."}
             status = 202

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -835,6 +835,8 @@ class TestMain:
         self.napp.circuits = {"1": evc1, "2": MagicMock()}
         url = f"{self.base_endpoint}/v2/evc/1/redeploy"
         response = await self.api_client.patch(url)
+        evc1.remove_failover_flows.assert_called()
+        evc1.remove_current_flows.assert_called()
         assert response.status_code == 202, response.data
 
     async def test_redeploy_evc_disabled(self):
@@ -844,6 +846,8 @@ class TestMain:
         self.napp.circuits = {"1": evc1, "2": MagicMock()}
         url = f"{self.base_endpoint}/v2/evc/1/redeploy"
         response = await self.api_client.patch(url)
+        evc1.remove_failover_flows.assert_not_called()
+        evc1.remove_current_flows.assert_not_called()
         assert response.status_code == 409, response.data
 
     async def test_redeploy_evc_deleted(self):


### PR DESCRIPTION
Closes #446 

### Summary

See updated changelog file

### Local Tests

- I didn't manage to reproduce the original issue but I tested the following cases:
- Confirmed that after a redeploy it clean up the failover flows
- Confirmed that after a redeploy if there has been a link status change it would still respect the timer to compute a new failover_path

```
kytos $> 2024-03-13 17:13:28,428 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:02, command: delete, force: True,  flo
ws[0, 1]: [{'cookie': 12252344641096843340, 'cookie_mask': 18446744073709551615}]
2024-03-13 17:13:28,436 - INFO [uvicorn.access] (MainThread) 127.0.0.1:42472 - "POST /api/kytos/flow_manager/v2/delete/00%3A00%3A00%3A00%3A00%3A00%3A00%3A02 HTTP/1.1" 202
2024-03-13 17:13:28,448 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:03, command: delete, force: True,  flows[0, 1]:
 [{'cookie': 12252344641096843340, 'cookie_mask': 18446744073709551615}]
2024-03-13 17:13:28,454 - INFO [uvicorn.access] (MainThread) 127.0.0.1:42486 - "POST /api/kytos/flow_manager/v2/delete/00%3A00%3A00%3A00%3A00%3A00%3A00%3A03 HTTP/1.1" 202
2024-03-13 17:13:28,460 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: delete, force: True,  flows[0, 1]:
 [{'cookie': 12252344641096843340, 'cookie_mask': 18446744073709551615}]
2024-03-13 17:13:28,466 - INFO [uvicorn.access] (MainThread) 127.0.0.1:42500 - "POST /api/kytos/flow_manager/v2/delete/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202
2024-03-13 17:13:28,475 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:03, command: delete, force: True,  flows[0, 1]:
 [{'cookie': 12252344641096843340, 'cookie_mask': 18446744073709551615}]
2024-03-13 17:13:28,477 - INFO [uvicorn.access] (MainThread) 127.0.0.1:42508 - "POST /api/kytos/flow_manager/v2/delete/00%3A00%3A00%3A00%3A00%3A00%3A00%3A03 HTTP/1.1" 202
2024-03-13 17:13:28,482 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: delete, force: True,  flows[0, 1]:
 [{'cookie': 12252344641096843340, 'cookie_mask': 18446744073709551615}]
2024-03-13 17:13:28,484 - INFO [uvicorn.access] (MainThread) 127.0.0.1:42510 - "POST /api/kytos/flow_manager/v2/delete/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202
2024-03-13 17:13:28,492 - INFO [uvicorn.access] (MainThread) 127.0.0.1:42524 - "POST /api/kytos/pathfinder/v3/ HTTP/1.1" 200
2024-03-13 17:13:28,497 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: add, force: False,  flows[0, 2]: [
{'match': {'in_port': 1, 'dl_vlan': 2222}, 'cookie': 12252344641096843340, 'actions': [{'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'action_
type': 'output', 'port': 4}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}, {'match': {'in_port': 4, 'dl_vlan': 1}, 'cookie': 12252344641096843340, 'act
ions': [{'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 1}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}]
2024-03-13 17:13:28,503 - INFO [uvicorn.access] (MainThread) 127.0.0.1:42526 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202
2024-03-13 17:13:28,510 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:03, command: add, force: False,  flows[0, 2]: [
{'match': {'in_port': 1, 'dl_vlan': 2222}, 'cookie': 12252344641096843340, 'actions': [{'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'action_
type': 'output', 'port': 3}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}, {'match': {'in_port': 3, 'dl_vlan': 1}, 'cookie': 12252344641096843340, 'act
ions': [{'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 1}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}]
2024-03-13 17:13:28,520 - INFO [uvicorn.access] (MainThread) 127.0.0.1:42540 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A03 HTTP/1.1" 202
2024-03-13 17:13:28,524 - INFO [kytos.napps.kytos/mef_eline] (AnyIO worker thread) EVC(0912890e3d004c, inter_evpl) was deployed.
2024-03-13 17:13:28,525 - INFO [uvicorn.access] (MainThread) 127.0.0.1:42466 - "PATCH /api/kytos/mef_eline/v2/evc/0912890e3d004c/redeploy HTTP/1.1" 202
2024-03-13 17:13:28,530 - INFO [uvicorn.access] (MainThread) 127.0.0.1:42542 - "POST /api/kytos/pathfinder/v3/ HTTP/1.1" 200
2024-03-13 17:13:28,543 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:02, command: add, force: False,  flows[0, 2]: [
{'match': {'in_port': 2, 'dl_vlan': 1}, 'cookie': 12252344641096843340, 'actions': [{'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output', 'port': 3}], 'owner': 'mef_eline'
, 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}, {'match': {'in_port': 3, 'dl_vlan': 1}, 'cookie': 12252344641096843340, 'actions': [{'action_type': 'set_vlan', 'vlan_id': 1},
 {'action_type': 'output', 'port': 2}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}]
2024-03-13 17:13:28,550 - INFO [uvicorn.access] (MainThread) 127.0.0.1:42544 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A02 HTTP/1.1" 202
2024-03-13 17:13:28,558 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: add, force: False,  flows[0, 1]: [
{'match': {'in_port': 3, 'dl_vlan': 1}, 'cookie': 12252344641096843340, 'actions': [{'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 1}], 'owner': 'mef_eline', 'table_group
': 'evpl', 'table_id': 0, 'priority': 20000}]
2024-03-13 17:13:28,564 - INFO [uvicorn.access] (MainThread) 127.0.0.1:42558 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202
2024-03-13 17:13:28,571 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:03, command: add, force: False,  flows[0, 1]: [
{'match': {'in_port': 2, 'dl_vlan': 1}, 'cookie': 12252344641096843340, 'actions': [{'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 1}], 'owner': 'mef_eline', 'table_group
': 'evpl', 'table_id': 0, 'priority': 20000}]
2024-03-13 17:13:28,576 - INFO [uvicorn.access] (MainThread) 127.0.0.1:42572 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A03 HTTP/1.1" 202
2024-03-13 17:13:28,584 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_10) Failover path for EVC(0912890e3d004c, inter_evpl) was deployed.

```

### End-to-End Tests

I'll dispatch an e2e exec with this branch, I'll post the results here later. 