### PR TITLE
Fixed SVLAN not being deleted

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [Unreleased]
 ************
 
+[2023.2.5] - 2024-10-29
+***********************
+
+Fixed
+=====
+- Fixed ``primary_path`` metadata persitent in ``current_path`` and deploying flows with its ``SVLAN``
+
 [2023.2.4] - 2024-10-24
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2023.2.4",
+  "version": "2023.2.5",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],

--- a/models/path.py
+++ b/models/path.py
@@ -9,7 +9,7 @@ from napps.kytos.mef_eline import settings
 from napps.kytos.mef_eline.exceptions import InvalidPath
 
 
-class Path(list, GenericEntity):
+class Path(list[Link], GenericEntity):
     """Class to represent a Path."""
 
     def __eq__(self, other=None):
@@ -38,6 +38,7 @@ class Path(list, GenericEntity):
         for link in self:
             tag_value = link.get_next_available_tag(controller, link.id)
             tag = TAG('vlan', tag_value)
+            link.remove_metadata("s_vlan")
             link.add_metadata("s_vlan", tag)
 
     def make_vlans_available(self, controller):

--- a/tests/unit/models/test_path.py
+++ b/tests/unit/models/test_path.py
@@ -16,7 +16,7 @@ from napps.kytos.mef_eline.exceptions import InvalidPath  # NOQA pycodestyle
 from napps.kytos.mef_eline.models import (  # NOQA pycodestyle
     DynamicPathManager, Path)
 from napps.kytos.mef_eline.tests.helpers import (  # NOQA pycodestyle
-    MockResponse, get_link_mocked, get_mocked_requests, id_to_interface_mock)
+    MockResponse, get_link_mocked, id_to_interface_mock)
 
 
 class TestPath():
@@ -54,9 +54,7 @@ class TestPath():
         current_path = Path()
         assert current_path.status == EntityStatus.DISABLED
 
-    @patch("requests.get", side_effect=get_mocked_requests)
-    def test_status_case_2(self, requests_mocked):
-        # pylint: disable=unused-argument
+    def test_status_case_2(self):
         """Test if link status is DOWN."""
         link1 = get_link_mocked()
         link2 = get_link_mocked()
@@ -84,65 +82,59 @@ class TestPath():
             200,
         )
 
-    @patch("requests.get", side_effect=_mocked_requests_get_status_case_4)
-    def test_status_case_4(self, requests_mocked):
+    def test_status_case_4(self):
         # pylint: disable=unused-argument
         """Test if link status is UP."""
-        link1 = get_link_mocked()
-        link2 = get_link_mocked()
+        link1 = get_link_mocked(status=EntityStatus.UP)
+        link2 = get_link_mocked(status=EntityStatus.UP)
         link1.id = "def"
         link2.id = "abc"
         links = [link1, link2]
         current_path = Path(links)
         assert current_path.status == EntityStatus.UP
 
-    # This method will be used by the mock to replace requests.get
-    def _mocked_requests_get_status_case_5(self):
-        return MockResponse(
-            {
-                "links": {
-                    "abc": {"active": True, "enabled": True},
-                    "def": {"active": False, "enabled": False},
-                }
-            },
-            200,
-        )
-
-    @patch("requests.get", side_effect=_mocked_requests_get_status_case_5)
-    def test_status_case_5(self, requests_mocked):
+    def test_status_case_5(self):
         # pylint: disable=unused-argument
         """Test if link status is UP."""
-        link1 = get_link_mocked()
-        link2 = get_link_mocked()
+        link1 = get_link_mocked(status=EntityStatus.UP)
+        link2 = get_link_mocked(status=EntityStatus.DISABLED)
         link1.id = "def"
         link2.id = "abc"
         links = [link1, link2]
         current_path = Path(links)
         assert current_path.status == EntityStatus.DISABLED
 
-    # This method will be used by the mock to replace requests.get
-    def _mocked_requests_get_status_case_6(self):
-        return MockResponse(
-            {
-                "links": {
-                    "abc": {"active": False, "enabled": False},
-                    "def": {"active": False, "enabled": True},
-                }
-            },
-            200,
-        )
-
-    @patch("requests.get", side_effect=_mocked_requests_get_status_case_6)
-    def test_status_case_6(self, requests_mocked):
+    def test_status_case_6(self):
         # pylint: disable=unused-argument
         """Test if link status is UP."""
-        link1 = get_link_mocked()
-        link2 = get_link_mocked()
+        link1 = get_link_mocked(status=EntityStatus.DISABLED)
+        link2 = get_link_mocked(status=EntityStatus.UP)
         link1.id = "def"
         link2.id = "abc"
         links = [link1, link2]
         current_path = Path(links)
         assert current_path.status == EntityStatus.DISABLED
+
+    def test_status_case_7(self):
+        """Test if link status is DOWN if has one link down."""
+        link1 = get_link_mocked(status=EntityStatus.UP)
+        link2 = get_link_mocked(status=EntityStatus.DOWN)
+        link1.id = "def"
+        link2.id = "abc"
+        links = [link1, link2]
+        current_path = Path(links)
+        assert current_path.status == EntityStatus.DOWN
+
+    def test_status_case_8(self):
+        """Test if status is DOWN if has one endpoint link is mismatched."""
+        link1 = get_link_mocked(status=EntityStatus.UP)
+        link1.endpoint_a.link = None
+        link2 = get_link_mocked(status=EntityStatus.UP)
+        link1.id = "def"
+        link2.id = "abc"
+        links = [link1, link2]
+        current_path = Path(links)
+        assert current_path.status == EntityStatus.DOWN
 
     def test_compare_same_paths(self):
         """Test compare paths with same links."""
@@ -269,6 +261,20 @@ class TestPath():
         path = Path(links)
         with pytest.raises(InvalidPath):
             path.is_valid(switch3, switch6)
+
+    def test_choose_vlans(self):
+        """Test choose_vlans"""
+        link1 = get_link_mocked()
+        link2 = get_link_mocked()
+        link1.id = "def"
+        link2.id = "abc"
+        links = [link1, link2]
+        current_path = Path(links)
+        current_path.choose_vlans(MagicMock())
+        assert link1.remove_metadata.call_count == 1
+        assert link1.add_metadata.call_count == 1
+        assert link2.remove_metadata.call_count == 1
+        assert link2.add_metadata.call_count == 1
 
 
 class TestDynamicPathManager():


### PR DESCRIPTION
Closes #551 

### Summary

- When a link chooses a TAG, remove the SVLAN so the new desired value can be added.
- Backported unit tests from PR [#467](https://github.com/kytos-ng/mef_eline/pull/467)

### Local Tests
Run unit test:
```
tests/unit/test_controllers.py ........                                                                                       [  2%]
tests/unit/test_db_models.py .........................                                                                        [ 11%]
tests/unit/test_main.py ............................................................................                          [ 37%]
tests/unit/test_scheduler.py .........                                                                                        [ 40%]
tests/unit/test_utils.py .........                                                                                            [ 43%]
tests/unit/models/test_evc_base.py .................................                                                          [ 54%]
tests/unit/models/test_evc_deploy.py ....................................................................................     [ 83%]
tests/unit/models/test_link_protection.py ...................                                                                 [ 90%]
tests/unit/models/test_path.py ............................                                                                   [100%]
```
With `dev.in`:
```
-e git+https://github.com/kytos-ng/python-openflow.git@2023.2.0#egg=python-openflow
-e git+https://github.com/kytos-ng/kytos.git@2023.2.0#egg=kytos[dev]
-e .
```
Installed EVC with a `primary_path` that had its metadata populated by an SVLAN

### End-to-End Tests
N/A