### PR TITLE
Added lock for EVC deletion

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Changed
 Fixed
 =====
 - Only redeploy when handling ``kytos/topology.link_up`` if a dynamic EVC isn't active
+- Fixed possible EVCs duplication when constant delete requests are sent.
 
 [2023.2.0] - 2024-02-16
 ***********************

--- a/main.py
+++ b/main.py
@@ -439,8 +439,10 @@ class Main(KytosNApp):
                 evc.archive()
                 evc.remove_uni_tags()
                 evc.sync()
-                emit_event(self.controller, "deleted",
-                   content=map_evc_event_content(evc))
+                emit_event(
+                    self.controller, "deleted",
+                    content=map_evc_event_content(evc)
+                )
 
         log.info("EVC removed. %s", evc)
         result = {"response": f"Circuit {circuit_id} removed"}

--- a/main.py
+++ b/main.py
@@ -439,14 +439,14 @@ class Main(KytosNApp):
                 evc.archive()
                 evc.remove_uni_tags()
                 evc.sync()
+                emit_event(self.controller, "deleted",
+                   content=map_evc_event_content(evc))
 
         log.info("EVC removed. %s", evc)
         result = {"response": f"Circuit {circuit_id} removed"}
         status = 200
-
         log.debug("delete_circuit result %s %s", result, status)
-        emit_event(self.controller, "deleted",
-                   content=map_evc_event_content(evc))
+
         return JSONResponse(result, status_code=status)
 
     @rest("/v2/evc/{circuit_id}/metadata", methods=["GET"])

--- a/main.py
+++ b/main.py
@@ -425,7 +425,7 @@ class Main(KytosNApp):
         circuit_id = request.path_params["circuit_id"]
         log.debug("delete_circuit /v2/evc/%s", circuit_id)
         try:
-            evc = self.circuits.pop(circuit_id)
+            evc = self.circuits[circuit_id]
         except KeyError:
             result = f"circuit_id {circuit_id} not found"
             log.debug("delete_circuit result %s %s", result, 404)
@@ -441,6 +441,7 @@ class Main(KytosNApp):
             evc.archive()
             evc.remove_uni_tags()
             evc.sync()
+        self.circuits.pop(circuit_id)
         log.info("EVC removed. %s", evc)
         result = {"response": f"Circuit {circuit_id} removed"}
         status = 200

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,8 @@ class Test(TestCommand):
 
     def run(self):
         """Run tests."""
-        cmd = f"python3 -m pytest tests/ {self.get_args()}"
+        cmd = "python3 -m pytest tests/ --cov-report term-missing"
+        cmd += f" {self.get_args()}"
         try:
             check_call(cmd, shell=True)
         except CalledProcessError as exc:
@@ -114,7 +115,8 @@ class TestCoverage(Test):
 
     def run(self):
         """Run tests quietly and display coverage report."""
-        cmd = f"python3 -m pytest --cov=. tests/ {self.get_args()}"
+        cmd = "python3 -m pytest --cov=. tests/ --cov-report term-missing"
+        cmd += f" {self.get_args()}"
         try:
             check_call(cmd, shell=True)
         except CalledProcessError as exc:


### PR DESCRIPTION
Closes #478 

### Summary

Duplicated EVCs could happen. How?:

So these are the LOG messages from an EVC which got deployed by consistency check:
```
(mef_eline) Got circuits for check number: 3
(AnyIO worker thread) EVC(4b3cd9f35d6243, evc1) was deployed.
(AnyIO worker thread) delete_circuit /v2/evc/4b3cd9f35d6243 last CONSIS: 3          # EVC removed from memory (.pop())
(AnyIO worker thread) Removing EVC(4b3cd9f35d6243, evc1)
(mef_eline) Got circuits for check number: 4                                        # Copy EVCs from memory and DB 
(thread_pool_app_0) Failover path for EVC(4b3cd9f35d6243, evc1) was deployed.
(AnyIO worker thread) EVC removed. EVC(4b3cd9f35d6243, evc1)                        # Confirmation EVC deleted removed DB
127.0.0.1:55234 - "DELETE /api/kytos/mef_eline/v2/evc/4b3cd9f35d6243/ HTTP/1.1" 200
(mef_eline) EVC found in mongodb but unloaded 4b3cd9f35d6243 from check N: 4        # EVC restored
(mef_eline) Failover path for EVC(4b3cd9f35d6243, evc1) was deployed.
```

For an EVC deletion, first  we pop the EVC from memory and then prepare EVC data to for its sync (DB deletion). While EVC was being prepared to be deleted, consistency check copied EVCs from memory (without popped EVC) and DB data (with EVC yet to be deleted). This caused it to be restored.

### Local Tests
Run scripts again and no duplicated EVCs were found.

### End-to-End Tests
```
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  7%]
tests/test_e2e_06_topology.py ....                                       [  9%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 24%]
tests/test_e2e_11_mef_eline.py ......                                    [ 26%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 44%]
.                                                                        [ 45%]
tests/test_e2e_14_mef_eline.py x                                         [ 45%]
tests/test_e2e_15_mef_eline.py .....                                     [ 47%]
tests/test_e2e_16_mef_eline.py .                                         [ 47%]
tests/test_e2e_20_flow_manager.py ......................                 [ 56%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 62%]
tests/test_e2e_23_flow_manager.py ..............                         [ 68%]
tests/test_e2e_30_of_lldp.py .R...                                       [ 69%]
tests/test_e2e_31_of_lldp.py ...                                         [ 70%]
tests/test_e2e_32_of_lldp.py ...                                         [ 71%]
tests/test_e2e_40_sdntrace.py ................                           [ 77%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 80%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ............................            [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .....RR...                              [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]

```