### PR TITLE
Events with flows are deep copied

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,12 +6,13 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
-[2024.1.1] - 2024-08-23
+[2024.1.2] - 2024-08-23
 ***********************
 
 Fixed
 =====
 - Flows sent through an event are deep copies, meaning these can be modified from a subscriber NApp without affecting other subscribers.
+- Added exception handler when getting path for disjointed paths.
 
 [2024.1.1] - 2024-08-23
 ***********************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
-[2024.1.2] - 2024-08-23
+[2024.1.2] - 2024-08-26
 ***********************
 
 Fixed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,13 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 
 Fixed
 =====
+- Flows sent through an event are deep copies, meaning these can be modified from a subscriber NApp without affecting other subscribers.
+
+[2024.1.1] - 2024-08-23
+***********************
+
+Fixed
+=====
 - Fixed flow mods when deleting ``old_path``
 
 [2024.1.0] - 2024-07-23

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2024.1.1",
+  "version": "2024.1.2",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ import pathlib
 import time
 import traceback
 from collections import defaultdict
+from copy import deepcopy
 from threading import Lock
 from typing import Optional
 
@@ -875,7 +876,7 @@ class Main(KytosNApp):
 
         if failover_event_contents:
             emit_event(self.controller, "failover_link_down",
-                       content=failover_event_contents)
+                       content=deepcopy(failover_event_contents))
         send_flow_mods_event(self.controller, switch_flows, 'install')
 
         for evc in evcs_normal:
@@ -970,7 +971,7 @@ class Main(KytosNApp):
                 total_flows = merge_flow_dicts(removed_flows, total_flows)
                 content = map_evc_event_content(
                     evc,
-                    removed_flows=removed_flows,
+                    removed_flows=deepcopy(removed_flows),
                     current_path=evc.current_path.as_dict(),
                 )
                 event_contents[evc.id] = content

--- a/models/evc.py
+++ b/models/evc.py
@@ -964,8 +964,8 @@ class EVCDeploy(EVCBase):
             emit_event(self._controller, "failover_deployed", content={
                 self.id: map_evc_event_content(
                     self,
-                    flows=out_new_flows,
-                    removed_flows=out_removed_flows,
+                    flows=deepcopy(out_new_flows),
+                    removed_flows=deepcopy(out_removed_flows),
                     error_reason=reason,
                     current_path=self.current_path.as_dict(),
                 )

--- a/models/path.py
+++ b/models/path.py
@@ -227,8 +227,16 @@ class DynamicPathManager:
         if not unwanted_links:
             return None
 
-        paths = cls.get_paths(circuit, max_paths=cutoff,
-                              **circuit.secondary_constraints)
+        try:
+            paths = cls.get_paths(circuit, max_paths=cutoff,
+                                  **circuit.secondary_constraints)
+        except PathFinderException as err:
+            log.error(
+                f"{circuit} failed to get disjointed paths from pathfinder."
+                f" Error {err}"
+            )
+            return None
+
         for path in paths:
             links_n, switches_n = cls.get_shared_components(
                 path, unwanted_links, unwanted_switches


### PR DESCRIPTION
Closes #501

### Summary

Flows sent through events were not copies and any modification would affect any NApp listening to the event.

### Local Tests
Added listener for the events that sent flows to verify any modifications to flows were not affecting other listeners.

### End-to-End Tests
N/A
