### PR TITLE
backport/fix 2023.2.1: optimized Path.status not to depend on a HTTP request

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [Unreleased]
 ************
 
+[2023.2.1] - 2024-05-23
+***********************
+
+Changed
+=======
+- Optimized ``Path.status`` not to depend on a HTTP request
+
 [2023.2.0] - 2024-02-16
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2023.2.0",
+  "version": "2023.2.1",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],


### PR DESCRIPTION
Closes #466 

Backport from PR #465 

### Summary

- See updated changelog file 
- Unit tests weren't included since it's not run in the CI for backports (but see the associated PR)

### Local Tests

Done on PR #465 

### End-to-End Tests

Done on PR #465 
