### PR TITLE
fix: only redeploy when handling kytos/topology.link_up if a dynamic EVC isn't active

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ Changed
 - Updated test dependencies
 - Optimized ``Path.status`` not to depend on a HTTP request
 
+Fixed
+=====
+- Only redeploy when handling ``kytos/topology.link_up`` if a dynamic EVC isn't active
+
 [2023.2.0] - 2024-02-16
 ***********************
 

--- a/models/evc.py
+++ b/models/evc.py
@@ -1612,7 +1612,7 @@ class LinkProtection(EVCDeploy):
             # In this case, the circuit is not being used and we should
             # try a dynamic path
             (
-                lambda me: me.dynamic_backup_path,
+                lambda me: me.dynamic_backup_path and not me.is_active(),
                 lambda me: (me.deploy_to_path(), 'redeploy')
             )
         ]

--- a/tests/unit/models/test_link_protection.py
+++ b/tests/unit/models/test_link_protection.py
@@ -832,6 +832,20 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
         assert self.evc.deploy_to_backup_path.call_count == 2
         assert self.evc.deploy_to_path.call_count == 5
 
+    async def test_handle_link_up_case_7(self):
+        """Test handle_link_up method."""
+        return_false_mock = MagicMock(return_value=False)
+        self.evc.is_using_primary_path = return_false_mock
+        self.evc.primary_path.is_affected_by_link = return_false_mock
+        self.evc.is_using_dynamic_path = return_false_mock
+        self.evc.backup_path.is_affected_by_link = return_false_mock
+        self.evc.dynamic_backup_path = True
+        self.evc.activate()
+        assert self.evc.is_active()
+        self.evc.deploy_to_path = MagicMock(return_value=True)
+        assert not self.evc.handle_link_up(MagicMock())
+        assert self.evc.deploy_to_path.call_count == 0
+
     async def test_get_interface_from_switch(self):
         """Test get_interface_from_switch"""
         interface = id_to_interface_mock('00:01:1')


### PR DESCRIPTION
Closes #468 

### Summary

Only redeploy when handling ``kytos/topology.link_up`` if a dynamic EVC isn't active

### Local Tests

- Created a dynamic EVC exercised link_up, it didn't redeploy after a controller restart
- Simulated link_up with this EVC active, it didn't reploy as expected
- Shut it down all NNIs interfaces, in the next link_up the link_up resulted in reploy 

```
2024-06-06 14:12:49,486 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_5) Event handle_interface_link_down Interface('s1-eth4', 4, Switch('00:00:00:00:00:00:00:01'))
2024-06-06 14:12:49,487 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_23) Event handle_interface_link_down Interface('s3-eth3', 3, Switch('00:00:00:00:00:00:00:03'))
kytos $> 

kytos $> 

kytos $> 2024-06-06 14:12:54,378 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:4 state OFPPS_LIVE
2024-06-06 14:12:54,380 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:03:3 state OFPPS_LIVE
2024-06-06 14:12:54,482 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_17) Event handle_interface_link_up Interface('s1-eth4', 4, Switch('00:00:00:00:00:00:00:01'))
2024-06-06 14:12:54,483 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_21) Event handle_interface_link_up Interface('s3-eth3', 3, Switch('00:00:00:00:00:00:00:03'))
kytos $> 

kytos $> 

kytos $> 2024-06-06 14:12:57,388 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_15) Event handle_link_up Link(Interface('s3-eth3', 3, Switch('00:00:00:00:00:00:00:03')), Interfa
ce('s1-eth4', 4, Switch('00:00:00:00:00:00:00:01')), c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07)
2024-06-06 14:12:57,397 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: delete, force: True,  flows[0, 1
]: [{'cookie': 12258609547666106951, 'cookie_mask': 18446744073709551615}]
2024-06-06 14:12:57,403 - INFO [uvicorn.access] (MainThread) 127.0.0.1:53178 - "POST /api/kytos/flow_manager/v2/delete/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202
2024-06-06 14:12:57,415 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:03, command: delete, force: True,  flows[0, 1
]: [{'cookie': 12258609547666106951, 'cookie_mask': 18446744073709551615}]
2024-06-06 14:12:57,418 - INFO [uvicorn.access] (MainThread) 127.0.0.1:53180 - "POST /api/kytos/flow_manager/v2/delete/00%3A00%3A00%3A00%3A00%3A00%3A00%3A03 HTTP/1.1" 202
2024-06-06 14:12:57,432 - INFO [uvicorn.access] (MainThread) 127.0.0.1:53186 - "POST /api/kytos/pathfinder/v3/ HTTP/1.1" 200
2024-06-06 14:12:57,440 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: add, force: False,  flows[0, 2]:
 [{'match': {'in_port': 1, 'dl_vlan': 100}, 'cookie': 12258609547666106951, 'actions': [{'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'acti
on_type': 'output', 'port': 4}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}, {'match': {'in_port': 4, 'dl_vlan': 1}, 'cookie': 12258609547666106951,
 'actions': [{'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 1}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}]
2024-06-06 14:12:57,447 - INFO [uvicorn.access] (MainThread) 127.0.0.1:53194 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202
2024-06-06 14:12:57,453 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:03, command: add, force: False,  flows[0, 2]:
 [{'match': {'in_port': 1, 'dl_vlan': 100}, 'cookie': 12258609547666106951, 'actions': [{'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'acti
on_type': 'output', 'port': 3}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}, {'match': {'in_port': 3, 'dl_vlan': 1}, 'cookie': 12258609547666106951,
 'actions': [{'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 1}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}]
2024-06-06 14:12:57,458 - INFO [uvicorn.access] (MainThread) 127.0.0.1:53202 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A03 HTTP/1.1" 202
2024-06-06 14:12:57,461 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_15) EVC(1f546f48d9aa47, inter_evpl) was deployed.
kytos $> 

kytos $> 2024-06-06 14:13:01,432 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:3 state OFPPS_LIVE
2024-06-06 14:13:01,432 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:02:2 state OFPPS_LIVE
2024-06-06 14:13:01,534 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_20) Event handle_interface_link_up Interface('s1-eth3', 3, Switch('00:00:00:00:00:00:00:01'))
2024-06-06 14:13:01,535 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_18) Event handle_interface_link_up Interface('s2-eth2', 2, Switch('00:00:00:00:00:00:00:02'))
kytos $> 

kytos $> 2024-06-06 14:13:04,437 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_5) Event handle_link_up Link(Interface('s1-eth3', 3, Switch('00:00:00:00:00:00:00:01')), Interfac
e('s2-eth2', 2, Switch('00:00:00:00:00:00:00:02')), 78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0)
2024-06-06 14:13:05,417 - INFO [uvicorn.access] (MainThread) 127.0.0.1:57954 - "GET /api/kytos/mef_eline/v2/evc/ HTTP/1.1" 200
2024-06-06 14:13:05,978 - INFO [uvicorn.access] (MainThread) 127.0.0.1:57954 - "GET /api/kytos/mef_eline/v2/evc/ HTTP/1.1" 200
2024-06-06 14:14:19,539 - INFO [uvicorn.access] (MainThread) 127.0.0.1:41990 - "POST /api/kytos/pathfinder/v3/ HTTP/1.1" 200
2024-06-06 14:14:19,556 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:02, command: add, force: False,  flows[0, 2]:
 [{'match': {'in_port': 2, 'dl_vlan': 1}, 'cookie': 12258609547666106951, 'actions': [{'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output', 'port': 3}], 'owner': 'mef_el
ine', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}, {'match': {'in_port': 3, 'dl_vlan': 1}, 'cookie': 12258609547666106951, 'actions': [{'action_type': 'set_vlan', 'vlan_id
': 1}, {'action_type': 'output', 'port': 2}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}]
2024-06-06 14:14:19,571 - INFO [uvicorn.access] (MainThread) 127.0.0.1:41992 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A02 HTTP/1.1" 202
2024-06-06 14:14:19,583 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: add, force: False,  flows[0, 1]:
 [{'match': {'in_port': 3, 'dl_vlan': 1}, 'cookie': 12258609547666106951, 'actions': [{'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 1}], 'owner': 'mef_eline', 'table_g
roup': 'evpl', 'table_id': 0, 'priority': 20000}]
2024-06-06 14:14:19,591 - INFO [uvicorn.access] (MainThread) 127.0.0.1:42002 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202
2024-06-06 14:14:19,597 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:03, command: add, force: False,  flows[0, 1]:
 [{'match': {'in_port': 2, 'dl_vlan': 1}, 'cookie': 12258609547666106951, 'actions': [{'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 1}], 'owner': 'mef_eline', 'table_g
roup': 'evpl', 'table_id': 0, 'priority': 20000}]
2024-06-06 14:14:19,601 - INFO [uvicorn.access] (MainThread) 127.0.0.1:42014 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A03 HTTP/1.1" 202
2024-06-06 14:14:19,606 - INFO [kytos.napps.kytos/mef_eline] (mef_eline) Failover path for EVC(1f546f48d9aa47, inter_evpl) was deployed.

```

### End-to-End Tests

e2e tests exec with this branch:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 263 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  7%]
tests/test_e2e_06_topology.py ....                                       [  9%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 24%]
tests/test_e2e_11_mef_eline.py ......                                    [ 26%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 45%]
.                                                                        [ 45%]
tests/test_e2e_14_mef_eline.py x                                         [ 46%]
tests/test_e2e_15_mef_eline.py .....                                     [ 47%]
tests/test_e2e_16_mef_eline.py .                                         [ 48%]
tests/test_e2e_20_flow_manager.py .....................                  [ 56%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 63%]
tests/test_e2e_23_flow_manager.py ..............                         [ 68%]
tests/test_e2e_30_of_lldp.py ....                                        [ 69%]
tests/test_e2e_31_of_lldp.py ...                                         [ 71%]
tests/test_e2e_32_of_lldp.py ...                                         [ 72%]
tests/test_e2e_40_sdntrace.py ..............                             [ 77%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 80%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ............................            [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py ........                                [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
=============================== warnings summary ===============================
------------------------------- start/stop times -------------------------------
= 239 passed, 8 skipped, 9 xfailed, 7 xpassed, 1295 warnings in 12124.53s (3:22:04) =
```