### PR TITLE
remove the submit javascript call from the form to avoid Enter event …

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 Changed
 =======
 - The mef_eline modal now uses the modal component
+- UI: fixed premature submit when pressing Enter during autocomplete on inputs
 
 [2024.1.4] - 2024-09-09
 ***********************

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -208,6 +208,7 @@
                 </div>
             </k-accordion-item>
         </span>
+        </form>
         <k-button tooltip="Request Circuit" title="Request Circuit"
         icon="gear" @click="request_circuit">
         </k-button>
@@ -215,7 +216,6 @@
             <k-button tooltip="List installed EVC" title="List installed EVC"
                      icon="plug" @click="viewPanel">
             </k-button>
-        </form>
         </k-accordion-item>
       </k-accordion>
     </div>


### PR DESCRIPTION
Closes #518 

### Summary

See updated changelog file for summary of the changes. Basically, although the form on mef_eline is [trying to prevent premature submit upon Enter keyboard events](https://github.com/kytos-ng/mef_eline/blob/04b642e4cc58edc30f27d5907cf77485a33d96f9/ui/k-toolbar/main.kytos#L6), the submit event still leaks to the original form and ended up calling the `@click` event will later send the premature request to MEF. After some unsuccessfully tries, I follow one [suggestion](https://stackoverflow.com/a/78484072/27667395) to move the submit `@click` event caller to outside of the form and it worked. Looking into other usages of k-input-auto (sdntrace, sdntrace_cp and pathfinder), they don't even have forms (which makes sense, since we are handling all process on js).

### Local Tests

Tests after fixing Issue #518 and also fixing https://github.com/kytos-ng/ui/issues/90

![Oct-07-2024 05-16-56](https://github.com/user-attachments/assets/0e0e5999-ddca-4922-946a-ec4c6398db9d)

### End-to-End Tests

Does not apply.