### PR TITLE
[backport 2023.2.2] fix: only redeploy when handling kytos/topology.link_up if a dynamic EVC isn't active

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [Unreleased]
 ************
 
+[2023.2.2] - 2024-06-06
+***********************
+
+Fixed
+=====
+- Only redeploy when handling ``kytos/topology.link_up`` if a dynamic EVC isn't active
+
 [2023.2.1] - 2024-05-23
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2023.2.1",
+  "version": "2023.2.2",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],

--- a/models/evc.py
+++ b/models/evc.py
@@ -1612,7 +1612,7 @@ class LinkProtection(EVCDeploy):
             # In this case, the circuit is not being used and we should
             # try a dynamic path
             (
-                lambda me: me.dynamic_backup_path,
+                lambda me: me.dynamic_backup_path and not me.is_active(),
                 lambda me: (me.deploy_to_path(), 'redeploy')
             )
         ]


### PR DESCRIPTION
Closes #469 


### Summary

Backported from https://github.com/kytos-ng/mef_eline/pull/471/

### Local Tests

Same as PR 471

### End-to-End Tests

Same as PR 471
