### PR TITLE
feat: added kytos/mef_eline.uni_active_updated event

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Added
+=====
+- Added ``kytos/mef_eline.uni_active_updated`` event
+
 Changed
 =======
 - Updated python environment installation from 3.9 to 3.11

--- a/README.rst
+++ b/README.rst
@@ -91,6 +91,24 @@ Event with all evcs that got loaded
     '<evc_id>': <dict>
   }
 
+kytos/mef_eline.uni_active_updated
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Event published when an EVC active state changes due to a UNI going up or down
+
+.. code-block:: python3
+   
+  {
+   "evc_id": evc.id,
+   "name": evc.name,
+   "metadata": evc.metadata,
+   "active": evc._active,
+   "enabled": evc._enabled,
+   "uni_a": evc.uni_a.as_dict(),
+   "uni_z": evc.uni_z.as_dict()}
+  }
+
+
 .. TAGs
 
 .. |Stable| image:: https://img.shields.io/badge/stability-stable-green.svg

--- a/models/evc.py
+++ b/models/evc.py
@@ -1720,6 +1720,8 @@ class LinkProtection(EVCDeploy):
             f"Activating EVC {self.id}. Interfaces: "
             f"{interface_dicts}."
         )
+        emit_event(self._controller, "uni_active_updated",
+                   content=map_evc_event_content(self))
         self.sync()
 
     def handle_interface_link_down(self, interface):
@@ -1750,6 +1752,8 @@ class LinkProtection(EVCDeploy):
             f"Deactivating EVC {self.id}. Interfaces: "
             f"{interface_dicts}."
         )
+        emit_event(self._controller, "uni_active_updated",
+                   content=map_evc_event_content(self))
         self.sync()
 
 

--- a/tests/unit/models/test_link_protection.py
+++ b/tests/unit/models/test_link_protection.py
@@ -895,7 +895,7 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
         expected = (False, interfaces)
         assert actual == expected
 
-    async def test_handle_interface_link(self):
+    async def test_handle_interface_link(self, monkeypatch):
         """
         Test Interface Link Up
         """
@@ -905,6 +905,9 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
         interface_a.enable()
         interface_b = self.evc.uni_z.interface
         interface_b.enable()
+        emit_mock = MagicMock()
+        monkeypatch.setattr("napps.kytos.mef_eline.models.evc.emit_event",
+                            emit_mock)
 
         self.evc.activate = MagicMock()
         self.evc.deactivate = MagicMock()
@@ -921,7 +924,9 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
         # Test deactivating
         interface_a.deactivate()
 
+        assert emit_mock.call_count == 0
         self.evc.handle_interface_link_down(interface_a)
+        assert emit_mock.call_count == 1
 
         self.evc.deactivate.assert_called_once()
         self.evc.sync.assert_called_once()
@@ -937,7 +942,9 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
         # Test activating
         interface_a.activate()
 
+        assert emit_mock.call_count == 1
         self.evc.handle_interface_link_up(interface_a)
 
         self.evc.activate.assert_called_once()
         assert self.evc.sync.call_count == 2
+        assert emit_mock.call_count == 2


### PR DESCRIPTION
Closes #454 

### Summary

See updated changelog file 

### Local Tests

Local tests were documented on https://github.com/kytos-ng/telemetry_int/pull/91

### End-to-End Tests

No needed for this case since it doesn't impact on any existing one, and telemetry_int doesn't have e2e tests yet.
