### PR TITLE
chore: included id on `map_evc_event_content` to normalize the content

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Added
 =====
 - EVC list now utilizes ``localStorage`` to store ``search_cols`` and make them persistent throughout EVC list usage.
 - Added ``kytos/mef_eline.uni_active_updated`` event
+- Included "id" on EVC mapped content to normalize it with the other models
 
 Changed
 =======

--- a/README.rst
+++ b/README.rst
@@ -99,6 +99,7 @@ Event published when an EVC active state changes due to a UNI going up or down
 .. code-block:: python3
    
   {
+   "id", evc.id,
    "evc_id": evc.id,
    "name": evc.name,
    "metadata": evc.metadata,

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1969,6 +1969,7 @@ class TestMain:
         emit_event_mock.assert_has_calls([
             call(self.napp.controller, event_name, content={
                 "link": link,
+                "id": "6",
                 "evc_id": "6",
                 "name": "name",
                 "metadata": "mock",
@@ -1980,6 +1981,7 @@ class TestMain:
             call(self.napp.controller, event_name, content={
                 "link": link,
                 "evc_id": "3",
+                "id": "3",
                 "name": "name",
                 "metadata": "mock",
                 "active": "true",
@@ -1990,6 +1992,7 @@ class TestMain:
             call(self.napp.controller, event_name, content={
                 "link": link,
                 "evc_id": "1",
+                "id": "1",
                 "name": "name",
                 "metadata": "mock",
                 "active": "true",
@@ -2005,6 +2008,7 @@ class TestMain:
         emit_event_mock.assert_has_calls([
             call(self.napp.controller, event_name, content={
                 "evc_id": "4",
+                "id": "4",
                 "name": "name",
                 "metadata": "mock",
                 "active": "true",
@@ -2050,6 +2054,7 @@ class TestMain:
         self.napp.handle_evc_affected_by_link_down(event)
         emit_event_mock.assert_called_with(
             self.napp.controller, "redeployed_link_down", content={
+                "id": "1",
                 "evc_id": "1",
                 "name": "name_mocked",
                 "metadata": "data_mocked",
@@ -2065,6 +2070,7 @@ class TestMain:
         emit_event_mock.assert_called_with(
             self.napp.controller, "error_redeploy_link_down", content={
                 "evc_id": "2",
+                "id": "2",
                 "name": "mocked_name",
                 "metadata": "mocked_data",
                 "active": "false",

--- a/utils.py
+++ b/utils.py
@@ -10,6 +10,7 @@ from napps.kytos.mef_eline.exceptions import DisabledSwitch
 def map_evc_event_content(evc, **kwargs):
     """Returns a set of values from evc to be used for content"""
     return kwargs | {"evc_id": evc.id,
+                     "id": evc.id,
                      "name": evc.name,
                      "metadata": evc.metadata,
                      "active": evc._active,


### PR DESCRIPTION
Closes #462 

### Summary

See updated changelog file 

### Local Tests

Exercised some of the events with telemetry_int:

```

kytos $> 2024-05-16 13:49:27,329 - INFO [kytos.napps.kytos/mef_eline] (AnyIO worker thread) Removing EVC(df66e1705b1849, epl)
2024-05-16 13:49:27,332 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:03, command: delete, force: True,  flows[0, 1
]: [{'cookie': 12312673024692918345, 'cookie_mask': 18446744073709551615}]
2024-05-16 13:49:27,338 - INFO [uvicorn.access] (MainThread) 127.0.0.1:41726 - "POST /api/kytos/flow_manager/v2/delete/00%3A00%3A00%3A00%3A00%3A00%3A00%3A03 HTTP/1.1" 202
2024-05-16 13:49:27,344 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: delete, force: True,  flows[0, 1
]: [{'cookie': 12312673024692918345, 'cookie_mask': 18446744073709551615}]
2024-05-16 13:49:27,349 - INFO [uvicorn.access] (MainThread) 127.0.0.1:41736 - "POST /api/kytos/flow_manager/v2/delete/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202
2024-05-16 13:49:27,358 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:02, command: delete, force: True,  flows[0, 1
]: [{'cookie': 12312673024692918345, 'cookie_mask': 18446744073709551615}]
2024-05-16 13:49:27,362 - INFO [uvicorn.access] (MainThread) 127.0.0.1:41744 - "POST /api/kytos/flow_manager/v2/delete/00%3A00%3A00%3A00%3A00%3A00%3A00%3A02 HTTP/1.1" 202
2024-05-16 13:49:27,366 - INFO [kytos.napps.kytos/mef_eline] (AnyIO worker thread) EVC removed. EVC(df66e1705b1849, epl)
2024-05-16 13:49:27,369 - INFO [uvicorn.access] (MainThread) 127.0.0.1:41710 - "DELETE /api/kytos/mef_eline/v2/evc/df66e1705b1849 HTTP/1.1" 200
2024-05-16 13:49:27,371 - INFO [kytos.napps.kytos/telemetry_int] (MainThread) Handling mef_eline.deleted on EVC id: df66e1705b1849
2024-05-16 13:49:27,371 - INFO [kytos.napps.kytos/telemetry_int] (MainThread) Disabling INT on EVC ids: ['df66e1705b1849'], force: True
2024-05-16 13:49:27,379 - INFO [uvicorn.access] (MainThread) 127.0.0.1:41760 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending HTTP/1.1" 200
2024-05-16 13:49:27,391 - INFO [uvicorn.access] (MainThread) 127.0.0.1:41770 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 404
kytos $> 

```

### End-to-End Tests

Not needed for this case