### PR TITLE
Removing `s_vlan` before adding new one

### DIFF
--- a/models/path.py
+++ b/models/path.py
@@ -12,7 +12,7 @@ from napps.kytos.mef_eline import settings
 from napps.kytos.mef_eline.exceptions import InvalidPath, PathFinderException
 
 
-class Path(list, GenericEntity):
+class Path(list[Link], GenericEntity):
     """Class to represent a Path."""
 
     def __eq__(self, other=None):
@@ -41,6 +41,7 @@ class Path(list, GenericEntity):
         for link in self:
             tag_value = link.get_next_available_tag(controller, link.id)
             tag = TAG('vlan', tag_value)
+            link.remove_metadata("s_vlan")
             link.add_metadata("s_vlan", tag)
 
     def make_vlans_available(self, controller):

--- a/tests/unit/models/test_path.py
+++ b/tests/unit/models/test_path.py
@@ -259,6 +259,20 @@ class TestPath():
         with pytest.raises(InvalidPath):
             path.is_valid(switch3, switch6)
 
+    def test_choose_vlans(self):
+        """Test choose_vlans"""
+        link1 = get_link_mocked()
+        link2 = get_link_mocked()
+        link1.id = "def"
+        link2.id = "abc"
+        links = [link1, link2]
+        current_path = Path(links)
+        current_path.choose_vlans(MagicMock())
+        assert link1.remove_metadata.call_count == 1
+        assert link1.add_metadata.call_count == 1
+        assert link2.remove_metadata.call_count == 1
+        assert link2.add_metadata.call_count == 1
+
 
 class TestDynamicPathManager():
     """Tests for the DynamicPathManager class"""


### PR DESCRIPTION
Closes #550 

### Summary

Removing `s_vlan` in a link before adding a new one
Missing to update `CHANGELOG`

### Local Tests
Create an EVC with `primary_path` and a chosen `s_vlan`.

### End-to-End Tests
Created [issue](https://github.com/kytos-ng/kytos-end-to-end-tests/issues/332).
