### PR TITLE
Show error messages from deploying path tries

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,7 @@ Fixed
 =====
 - Only redeploy when handling ``kytos/topology.link_up`` if a dynamic EVC isn't active
 - Fixed possible EVCs duplication when constant delete requests are sent.
+- Improved log when path was not deployed due to TAG availability. Also, in this case, the log was change to error instead of warning.
 
 [2023.2.0] - 2024-02-16
 ***********************

--- a/models/evc.py
+++ b/models/evc.py
@@ -872,7 +872,9 @@ class EVCDeploy(EVCBase):
                 msg = f"{self} was not deployed. No available path was found."
                 if tag_errors:
                     msg = self.add_tag_errors(msg, tag_errors)
-                log.warning(msg)
+                    log.error(msg)
+                else:
+                    log.warning(msg)
                 return False
         except FlowModException as err:
             log.error(
@@ -966,7 +968,9 @@ class EVCDeploy(EVCBase):
             msg = f"Failover path for {self} was not deployed: {reason}."
             if tag_errors:
                 msg = self.add_tag_errors(msg, tag_errors)
-            log.warning(msg)
+                log.error(msg)
+            else:
+                log.warning(msg)
             return False
         log.info(f"Failover path for {self} was deployed.")
         return True


### PR DESCRIPTION
Closes #481

### Summary

Catching error messages from `KytosNoTagAvailableError` for a better log message when a path failed to be deployed. Example: 
`Failover path for EVC(d19049313a3341, evc-111) was not deployed: No available path was found. 1 path was rejected with message: ['Link 78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0 has no vlan available.']`

### Local Tests
Deployed EVC with no available VLANs in the possible path interfaces

### End-to-End Tests
N/A
