### PR TITLE
feat: new failover_path publish events

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Added
 - EVC list now utilizes ``localStorage`` to store ``search_cols`` and make them persistent throughout EVC list usage.
 - Added ``kytos/mef_eline.uni_active_updated`` event
 - Included "id" on EVC mapped content to normalize it with the other models
+- Introduced ``failover_old_path``, ``failover_deployed``, and ``failover_link_down`` events, which will be primarily consumed by ``telemetry_int`` NApp
 
 Changed
 =======

--- a/README.rst
+++ b/README.rst
@@ -109,6 +109,73 @@ Event published when an EVC active state changes due to a UNI going up or down
    "uni_z": evc.uni_z.as_dict()}
   }
 
+kytos/mef_eline.failover_deployed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Event published when an EVC failover_path gets deployed. ``flows`` are the new deployed flows, and ``removed_flows`` are the removed ones.
+
+.. code-block:: python3
+   
+  {
+   evc.id: {
+     "id", evc.id,
+     "evc_id": evc.id,
+     "name": evc.name,
+     "metadata": evc.metadata,
+     "active": evc._active,
+     "enabled": evc._enabled,
+     "uni_a": evc.uni_a.as_dict(),
+     "uni_z": evc.uni_z.as_dict(),
+     "flows": [],
+     "removed_flows": [],
+     "error_reason": string,
+     "current_path": evc.current_path.as_dict(),
+   }
+  }
+
+kytos/mef_eline.failover_link_down
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Event published when an EVC failover_path switches over. ``flows`` are the new deployed flows.
+
+.. code-block:: python3
+   
+  {
+   evc.id: {
+     "id", evc.id,
+     "evc_id": evc.id,
+     "name": evc.name,
+     "metadata": evc.metadata,
+     "active": evc._active,
+     "enabled": evc._enabled,
+     "uni_a": evc.uni_a.as_dict(),
+     "uni_z": evc.uni_z.as_dict(),
+     "flows": [],
+   }
+  }
+
+kytos/mef_eline.failover_old_path
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Event published when an EVC failover related old path gets removed (cleaned up). ``removed_flows`` are the removed flows.
+
+.. code-block:: python3
+   
+  {
+   evc.id: {
+     "id", evc.id,
+     "evc_id": evc.id,
+     "name": evc.name,
+     "metadata": evc.metadata,
+     "active": evc._active,
+     "enabled": evc._enabled,
+     "uni_a": evc.uni_a.as_dict(),
+     "uni_z": evc.uni_z.as_dict(),
+     "removed_flows": [],
+     "current_path": evc.current_path.as_dict(),
+   }
+  }
+
 
 .. TAGs
 

--- a/main.py
+++ b/main.py
@@ -816,7 +816,9 @@ class Main(KytosNApp):
         """Change circuit when link is down or under_mantenance."""
         self.handle_link_down(event)
 
-    def handle_link_down(self, event):  # pylint: disable=too-many-branches
+    # pylint: disable=too-many-branches
+    # pylint: disable=too-many-locals
+    def handle_link_down(self, event):
         """Change circuit when link is down or under_mantenance."""
         link = event.content["link"]
         log.info("Event handle_link_down %s", link)

--- a/main.py
+++ b/main.py
@@ -959,7 +959,11 @@ class Main(KytosNApp):
             if not evc.old_path:
                 continue
             removed_flows = evc.remove_path_flows(evc.old_path)
-            content = map_evc_event_content(evc, removed_flows=removed_flows)
+            content = map_evc_event_content(
+                evc,
+                removed_flows=removed_flows,
+                current_path=evc.current_path.as_dict(),
+            )
             event_contents[evc.id] = content
             evc.old_path = Path([])
         if event_contents:

--- a/models/evc.py
+++ b/models/evc.py
@@ -907,9 +907,9 @@ class EVCDeploy(EVCBase):
         if not self.is_eligible_for_failover_path():
             return False
 
-        out_removed_flows, out_new_flows = {}, {}
+        out_new_flows: dict[str, list[dict]] = {}
         reason = ""
-        out_new_flows = self.remove_path_flows(self.failover_path)
+        out_removed_flows = self.remove_path_flows(self.failover_path)
         self.failover_path = Path([])
 
         for use_path in self.get_failover_path_candidates():

--- a/models/evc.py
+++ b/models/evc.py
@@ -26,7 +26,8 @@ from napps.kytos.mef_eline.utils import (check_disabled_component,
                                          compare_endpoint_trace,
                                          compare_uni_out_trace, emit_event,
                                          make_uni_list, map_dl_vlan,
-                                         map_evc_event_content)
+                                         map_evc_event_content,
+                                         merge_flow_dicts)
 
 from .path import DynamicPathManager, Path
 
@@ -739,12 +740,14 @@ class EVCDeploy(EVCBase):
         if sync:
             self.sync()
 
-    def remove_path_flows(self, path=None, force=True):
-        """Remove all flows from path."""
-        if not path:
-            return
+    def remove_path_flows(
+        self, path=None, force=True
+    ) -> dict[str, list[dict]]:
+        """Remove all flows from path, and return the removed flows."""
+        dpid_flows_match: dict[str, list[dict]] = {}
 
-        dpid_flows_match = {}
+        if not path:
+            return dpid_flows_match
 
         try:
             nni_flows = self._prepare_nni_flows(path)
@@ -792,6 +795,8 @@ class EVCDeploy(EVCBase):
             path.make_vlans_available(self._controller)
         except KytosTagError as err:
             log.error(f"Error when removing path flows: {err}")
+
+        return dpid_flows_match
 
     @staticmethod
     def links_zipped(path=None):
@@ -902,9 +907,11 @@ class EVCDeploy(EVCBase):
         if not self.is_eligible_for_failover_path():
             return False
 
+        out_removed_flows, out_new_flows = {}, {}
         reason = ""
-        self.remove_path_flows(self.failover_path)
+        out_new_flows = self.remove_path_flows(self.failover_path)
         self.failover_path = Path([])
+
         for use_path in self.get_failover_path_candidates():
             if not use_path:
                 continue
@@ -919,18 +926,32 @@ class EVCDeploy(EVCBase):
 
         try:
             if use_path:
-                self._install_nni_flows(use_path)
-                self._install_uni_flows(use_path, skip_in=True)
+                _nni_flows = self._install_nni_flows(use_path)
+                out_new_flows = merge_flow_dicts(out_new_flows, _nni_flows)
+                _uni_flows = self._install_uni_flows(use_path, skip_in=True)
+                out_new_flows = merge_flow_dicts(out_new_flows, _uni_flows)
         except FlowModException as err:
             reason = "Error deploying failover path"
             log.error(
                 f"{reason} for {self}. FlowManager error: {err}"
             )
-            self.remove_path_flows(use_path)
+            _rmed_flows = self.remove_path_flows(use_path)
+            out_new_flows = merge_flow_dicts(out_new_flows, _rmed_flows)
             use_path = Path([])
 
         self.failover_path = use_path
         self.sync()
+
+        if out_new_flows or out_removed_flows:
+            content = {
+                self.id: map_evc_event_content(
+                    self,
+                    flows=out_new_flows,
+                    removed_flows=out_removed_flows,
+                    error_reason=reason,
+                )
+            }
+            emit_event(self._controller, "failover_deployed", content=content)
 
         if not use_path:
             log.warning(
@@ -1064,10 +1085,14 @@ class EVCDeploy(EVCBase):
             nni_flows[in_endpoint.switch.id] = flows
         return nni_flows
 
-    def _install_nni_flows(self, path=None):
+    def _install_nni_flows(
+        self, path=None
+    ) -> dict[str, list[dict]]:
         """Install NNI flows."""
-        for dpid, flows in self._prepare_nni_flows(path).items():
+        nni_flows = self._prepare_nni_flows(path)
+        for dpid, flows in nni_flows.items():
             self._send_flow_mods(dpid, flows)
+        return nni_flows
 
     @staticmethod
     def _get_value_from_uni_tag(uni: UNI):
@@ -1184,12 +1209,16 @@ class EVCDeploy(EVCBase):
 
         return uni_flows
 
-    def _install_uni_flows(self, path=None, skip_in=False, skip_out=False):
+    def _install_uni_flows(
+        self, path=None, skip_in=False, skip_out=False
+    ) -> dict[str, list[dict]]:
         """Install UNI flows."""
         uni_flows = self._prepare_uni_flows(path, skip_in, skip_out)
 
         for (dpid, flows) in uni_flows.items():
             self._send_flow_mods(dpid, flows)
+
+        return uni_flows
 
     @staticmethod
     def _send_flow_mods(dpid, flow_mods, command='flows', force=False):

--- a/models/evc.py
+++ b/models/evc.py
@@ -949,6 +949,7 @@ class EVCDeploy(EVCBase):
                     flows=out_new_flows,
                     removed_flows=out_removed_flows,
                     error_reason=reason,
+                    current_path=self.current_path.as_dict(),
                 )
             }
             emit_event(self._controller, "failover_deployed", content=content)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -8,11 +8,12 @@ from napps.kytos.mef_eline.exceptions import DisabledSwitch
 from napps.kytos.mef_eline.utils import (check_disabled_component,
                                          compare_endpoint_trace,
                                          compare_uni_out_trace,
-                                         get_vlan_tags_and_masks, map_dl_vlan)
+                                         get_vlan_tags_and_masks, map_dl_vlan,
+                                         merge_flow_dicts)
 
 
 # pylint: disable=too-many-public-methods, too-many-lines
-class TestUtils():
+class TestUtils:
     """Test utility functions."""
 
     @pytest.mark.parametrize(
@@ -140,3 +141,25 @@ class TestUtils():
         # There is no disabled component
         uni_z.interface.status = EntityStatus.UP
         check_disabled_component(uni_a, uni_z)
+
+    @pytest.mark.parametrize(
+        "src1,src2,src3,expected",
+        [
+            (
+                {"dpida": [10, 11, 12]},
+                {"dpida": [11, 20, 21]},
+                {"dpidb": [30, 31, 32]},
+                {"dpida": [10, 11, 12, 11, 20, 21], "dpidb": [30, 31, 32]},
+            ),
+            (
+                {"dpida": [10, 11, 12]},
+                {"dpida": [11, 20, 21], "dpidb": [40, 41, 42]},
+                {"dpidb": [30, 31, 32]},
+                {"dpida": [10, 11, 12, 11, 20, 21],
+                 "dpidb": [40, 41, 42, 30, 31, 32]},
+            ),
+        ]
+    )
+    def test_merge_flow_dicts(self, src1, src2, src3, expected) -> None:
+        """test merge flow dicts."""
+        assert merge_flow_dicts({}, src1, src2, src3) == expected

--- a/utils.py
+++ b/utils.py
@@ -28,8 +28,8 @@ def emit_event(controller, name, context="kytos/mef_eline", content=None,
 
 
 def merge_flow_dicts(
-    dst: dict[str, list[dict]], *srcs: list[dict[str, list[dict]]]
-) -> dict[str, list[dict]]:
+    dst: dict[str, list], *srcs: list[dict[str, list]]
+) -> dict[str, list]:
     """Merge srcs dict flows into dst."""
     for src in srcs:
         for k, v in src.items():

--- a/utils.py
+++ b/utils.py
@@ -27,6 +27,19 @@ def emit_event(controller, name, context="kytos/mef_eline", content=None,
     controller.buffers.app.put(event, timeout=timeout)
 
 
+def merge_flow_dicts(
+    dst: dict[str, list[dict]], *srcs: list[dict[str, list[dict]]]
+) -> dict[str, list[dict]]:
+    """Merge srcs dict flows into dst."""
+    for src in srcs:
+        for k, v in src.items():
+            if k not in dst:
+                dst[k] = v
+            else:
+                dst[k].extend(v)
+    return dst
+
+
 async def aemit_event(controller, name, content):
     """Send an asynchronous event"""
     event = KytosEvent(name=name, content=content)


### PR DESCRIPTION
Closes #456
Closes #455

This is on top of PR #471 

### Summary

- See updated changelog file 
- Some methods which didn't return anything now also return the generated flows

### Local Tests

I tested out in the NoviFlow lab, it's working, I'll publish the rest of the local tests on https://github.com/kytos-ng/telemetry_int/issues/90.

### End-to-End Tests

I've dispatched an e2e exec with this branch:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 263 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  7%]
tests/test_e2e_06_topology.py ....                                       [  9%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 24%]
tests/test_e2e_11_mef_eline.py ......                                    [ 26%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 45%]
.                                                                        [ 45%]
tests/test_e2e_14_mef_eline.py x                                         [ 46%]
tests/test_e2e_15_mef_eline.py .....                                     [ 47%]
tests/test_e2e_16_mef_eline.py .                                         [ 48%]
tests/test_e2e_20_flow_manager.py .....................                  [ 56%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 63%]
tests/test_e2e_23_flow_manager.py ..............                         [ 68%]
tests/test_e2e_30_of_lldp.py ....                                        [ 69%]
tests/test_e2e_31_of_lldp.py ...                                         [ 71%]
tests/test_e2e_32_of_lldp.py ...                                         [ 72%]
tests/test_e2e_40_sdntrace.py ..............                             [ 77%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 80%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ............................            [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py ........                                [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
=============================== warnings summary ===============================
------------------------------- start/stop times -------------------------------
= 239 passed, 8 skipped, 9 xfailed, 7 xpassed, 1295 warnings in 12152.90s (3:22:32) =
```
