### PR TITLE
backport/hotfix for issue #529 into 2024.1 -- fixed default collapsed path constraint options on EVC creation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 Changed
 =======
 - UI: fixed premature submit when pressing Enter during autocomplete on inputs.
+- UI: fixed path constraints fields to be collabsed by default when creating EVC to better usability for listing EVCs
 
 [2024.1.4] - 2024-09-09
 ***********************

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -67,7 +67,7 @@
         </k-accordion-item>
 
         <span v-for="constraint in ['primary_constraints', 'secondary_constraints']">
-            <k-accordion-item :title="constraint_titles[constraint]" ref="accordion_checked">
+            <k-accordion-item :title="constraint_titles[constraint]" :checked=false>
 
                 <k-select :title="constraint_titles.undesired_links" :options="get_link_options()"
                 v-model:value ="form_constraints[constraint].undesired_links"
@@ -611,11 +611,6 @@ module.exports = {
     this.fetch_dpids();
     this.load_topology();
     this.init_path_constraints();
-
-    // Close constraint accordion-item
-    this.$refs.accordion_checked.forEach((item) => {
-      item.checked = false;
-    });
   },
 }
 </script>


### PR DESCRIPTION
Closes #529 

Heads-up: this PR sits on top of #531 

### Summary

See updated changelog file.

### Local Tests

After applying this patch, we have the following view:

![Screenshot 2024-10-07 at 15 30 56](https://github.com/user-attachments/assets/87f54eca-5c67-4e30-837c-ce41a689c73d)


### End-to-End Tests

N/A