### PR TITLE
release: bumped 2024.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,9 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2024.1.0] - 2024-07-23
+***********************
+
 Added
 =====
 - EVC list now utilizes ``localStorage`` to store ``search_cols`` and make them persistent throughout EVC list usage.
@@ -17,7 +20,6 @@ Added
 Changed
 =======
 - Updated python environment installation from 3.9 to 3.11
-- Updated test dependencies
 - Optimized ``Path.status`` not to depend on a HTTP request
 - Upgraded UI framework to Vue3 
 - ``enable`` is not longer accepted when patching/updating an EVC, using ``enabled`` instead.

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2023.2.0",
+  "version": "2024.1.0",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],


### PR DESCRIPTION
### Summary

release: bumped 2024.1.0

### Local Tests

N/A

### End-to-End Tests

e2e nightly tests are passing. N/A for this PR.
