### PR TITLE
backport/hotfix for issue #525 into 2023.2 -- fix premature submit when press Enter while choosing endpoints for EVC creation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,12 +6,13 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [Unreleased]
 ************
 
-[2023.2.3] - 2024-10-04
+[2023.2.3] - 2024-10-07
 ***********************
 
 Changed
 =======
 - Optimized logging message of interface Link Up event to be generated only once instead of for each EVC
+- UI: fixed premature submit when pressing Enter during autocomplete on inputs
 
 [2023.2.2] - 2024-06-06
 ***********************

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -220,6 +220,7 @@
                 </div>
             </k-accordion-item>
         </span>
+        </form>
         <k-button tooltip="Request Circuit" title="Request Circuit"
         icon="gear" :on_click="request_circuit">
         </k-button>
@@ -227,7 +228,6 @@
             <k-button tooltip="List installed EVC" title="List installed EVC"
                      icon="plug" :on_click="viewPanel">
             </k-button>
-        </form>
         </k-accordion-item>
       </k-accordion>
     </div>


### PR DESCRIPTION
Closes #525

Heads-up: this PR sits on top of PR #522

### Summary

See updated changelog file.

### Local Tests

After applying this fix along with https://github.com/kytos-ng/ui/pull/99 we have the following result:

![Oct-07-2024 16-04-36](https://github.com/user-attachments/assets/f0867148-de18-42e3-8ecb-c46cf9390d1e)

### End-to-End Tests

N/A