### PR TITLE
hotfix 2023.2.3: optimized logging when handling interface link up

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [Unreleased]
 ************
 
+[2023.2.3] - 2024-10-04
+***********************
+
+Changed
+=======
+- Optimized logging message of interface Link Up event to be generated only once instead of for each EVC
+
 [2023.2.2] - 2024-06-06
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2023.2.2",
+  "version": "2023.2.3",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],

--- a/main.py
+++ b/main.py
@@ -793,9 +793,9 @@ class Main(KytosNApp):
         """
         Handler for interface link_up events
         """
+        log.info("Event handle_interface_link_up %s", interface)
         for evc in self.get_evcs_by_svc_level():
             with evc.lock:
-                log.info("Event handle_interface_link_up %s", interface)
                 evc.handle_interface_link_up(
                     interface
                 )


### PR DESCRIPTION
Closes #521 

### Summary

See updated changelog file and/or add any other summarized helpful information for reviewers

### Local Tests

Running Kytos/mef_eline with 2023.2.2 without this fix and a bunch of EVCs, during the startup will generate many event for the same interface (basically one event per EVC):

```
2024-10-05 08:07:22,029 - INFO [kytos.napps.kytos/mef_eline] [main.py:798:handle_interface_link_up] (thread_pool_app_301) Event handle_interface_link_up Interface('mia_s10-eth31', 31, Switch('00:00:00:00:00:00:00:10'))
2024-10-05 08:07:22,046 - INFO [kytos.napps.kytos/mef_eline] [main.py:798:handle_interface_link_up] (thread_pool_app_301) Event handle_interface_link_up Interface('mia_s10-eth31', 31, Switch('00:00:00:00:00:00:00:10'))
2024-10-05 08:07:22,060 - INFO [kytos.napps.kytos/mef_eline] [main.py:798:handle_interface_link_up] (thread_pool_app_301) Event handle_interface_link_up Interface('mia_s10-eth31', 31, Switch('00:00:00:00:00:00:00:10'))
2024-10-05 08:07:22,077 - INFO [kytos.napps.kytos/mef_eline] [main.py:798:handle_interface_link_up] (thread_pool_app_301) Event handle_interface_link_up Interface('mia_s10-eth31', 31, Switch('00:00:00:00:00:00:00:10'))
2024-10-05 08:07:22,094 - INFO [kytos.napps.kytos/mef_eline] [main.py:798:handle_interface_link_up] (thread_pool_app_301) Event handle_interface_link_up Interface('mia_s10-eth31', 31, Switch('00:00:00:00:00:00:00:10'))
2024-10-05 08:07:22,108 - INFO [kytos.napps.kytos/mef_eline] [main.py:798:handle_interface_link_up] (thread_pool_app_301) Event handle_interface_link_up Interface('mia_s10-eth31', 31, Switch('00:00:00:00:00:00:00:10'))
2024-10-05 08:07:22,124 - INFO [kytos.napps.kytos/mef_eline] [main.py:798:handle_interface_link_up] (thread_pool_app_301) Event handle_interface_link_up Interface('mia_s10-eth31', 31, Switch('00:00:00:00:00:00:00:10'))
2024-10-05 08:07:22,139 - INFO [kytos.napps.kytos/mef_eline] [main.py:798:handle_interface_link_up] (thread_pool_app_301) Event handle_interface_link_up Interface('mia_s10-eth31', 31, Switch('00:00:00:00:00:00:00:10'))
2024-10-05 08:07:22,152 - INFO [kytos.napps.kytos/mef_eline] [main.py:798:handle_interface_link_up] (thread_pool_app_301) Event handle_interface_link_up Interface('mia_s10-eth31', 31, Switch('00:00:00:00:00:00:00:10'))
2024-10-05 08:07:22,163 - INFO [kytos.napps.kytos/mef_eline] [main.py:798:handle_interface_link_up] (thread_pool_app_301) Event handle_interface_link_up Interface('mia_s10-eth31', 31, Switch('00:00:00:00:00:00:00:10'))
2024-10-05 08:07:22,177 - INFO [kytos.napps.kytos/mef_eline] [main.py:798:handle_interface_link_up] (thread_pool_app_301) Event handle_interface_link_up Interface('mia_s10-eth31', 31, Switch('00:00:00:00:00:00:00:10'))
2024-10-05 08:07:22,187 - INFO [kytos.napps.kytos/mef_eline] [main.py:798:handle_interface_link_up] (thread_pool_app_301) Event handle_interface_link_up Interface('mia_s10-eth31', 31, Switch('00:00:00:00:00:00:00:10'))
2024-10-05 08:07:22,197 - INFO [kytos.napps.kytos/mef_eline] [main.py:798:handle_interface_link_up] (thread_pool_app_301) Event handle_interface_link_up Interface('mia_s10-eth31', 31, Switch('00:00:00:00:00:00:00:10'))
```

We can observe the name of the thread pool that the same interface is being logged multiple times. Indeed, if we account for the number of EVCs and number of active interfaces versus the number of Events, we clearly see the correlation:

```
## Number of EVCs:
# curl -s http://127.0.0.1:8181/api/kytos/mef_eline/v2/evc/ | jq -r '.|length'
290

## Number of active interfaces
# curl -s http://127.0.0.1:8181/api/kytos/topology/v3/interfaces | jq -r '.interfaces[]| .id + " " + (.active|tostring)' | grep -c " true"
258

## Number of interface link UP events:
# egrep "thread_pool_app.*Event handle_interface_link_up" /var/log/kytos.log | wc -l
74820

# python3 -c 'print(258*290)'
74820
```

Additionally, the boot time with the above configuration was 54 seconds.

After applying the fix:

```
## Number of interface link UP events:
# egrep "thread_pool_app.*Event handle_interface_link_up" /var/log/kytos.log | wc -l
258
```

Boot time reduced to 3 seconds.

### End-to-End Tests

Not needed when back porting.