### PR TITLE
Made changes for vue3sfcloader compatibility k-toolbar

### DIFF
--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -64,6 +64,7 @@
            <k-checkbox title="Enable INT" v-model:model="enable_int" :value="'enable'"
                        tooltip="Enable In-band Network Telemetry (INT)"
            ></k-checkbox>
+          </form>
         </k-accordion-item>
 
         <span v-for="constraint in ['primary_constraints', 'secondary_constraints']">
@@ -204,7 +205,6 @@
                 </div>
             </k-accordion-item>
         </span>
-        </form>
         <k-button tooltip="Request Circuit" title="Request Circuit"
         icon="gear" @click="request_circuit">
         </k-button>

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -199,11 +199,7 @@
                     <k-input icon="arrow-right"
                     placeholder='["blue", "red"]'
                     v-model:value="form_constraints[constraint].not_ownership"
-                    :action="function(val){
-                        try{form_constraints[constraint].metrics.not_ownership = JSON.parse(val)}
-                        catch(e){
-                          if(e instanceof SyntaxError){form_constraints[constraint].metrics.not_ownership=val}
-                          else{throw e}}}"></k-input>
+                    :action="function (val) { set_metrics(val, constraint) }"></k-input>
                   </div>
                 </div>
             </k-accordion-item>
@@ -309,6 +305,13 @@ module.exports = {
     },
   },
   methods: {
+    set_metrics: function (val, constraint) {
+      try { this.form_constraints[constraint].metrics.not_ownership = JSON.parse(val) }
+      catch (e) {
+        if (e instanceof SyntaxError) { this.form_constraints[constraint].metrics.not_ownership = val }
+        else { throw e }
+      }
+    },
     parse_check: function (val) {
       try { return JSON.parse(val) }
       catch (e) {
@@ -556,11 +559,11 @@ module.exports = {
     },
     fetch_dpids: function() {
         var self = this // create a closure to access component in the callback below
-        dataUrl = "/api/kytos/topology/v3/interfaces"
+        let dataUrl = "/api/kytos/topology/v3/interfaces"
         // Autocomplete usage example.
         fetch(dataUrl).then(response => response.json())
                     .then(data => {
-                        dpids = []
+                        let dpids = []
                         for ( const [key,value] of Object.entries( data.interfaces ) ) {
                             let item = key;
                             if(value.name) {


### PR DESCRIPTION
Closes #539 
Closes #520

### Summary

These changes are made to that mef_eline k-toolbar can be loaded in by the vue3-sfc-loader.
The try and catch block would not function within the html it needed to be within its own method.
There were also some undefined variables.

Mef_eline also had an issue with its form tags, since they were incorrectly placed. They were placed inside of a k-accordion-item while still spanning multiple other outside elements. Because of this I placed it inside the single k-accordion-item.

### Local Tests

### End-to-End Tests
