### PR TITLE
feat: UI checkbox to request that In-band Network Telemetry (INT) gets enabled

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Added
 - Added ``kytos/mef_eline.uni_active_updated`` event
 - Included "id" on EVC mapped content to normalize it with the other models
 - Introduced ``failover_old_path``, ``failover_deployed``, and ``failover_link_down`` events, which will be primarily consumed by ``telemetry_int`` NApp
+- UI checkbox to request that In-band Network Telemetry (INT) gets enabled
 
 Changed
 =======

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -60,6 +60,10 @@
 
            <k-dropdown icon="arrow-right" title="QoS Egress Queue" :options="get_queue_ids"
             v-model:value="queue_id"></k-dropdown>
+
+           <k-checkbox title="Enable INT" v-model:model="enable_int" :value="'enable'"
+                       tooltip="Enable In-band Network Telemetry (INT)"
+           ></k-checkbox>
         </k-accordion-item>
 
         <span v-for="constraint in ['primary_constraints', 'secondary_constraints']">
@@ -233,6 +237,7 @@ module.exports = {
         service_level: "",
         sb_priority: "",
         queue_id: "",
+        enable_int: [],
         dpids: [""],
         hasAutoComplete:false,
         link_options: [],
@@ -430,6 +435,7 @@ module.exports = {
       this.service_level = "";
       this.sb_priority = "";
       this.queue_id = "";
+      this.enable_int = [],
       this.link_options = [];
 
       this.init_path_constraints();
@@ -487,6 +493,9 @@ module.exports = {
         }
         if (this.queue_id !== undefined && this.queue_id !== "") {
             request.queue_id = parseInt(this.queue_id)
+        }
+        if (this.enable_int.includes('enable')) {
+          request.metadata = {telemetry_request: {}}
         }
 
         ['primary_constraints', 'secondary_constraints'].forEach(_type => {


### PR DESCRIPTION
Closes #180 
Closes #382 

This PR is on top of PR #473 

### Summary

- See updated changelog file 
- Even if `telemetry_int` isn't installed this won't create any issue, since it's just setting a metadata value, which `telemetry_int` subscribes to. 

### Local Tests

- UI with the checkbox checked (it set the metadata to request INT accordingly):

![20240612_102746](https://github.com/kytos-ng/mef_eline/assets/1010796/55fa7970-104c-4b6e-82a8-31ccfff6db5c)

```
2024-06-12 10:27:51,472 - INFO [kytos.napps.kytos/mef_eline] (AnyIO worker thread) EVC(3e68dd8231a646, inter_evpl) was deployed.
2024-06-12 10:27:51,472 - INFO [uvicorn.access] (MainThread) 127.0.0.1:52180 - "POST /api/kytos/mef_eline/v2/evc/ HTTP/1.1" 201
2024-06-12 10:27:51,472 - INFO [kytos.napps.kytos/telemetry_int] (MainThread) Handling mef_eline.deployed on EVC id: 3e68dd8231a646
2024-06-12 10:27:51,473 - INFO [kytos.napps.kytos/telemetry_int] (MainThread) Enabling INT on EVC ids: ['3e68dd8231a646'], force: True
2024-06-12 10:27:51,484 - INFO [uvicorn.access] (MainThread) 127.0.0.1:52240 - "POST /api/kytos/pathfinder/v3/ HTTP/1.1" 200
2024-06-12 10:27:51,487 - INFO [uvicorn.access] (MainThread) 127.0.0.1:52244 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending HTTP/1.1" 200
2024-06-12 10:27:51,500 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:02, command: add, force: False,  flows[0, 2]: 
```


![20240612_102757](https://github.com/kytos-ng/mef_eline/assets/1010796/33b68324-2230-45e2-9fa0-c2ae47ff6fd6)

- UI with checkbox not checked:

![20240612_102956](https://github.com/kytos-ng/mef_eline/assets/1010796/79e931c0-c8e4-46f2-95fe-61cd96730e47)



### End-to-End Tests

Not needed for UI
