### PR TITLE
Handled ConnectError

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2024.1.4] - 2024-09-09
+***********************
+
+Fixed
+=====
+- Catching error when searching for ``failover_path`` at kytos start.
+
 [2024.1.3] - 2024-09-03
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2024.1.3",
+  "version": "2024.1.4",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],

--- a/models/path.py
+++ b/models/path.py
@@ -147,6 +147,8 @@ class DynamicPathManager:
             api_reply = httpx.post(endpoint, json=request_data, timeout=10)
         except httpx.TimeoutException as err:
             raise PathFinderException(str(err)) from err
+        except httpx.ConnectError as err:
+            raise PathFinderException(str(err)) from err
 
         if api_reply.status_code >= 400:
             raise PathFinderException(api_reply.text)

--- a/models/path.py
+++ b/models/path.py
@@ -145,9 +145,7 @@ class DynamicPathManager:
         request_data.update(kwargs)
         try:
             api_reply = httpx.post(endpoint, json=request_data, timeout=10)
-        except httpx.TimeoutException as err:
-            raise PathFinderException(str(err)) from err
-        except httpx.ConnectError as err:
+        except httpx.RequestError as err:
             raise PathFinderException(str(err)) from err
 
         if api_reply.status_code >= 400:

--- a/tests/unit/models/test_path.py
+++ b/tests/unit/models/test_path.py
@@ -853,7 +853,8 @@ class TestDynamicPathManager():
     @patch("napps.kytos.mef_eline.models.path.log")
     @patch("time.sleep")
     def test_get_disjoint_paths_error(self, _, mock_log, mock_post):
-        """Test get_disjoint_paths"""
+        """Test get_disjoint_paths with reported errors. These are caught under
+        httpx.RequestError."""
         mock_post.side_effect = TimeoutException('mock')
         unwanted_path = [
             Link(

--- a/tests/unit/models/test_path.py
+++ b/tests/unit/models/test_path.py
@@ -3,7 +3,7 @@ import sys
 from unittest.mock import call, patch, Mock, MagicMock
 import pytest
 from napps.kytos.mef_eline import settings
-from httpx import TimeoutException
+from httpx import TimeoutException, ConnectError
 from kytos.core.common import EntityStatus
 from kytos.core.link import Link
 from kytos.core.switch import Switch
@@ -876,6 +876,11 @@ class TestDynamicPathManager():
         path = DynamicPathManager.get_disjoint_paths(evc, unwanted_path)
         assert len(list(path)) == 0
         assert mock_log.error.call_count == 1
+
+        mock_post.side_effect = ConnectError('mock')
+        path = DynamicPathManager.get_disjoint_paths(evc, unwanted_path)
+        assert len(list(path)) == 0
+        assert mock_log.error.call_count == 2
 
     def test_get_shared_components(self):
         """Test get_shared_components"""


### PR DESCRIPTION
Closes #489

### Summary

Added `httpx.ConnectError` to be caught and trigger a retry

### Local Tests
Created an EVC that cannot have a failover path so when kytos is starting a path search is triggered

### End-to-End Tests
```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 267 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  7%]
tests/test_e2e_06_topology.py ....                                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 26%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 44%]
.                                                                        [ 44%]
tests/test_e2e_14_mef_eline.py x                                         [ 45%]
tests/test_e2e_15_mef_eline.py .....                                     [ 47%]
tests/test_e2e_16_mef_eline.py ..                                        [ 47%]
tests/test_e2e_20_flow_manager.py ......................                 [ 56%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 62%]
tests/test_e2e_23_flow_manager.py ..............                         [ 68%]
tests/test_e2e_30_of_lldp.py .R...                                       [ 69%]
tests/test_e2e_31_of_lldp.py ...                                         [ 70%]
tests/test_e2e_32_of_lldp.py ...                                         [ 71%]
tests/test_e2e_40_sdntrace.py ................                           [ 77%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 80%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
```
The rest:
```
+ python3 -m pytest tests/test_e2e_50_maintenance.py tests/test_e2e_60_of_multi_table.py tests/test_e2e_70_kytos_stats.py tests/test_e2e_80_pathfinder.py --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 49 items

tests/test_e2e_50_maintenance.py ............................            [ 57%]
tests/test_e2e_60_of_multi_table.py .....                                [ 67%]
tests/test_e2e_70_kytos_stats.py ........                                [ 83%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
```
