### PR TITLE
hotfix 2024.1.3: fixed extra removed flows that were being published on event ``"failover_old_path"``

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2024.1.3] - 2024-09-03
+***********************
+
+Fixed
+=====
+- Fixed extra removed flows that were being published on event ``"failover_old_path"``
+
+
 [2024.1.2] - 2024-08-26
 ***********************
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 Fixed
 =====
 - Fixed extra removed flows that were being published on event ``"failover_old_path"``
+- Fixed evc.old_path clean up
 
 
 [2024.1.2] - 2024-08-26

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2024.1.2",
+  "version": "2024.1.3",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],

--- a/main.py
+++ b/main.py
@@ -967,14 +967,15 @@ class Main(KytosNApp):
                     err = traceback.format_exc().replace("\n", ", ")
                     log.error(f"Fail to remove {evc} old_path: {err}")
                     continue
-            if removed_flows:
-                total_flows = merge_flow_dicts(total_flows, removed_flows)
-                content = map_evc_event_content(
-                    evc,
-                    removed_flows=deepcopy(removed_flows),
-                    current_path=evc.current_path.as_dict(),
-                )
-                event_contents[evc.id] = content
+                if removed_flows:
+                    total_flows = merge_flow_dicts(total_flows, removed_flows)
+                    content = map_evc_event_content(
+                        evc,
+                        removed_flows=deepcopy(removed_flows),
+                        current_path=evc.current_path.as_dict(),
+                    )
+                    event_contents[evc.id] = content
+                    evc.old_path = Path([])
         if event_contents:
             send_flow_mods_event(self.controller, total_flows, 'delete')
             emit_event(self.controller, "failover_old_path",

--- a/main.py
+++ b/main.py
@@ -968,7 +968,7 @@ class Main(KytosNApp):
                     log.error(f"Fail to remove {evc} old_path: {err}")
                     continue
             if removed_flows:
-                total_flows = merge_flow_dicts(removed_flows, total_flows)
+                total_flows = merge_flow_dicts(total_flows, removed_flows)
                 content = map_evc_event_content(
                     evc,
                     removed_flows=deepcopy(removed_flows),

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2139,10 +2139,12 @@ class TestMain:
         assert create_flows.call_count == 4
         assert emit_event.call_count == 1
         assert emit_event.call_args[0][1] == "failover_old_path"
+        assert map_evc_content.call_args[1]['removed_flows'] == ['1', '2']
         assert len(emit_event.call_args[1]["content"]) == 2
         assert send_flows.call_count == 1
         assert send_flows.call_args[0][1] == ['1', '2']
         assert send_flows.call_args[0][2] == 'delete'
+        assert merge_flows.call_count == 4
 
     async def test_add_metadata(self):
         """Test method to add metadata"""

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2129,6 +2129,8 @@ class TestMain:
                                current_path=[], lock=MagicMock())
 
         event = KytosEvent(name="e1", content={"evcs": [evc1, evc2, evc3]})
+        assert evc1.old_path
+        assert evc2.old_path
         self.napp.handle_cleanup_evcs_old_path(event)
         evc1._prepare_nni_flows.assert_called_with(["1"])
         evc1._prepare_uni_flows.assert_called_with(["1"], skip_in=True)
@@ -2145,6 +2147,8 @@ class TestMain:
         assert send_flows.call_args[0][1] == ['1', '2']
         assert send_flows.call_args[0][2] == 'delete'
         assert merge_flows.call_count == 4
+        assert not evc1.old_path
+        assert not evc2.old_path
 
     async def test_add_metadata(self):
         """Test method to add metadata"""


### PR DESCRIPTION
Closes #504 

I'm still analyzing other potential related one https://github.com/kytos-ng/telemetry_int/issues/133 though

### Summary

See updated changelog file 

### Local Tests

- Simulated/forced `failover_old_path` events, it no longer is sending extra removed flows

```

2024-09-03 11:30:31,266 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_24) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:01, command: delete, force: True, total_len
gth: 101,  flows[0, 101]: [{'cookie': 12285320825246548803, 'match': {'in_port': 2, 'dl_vlan': 1}, 'owner': 'mef_eline', 'cookie_mask': 18446744073709551615}, {'cookie': 12254970944063
612495, 'match': {'in_port': 2, 'dl_vlan': 3}, 'owner': 'mef_eline', 'cookie_mask': 18446744073709551615}, {'cookie': 12316423280674281796, 'match': {'in_port': 2, 'dl_vlan': 7}, 'owne

2024-09-03 11:30:31,325 - INFO [kytos.napps.kytos/flow_manager] (dynamic_single_0) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:01, command: delete, force: True, total_lengt
h: 386,  flows[0, 200]: [{'cookie': 12141205637170692931, 'match': {'in_port': 2, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 6}, 'owner': 'telemetry_int', 'cookie_mask': 18446744073709
551615, 'priority': 21100, 'table_group': 'evpl', 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'por
t': 17}]}]}, {'cookie': 12141205637170692931, 'match': {'in_port': 2, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 17}, 'owner': 'telemetry_int', 'cookie_mask': 18446744073709551615, 'pr
iority': 21100, 'table_group': 'evpl', 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 17}]}]}



2024-09-03 11:30:31,255 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_27) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:02, command: delete, force: True, total_len
gth: 202,  flows[0, 200]: [{'cookie': 12285320825246548803, 'match': {'in_port': 2, 'dl_vlan': 1}, 'owner': 'mef_eline', 'cookie_mask': 18446744073709551615}, {'cookie': 12285320825246
548803, 'match': {'in_port': 1, 'dl_vlan': 1}, 'owner': 'mef_eline', 'cookie_mask': 18446744073709551615}, {'cookie': 12254970944063612495, 'match': {'in_port': 2, 'dl_vlan': 3}, 'owne


2024-09-03 11:30:35,418 - INFO [kytos.napps.kytos/flow_manager] (dynamic_single_0) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:02, command: delete, force: True, total_lengt
h: 404,  flows[0, 200]: [{'cookie': 12141205637170692931, 'match': {'in_port': 2, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 6}, 'owner': 'telemetry_int', 'cookie_mask': 18446744073709
551615, 'priority': 21100, 'table_group': 'evpl', 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}]}]}, {'cookie': 121412056371706

```

### End-to-End Tests

e2e exec with this branch:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 267 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  7%]
tests/test_e2e_06_topology.py ....                                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 26%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 44%]
.                                                                        [ 44%]
tests/test_e2e_14_mef_eline.py x                                         [ 45%]
tests/test_e2e_15_mef_eline.py .....                                     [ 47%]
tests/test_e2e_16_mef_eline.py ..                                        [ 47%]
tests/test_e2e_20_flow_manager.py ......................                 [ 56%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 62%]
tests/test_e2e_23_flow_manager.py ..............                         [ 68%]
tests/test_e2e_30_of_lldp.py ....                                        [ 69%]
tests/test_e2e_31_of_lldp.py ...                                         [ 70%]
tests/test_e2e_32_of_lldp.py ...                                         [ 71%]
tests/test_e2e_40_sdntrace.py ................                           [ 77%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 80%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ............................            [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 94%]
tests/test_e2e_70_kytos_stats.py ........                                [ 97%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
=============================== warnings summary ===============================
= 243 passed, 8 skipped, 9 xfailed, 7 xpassed, 1295 warnings in 12445.82s (3:27:25) =
```