### PR TITLE
fixed default collapsed path constraint options on EVC creation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Changed
 =======
 - The mef_eline modal now uses the modal component
 - UI: fixed premature submit when pressing Enter during autocomplete on inputs
+- UI: fixed path constraints fields to be collabsed by default when creating EVC to better usability for listing EVCs
 
 [2024.1.4] - 2024-09-09
 ***********************

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -67,7 +67,7 @@
         </k-accordion-item>
 
         <span v-for="constraint in ['primary_constraints', 'secondary_constraints']">
-            <k-accordion-item :title="constraint_titles[constraint]" ref="accordion_checked">
+            <k-accordion-item :title="constraint_titles[constraint]" :checked=false>
 
                 <k-select :title="constraint_titles.undesired_links" :options="get_link_options()"
                 v-model:value ="form_constraints[constraint].undesired_links"
@@ -611,11 +611,6 @@ module.exports = {
     this.fetch_dpids();
     this.load_topology();
     this.init_path_constraints();
-
-    // Close constraint accordion-item
-    this.$refs.accordion_checked.forEach((item) => {
-      item.checked = false;
-    });
   },
 }
 </script>


### PR DESCRIPTION
Closes #527 

Heads-up: this PR sits on top of PR #524 

### Summary

See updated changelog file.

### Local Tests

After applying the fix and reloading the page, the path constraint options now come all collapsed by default (as it should be):

![Screenshot 2024-10-07 at 06 11 32](https://github.com/user-attachments/assets/4d4ae94d-3c78-4314-933b-a939a4652471)


### End-to-End Tests
