### PR TITLE
Corrected wrong flow_mod sent to deletion

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Fixed
+=====
+- Fixed flow mods when deleting ``old_path``
+
 [2024.1.0] - 2024-07-23
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2024.1.0",
+  "version": "2024.1.1",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],

--- a/main.py
+++ b/main.py
@@ -31,7 +31,7 @@ from napps.kytos.mef_eline.scheduler import CircuitSchedule, Scheduler
 from napps.kytos.mef_eline.utils import (aemit_event, check_disabled_component,
                                          emit_event, get_vlan_tags_and_masks,
                                          map_evc_event_content,
-                                         merge_flow_dicts,
+                                         merge_flow_dicts, prepare_delete_flow,
                                          send_flow_mods_event)
 
 
@@ -952,11 +952,15 @@ class Main(KytosNApp):
             with evc.lock:
                 removed_flows = {}
                 try:
-                    nni_flows = evc._prepare_nni_flows(evc.old_path)
-                    uni_flows = evc._prepare_uni_flows(
-                        evc.old_path, skip_in=True
+                    nni_flows = prepare_delete_flow(
+                        evc._prepare_nni_flows(evc.old_path)
                     )
-                    removed_flows = merge_flow_dicts(nni_flows, uni_flows)
+                    uni_flows = prepare_delete_flow(
+                        evc._prepare_uni_flows(evc.old_path, skip_in=True)
+                    )
+                    removed_flows = merge_flow_dicts(
+                        nni_flows, uni_flows
+                    )
                 # pylint: disable=broad-except
                 except Exception:
                     err = traceback.format_exc().replace("\n", ", ")

--- a/models/evc.py
+++ b/models/evc.py
@@ -694,6 +694,7 @@ class EVCDeploy(EVCBase):
                         {
                             "cookie": cookie,
                             "cookie_mask": int(0xffffffffffffffff),
+                            "owner": "mef_eline",
                         }
                     ],
                     "delete",
@@ -725,7 +726,8 @@ class EVCDeploy(EVCBase):
         switches.add(self.uni_z.interface.switch)
         match = {
             "cookie": self.get_cookie(),
-            "cookie_mask": int(0xffffffffffffffff)
+            "cookie_mask": int(0xffffffffffffffff),
+            "owner": "mef_eline",
         }
 
         for switch in switches:
@@ -766,6 +768,7 @@ class EVCDeploy(EVCBase):
                 dpid_flows_match[dpid].append({
                     "cookie": flow["cookie"],
                     "match": flow["match"],
+                    "owner": "mef_eline",
                     "cookie_mask": int(0xffffffffffffffff)
                 })
 
@@ -783,6 +786,7 @@ class EVCDeploy(EVCBase):
                 dpid_flows_match[dpid].append({
                     "cookie": flow["cookie"],
                     "match": flow["match"],
+                    "owner": "mef_eline",
                     "cookie_mask": int(0xffffffffffffffff)
                 })
 

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -1008,7 +1008,8 @@ class TestEVC():
         assert send_flow_mods_mocked.call_count == 5
         assert evc.is_active() is False
         flows = [
-            {"cookie": evc.get_cookie(), "cookie_mask": 18446744073709551615}
+            {"cookie": evc.get_cookie(), "cookie_mask": 18446744073709551615,
+             "owner": "mef_eline"}
         ]
         switch_1 = evc.primary_links[0].endpoint_a.switch
         switch_2 = evc.primary_links[0].endpoint_b.switch
@@ -1076,7 +1077,8 @@ class TestEVC():
         assert send_flow_mods_mocked.call_count == 1
         flows = [
             {"cookie": evc.get_cookie(),
-             "cookie_mask": int(0xffffffffffffffff)}
+             "cookie_mask": int(0xffffffffffffffff),
+             "owner": "mef_eline"}
         ]
         send_flow_mods_mocked.assert_any_call(switch_b.id, flows, 'delete',
                                               force=True)
@@ -1140,7 +1142,8 @@ class TestEVC():
         assert send_flow_mods_mocked.call_count == 3
         flows = [
             {"cookie": evc.get_cookie(),
-             "cookie_mask": int(0xffffffffffffffff)}
+             "cookie_mask": int(0xffffffffffffffff),
+             "owner": "mef_eline"}
         ]
         send_flow_mods_mocked.assert_any_call(switch_a.id, flows, 'delete',
                                               force=True)
@@ -1367,6 +1370,7 @@ class TestEVC():
             {
                 'cookie': 12249790986447749121,
                 'cookie_mask': 18446744073709551615,
+                "owner": "mef_eline",
                 'match': {'in_port': 9, 'dl_vlan':  5}
             },
         ]
@@ -1374,11 +1378,13 @@ class TestEVC():
             {
                 'cookie': 12249790986447749121,
                 'cookie_mask': 18446744073709551615,
+                "owner": "mef_eline",
                 'match': {'in_port': 10, 'dl_vlan': 5}
             },
             {
                 'cookie': 12249790986447749121,
                 'cookie_mask': 18446744073709551615,
+                "owner": "mef_eline",
                 'match': {'in_port': 11, 'dl_vlan': 6}
             },
         ]
@@ -1386,6 +1392,7 @@ class TestEVC():
             {
                 'cookie': 12249790986447749121,
                 'cookie_mask': 18446744073709551615,
+                "owner": "mef_eline",
                 'match': {'in_port': 12, 'dl_vlan': 6}
             },
         ]

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2097,7 +2097,9 @@ class TestMain:
         current_path, map_evc_content, emit_event = [
             MagicMock(), MagicMock(), MagicMock()
         ]
-        send_flows, merge_flows = MagicMock(), MagicMock()
+        send_flows, merge_flows, create_flows = [
+            MagicMock(), MagicMock(), MagicMock()
+        ]
         monkeypatch.setattr(
             "napps.kytos.mef_eline.main.map_evc_event_content",
             map_evc_content
@@ -2113,6 +2115,10 @@ class TestMain:
         monkeypatch.setattr(
             "napps.kytos.mef_eline.main.merge_flow_dicts",
             merge_flows
+        )
+        monkeypatch.setattr(
+            "napps.kytos.mef_eline.main.prepare_delete_flow",
+            create_flows
         )
         merge_flows.return_value = ['1', '2']
         evc1 = create_autospec(EVC, id="1", old_path=["1"],
@@ -2130,6 +2136,7 @@ class TestMain:
         evc2._prepare_uni_flows.assert_called_with(["2"], skip_in=True)
         evc3._prepare_nni_flows.assert_not_called()
         evc3._prepare_uni_flows.assert_not_called()
+        assert create_flows.call_count == 4
         assert emit_event.call_count == 1
         assert emit_event.call_args[0][1] == "failover_old_path"
         assert len(emit_event.call_args[1]["content"]) == 2

--- a/ui/k-info-panel/show_circuit.kytos
+++ b/ui/k-info-panel/show_circuit.kytos
@@ -770,14 +770,14 @@ module.exports = {
             title: 'EVC id: ' + id + ' | name: ' + name + ' redeployed.',
             description: ""
         }
-        _this.$kytos.$emit("setNotification" , notification);
+        _this.$kytos.eventBus.$emit("setNotification" , notification);
       });
       request.fail(function(data) {
         let notification = {
           title: 'Redeploy EVC failed',
           description: 'Error redeploying EVC ' + id +'. ' + data.responseJSON.description
         }
-        _this.$kytos.$emit("setNotification" , notification);
+        _this.$kytos.eventBus.$emit("setNotification" , notification);
       });
     },
     saveEvc: function() {

--- a/utils.py
+++ b/utils.py
@@ -177,3 +177,21 @@ def send_flow_mods_event(
                 "force": force,
             },
         )
+
+
+def prepare_delete_flow(evc_flows: dict[str, list[dict]]):
+    """Create flow mods suited for flow deletion."""
+    dpid_flows: dict[str, list[dict]] = {}
+
+    if not evc_flows:
+        return dpid_flows
+
+    for dpid, flows in evc_flows.items():
+        dpid_flows.setdefault(dpid, [])
+        for flow in flows:
+            dpid_flows[dpid].append({
+                "cookie": flow["cookie"],
+                "match": flow["match"],
+                "cookie_mask": int(0xffffffffffffffff)
+            })
+    return dpid_flows

--- a/utils.py
+++ b/utils.py
@@ -192,6 +192,7 @@ def prepare_delete_flow(evc_flows: dict[str, list[dict]]):
             dpid_flows[dpid].append({
                 "cookie": flow["cookie"],
                 "match": flow["match"],
+                "owner": "mef_eline",
                 "cookie_mask": int(0xffffffffffffffff)
             })
     return dpid_flows


### PR DESCRIPTION
Closes #496
Closes #489 

### Summary

Corrected flow deletion for `old_paths` which was sending incorrect flows.

### Local Tests
Replicate issue

### End-to-End Tests
Created e2e test [PR](https://github.com/kytos-ng/kytos-end-to-end-tests/pull/323) to test this PR.
```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 267 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  7%]
tests/test_e2e_06_topology.py ....                                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 26%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 44%]
.                                                                        [ 44%]
tests/test_e2e_14_mef_eline.py x                                         [ 45%]
tests/test_e2e_15_mef_eline.py .....                                     [ 47%]
tests/test_e2e_16_mef_eline.py ..                                        [ 47%]
tests/test_e2e_20_flow_manager.py ......................                 [ 56%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 62%]
tests/test_e2e_23_flow_manager.py ..............                         [ 68%]
tests/test_e2e_30_of_lldp.py .R...                                       [ 69%]
tests/test_e2e_31_of_lldp.py ...                                         [ 70%]
tests/test_e2e_32_of_lldp.py ...                                         [ 71%]
tests/test_e2e_40_sdntrace.py ...........R.....                          [ 77%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 80%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ............................            [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 94%]
tests/test_e2e_70_kytos_stats.py ........                                [ 97%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
```

