### PR TITLE
fix: optimized `Path.status` not to depend on a HTTP request

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Changed
 =======
 - Updated python environment installation from 3.9 to 3.11
 - Updated test dependencies
+- Optimized ``Path.status`` not to depend on a HTTP request
 
 [2023.2.0] - 2024-02-16
 ***********************

--- a/tests/unit/models/test_path.py
+++ b/tests/unit/models/test_path.py
@@ -16,7 +16,7 @@ from napps.kytos.mef_eline.exceptions import InvalidPath  # NOQA pycodestyle
 from napps.kytos.mef_eline.models import (  # NOQA pycodestyle
     DynamicPathManager, Path)
 from napps.kytos.mef_eline.tests.helpers import (  # NOQA pycodestyle
-    MockResponse, get_link_mocked, get_mocked_requests, id_to_interface_mock)
+    MockResponse, get_link_mocked, id_to_interface_mock)
 
 
 class TestPath():
@@ -54,9 +54,7 @@ class TestPath():
         current_path = Path()
         assert current_path.status == EntityStatus.DISABLED
 
-    @patch("requests.get", side_effect=get_mocked_requests)
-    def test_status_case_2(self, requests_mocked):
-        # pylint: disable=unused-argument
+    def test_status_case_2(self):
         """Test if link status is DOWN."""
         link1 = get_link_mocked()
         link2 = get_link_mocked()
@@ -84,65 +82,56 @@ class TestPath():
             200,
         )
 
-    @patch("requests.get", side_effect=_mocked_requests_get_status_case_4)
-    def test_status_case_4(self, requests_mocked):
-        # pylint: disable=unused-argument
+    def test_status_case_4(self):
         """Test if link status is UP."""
-        link1 = get_link_mocked()
-        link2 = get_link_mocked()
+        link1 = get_link_mocked(status=EntityStatus.UP)
+        link2 = get_link_mocked(status=EntityStatus.UP)
         link1.id = "def"
         link2.id = "abc"
         links = [link1, link2]
         current_path = Path(links)
         assert current_path.status == EntityStatus.UP
 
-    # This method will be used by the mock to replace requests.get
-    def _mocked_requests_get_status_case_5(self):
-        return MockResponse(
-            {
-                "links": {
-                    "abc": {"active": True, "enabled": True},
-                    "def": {"active": False, "enabled": False},
-                }
-            },
-            200,
-        )
-
-    @patch("requests.get", side_effect=_mocked_requests_get_status_case_5)
-    def test_status_case_5(self, requests_mocked):
-        # pylint: disable=unused-argument
+    def test_status_case_5(self):
         """Test if link status is UP."""
-        link1 = get_link_mocked()
-        link2 = get_link_mocked()
+        link1 = get_link_mocked(status=EntityStatus.UP)
+        link2 = get_link_mocked(status=EntityStatus.DISABLED)
         link1.id = "def"
         link2.id = "abc"
         links = [link1, link2]
         current_path = Path(links)
         assert current_path.status == EntityStatus.DISABLED
 
-    # This method will be used by the mock to replace requests.get
-    def _mocked_requests_get_status_case_6(self):
-        return MockResponse(
-            {
-                "links": {
-                    "abc": {"active": False, "enabled": False},
-                    "def": {"active": False, "enabled": True},
-                }
-            },
-            200,
-        )
-
-    @patch("requests.get", side_effect=_mocked_requests_get_status_case_6)
-    def test_status_case_6(self, requests_mocked):
-        # pylint: disable=unused-argument
+    def test_status_case_6(self):
         """Test if link status is UP."""
-        link1 = get_link_mocked()
-        link2 = get_link_mocked()
+        link1 = get_link_mocked(status=EntityStatus.DISABLED)
+        link2 = get_link_mocked(status=EntityStatus.UP)
         link1.id = "def"
         link2.id = "abc"
         links = [link1, link2]
         current_path = Path(links)
         assert current_path.status == EntityStatus.DISABLED
+
+    def test_status_case_7(self):
+        """Test if link status is DOWN if has one link down."""
+        link1 = get_link_mocked(status=EntityStatus.UP)
+        link2 = get_link_mocked(status=EntityStatus.DOWN)
+        link1.id = "def"
+        link2.id = "abc"
+        links = [link1, link2]
+        current_path = Path(links)
+        assert current_path.status == EntityStatus.DOWN
+
+    def test_status_case_8(self):
+        """Test if status is DOWN if has one endpoint link is mismatched."""
+        link1 = get_link_mocked(status=EntityStatus.UP)
+        link1.endpoint_a.link = None
+        link2 = get_link_mocked(status=EntityStatus.UP)
+        link1.id = "def"
+        link2.id = "abc"
+        links = [link1, link2]
+        current_path = Path(links)
+        assert current_path.status == EntityStatus.DOWN
 
     def test_compare_same_paths(self):
         """Test compare paths with same links."""


### PR DESCRIPTION
Closes #464 

### Summary

See updated changelog file 

### Local Tests

- **Without this fix**, one request will be sent for each `Path` instance `status` access:

```
kytos $> for evc in controller.napps[('kytos', 'mef_eline')].circuits.values():
    ...:     for i in range(10):
    ...:         print(evc.current_path.status)
    ...: 
EntityStatus.UP
2024-05-23 09:06:33,221 - INFO [uvicorn.access] (MainThread) 127.0.0.1:33264 - "GET /api/kytos/topology/v3/links HTTP/1.1" 200
2024-05-23 09:06:33,223 - INFO [uvicorn.access] (MainThread) 127.0.0.1:33280 - "GET /api/kytos/topology/v3/links HTTP/1.1" 200
EntityStatus.UP
2024-05-23 09:06:33,225 - INFO [uvicorn.access] (MainThread) 127.0.0.1:33296 - "GET /api/kytos/topology/v3/links HTTP/1.1" 200
EntityStatus.UP
2024-05-23 09:06:33,228 - INFO [uvicorn.access] (MainThread) 127.0.0.1:33302 - "GET /api/kytos/topology/v3/links HTTP/1.1" 200
EntityStatus.UP
2024-05-23 09:06:33,230 - INFO [uvicorn.access] (MainThread) 127.0.0.1:33306 - "GET /api/kytos/topology/v3/links HTTP/1.1" 200
EntityStatus.UP
EntityStatus.UP
2024-05-23 09:06:33,232 - INFO [uvicorn.access] (MainThread) 127.0.0.1:33308 - "GET /api/kytos/topology/v3/links HTTP/1.1" 200
2024-05-23 09:06:33,234 - INFO [uvicorn.access] (MainThread) 127.0.0.1:33318 - "GET /api/kytos/topology/v3/links HTTP/1.1" 200
EntityStatus.UP
EntityStatus.UP
2024-05-23 09:06:33,236 - INFO [uvicorn.access] (MainThread) 127.0.0.1:33326 - "GET /api/kytos/topology/v3/links HTTP/1.1" 200
2024-05-23 09:06:33,238 - INFO [uvicorn.access] (MainThread) 127.0.0.1:33334 - "GET /api/kytos/topology/v3/links HTTP/1.1" 200
EntityStatus.UP
EntityStatus.UP
2024-05-23 09:06:33,240 - INFO [uvicorn.access] (MainThread) 127.0.0.1:33340 - "GET /api/kytos/topology/v3/links HTTP/1.1" 200

```

- With this branch fix:

```
kytos $> for evc in controller.napps[('kytos', 'mef_eline')].circuits.values():
    ...:     for i in range(10):
    ...:         print(evc.current_path.status)
    ...: 
EntityStatus.UP
EntityStatus.UP
EntityStatus.UP
EntityStatus.UP
EntityStatus.UP
EntityStatus.UP
EntityStatus.UP
EntityStatus.UP
EntityStatus.UP
EntityStatus.UP
```

- I've also explored link downs/ups worked as expected due to reusing the same endpoint_a and endpoint_b link topology's link ref:

```
kytos $> for evc in controller.napps[('kytos', 'mef_eline')].circuits.values():
    ...:     for i in range(10):
    ...:         print(evc.failover_path.status)
    ...: 
EntityStatus.DISABLED
EntityStatus.DISABLED
EntityStatus.DISABLED
EntityStatus.DISABLED
EntityStatus.DISABLED
EntityStatus.DISABLED
EntityStatus.DISABLED
EntityStatus.DISABLED
EntityStatus.DISABLED
EntityStatus.DISABLED

kytos $> 2024-05-23 09:13:14,395 - INFO [uvicorn.access] (MainThread) 127.0.0.1:35976 - "POST /api/kytos/pathfinder/v3/ HTTP/1.1" 200
2024-05-23 09:13:14,406 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: add, force: False,  flows[0, 1]: 
[{'match': {'in_port': 4, 'dl_vlan': 1}, 'cookie': 12303402349610937161, 'actions': [{'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 1}], 'owner': 'mef_eline', 'table_gro
up': 'evpl', 'table_id': 0, 'priority': 20000}]
2024-05-23 09:13:14,413 - INFO [uvicorn.access] (MainThread) 127.0.0.1:35984 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202
2024-05-23 09:13:14,416 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:03, command: add, force: False,  flows[0, 1]: 
[{'match': {'in_port': 3, 'dl_vlan': 1}, 'cookie': 12303402349610937161, 'actions': [{'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 1}], 'owner': 'mef_eline', 'table_gro
up': 'evpl', 'table_id': 0, 'priority': 20000}]
2024-05-23 09:13:14,420 - INFO [uvicorn.access] (MainThread) 127.0.0.1:35986 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A03 HTTP/1.1" 202
2024-05-23 09:13:14,424 - INFO [kytos.napps.kytos/mef_eline] (mef_eline) Failover path for EVC(be774031442b49, evpl2) was deployed.
kytos $> 

kytos $> for evc in controller.napps[('kytos', 'mef_eline')].circuits.values():
    ...:     for i in range(10):
    ...:         print(evc.failover_path.status)
    ...: 
EntityStatus.UP
EntityStatus.UP
EntityStatus.UP
EntityStatus.UP
EntityStatus.UP
EntityStatus.UP
EntityStatus.UP
EntityStatus.UP
EntityStatus.UP
EntityStatus.UP
```

### End-to-End Tests

There was a rerun but not related to this change:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 263 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  7%]
tests/test_e2e_06_topology.py ....                                       [  9%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 24%]
tests/test_e2e_11_mef_eline.py ......                                    [ 26%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 45%]
.                                                                        [ 45%]
tests/test_e2e_14_mef_eline.py x                                         [ 46%]
tests/test_e2e_15_mef_eline.py .....                                     [ 47%]
tests/test_e2e_16_mef_eline.py .                                         [ 48%]
tests/test_e2e_20_flow_manager.py ......R...............                 [ 56%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 63%]
tests/test_e2e_23_flow_manager.py ..............                         [ 68%]
tests/test_e2e_30_of_lldp.py ....                                        [ 69%]
tests/test_e2e_31_of_lldp.py ...                                         [ 71%]
tests/test_e2e_32_of_lldp.py ...                                         [ 72%]
tests/test_e2e_40_sdntrace.py ..............                             [ 77%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 80%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ............................            [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py ........                                [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
=============================== warnings summary ===============================
=========================== rerun test summary info ============================
RERUN tests/test_e2e_20_flow_manager.py::TestE2EFlowManager::test_025_delete_flows
= 239 passed, 8 skipped, 9 xfailed, 7 xpassed, 1295 warnings, 1 rerun in 12205.77s (3:23:25) =
```