### PR TITLE
Adds migration script to update the default queue_id from `None` to `-1`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Added
+=====
+- Added migration script for updating the default ``queue_id`` from ``None`` to ``-1``
+
 Changed
 =======
 - The mef_eline modal now uses the modal component

--- a/scripts/db/2023.2.0/001_update_default_queue.py
+++ b/scripts/db/2023.2.0/001_update_default_queue.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import os
+import sys
+from kytos.core.db import Mongo
+
+
+
+query = {"queue_id": None, "archived": False}
+update = { "$set": { "queue_id": -1 }}
+
+def update_default_queue_id(mongo: Mongo):
+    db = mongo.client[mongo.db_name]
+    count = db.evcs.update_many(
+        query,
+        update
+    ).modified_count
+
+    print(f"Change default queue_id from None to -1 updated: {count}")
+
+
+def read_evcs(mongo: Mongo):
+    db = mongo.client[mongo.db_name]
+    cursor = db.evcs.find(
+        query
+    )
+    print(f"EVCs that queue_id will be changed from None to -1:")
+    for document in cursor:
+        print("EVC ID: ", document["id"], "\n", document, "\n")
+
+
+
+def main() -> None:
+    """Main function."""
+    mongo = Mongo()
+    cmds = {
+        "update_database": update_default_queue_id,
+        "get_candidates": read_evcs,
+    }
+    try:
+        cmd = os.environ["CMD"]
+        cmds[cmd](mongo)
+    except KeyError:
+        print(
+            f"Please set the 'CMD' env var. \nIt has to be one of these: {list(cmds.keys())}"
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/db/2023.2.0/README.md
+++ b/scripts/db/2023.2.0/README.md
@@ -37,3 +37,33 @@ CMD=aggregate_int_vlan python3 scripts/db/2023.2.0/000_vlan_type_string.py
 CMD=update_database python3 scripts/db/2023.2.0/000_vlan_type_string.py
 ```
 `update_database` changes the value of every outdated TAG from integer to their respective string value.
+
+### Update default queue id fron `None` to -1
+
+[`001_update_default_queue.py`](./001_update_default_queue.py) is a script to update every evc using the old default ``queue_id`` of ``None`` to ``-1``. The default value was changes in `2023.2`.
+
+#### Pre-requisites
+
+- Make sure MongoDB replica set is up and running.
+- Export the following MongnoDB variables accordingly in case your running outside of a container
+
+```
+export MONGO_USERNAME=
+export MONGO_PASSWORD=
+export MONGO_DBNAME=napps
+export MONGO_HOST_SEEDS="mongo1:27017,mongo2:27018,mongo3:27099"
+```
+
+#### How to use
+
+The following `CMD` commands are available:
+
+```
+CMD=get_candidates python3 scripts/db/2023.2.0/001_update_default_queue.py
+```
+`get_candidates` command is to see which EVCs need to be changed by checking if they are using the old default `queue_id` value of `None`. 
+
+```
+CMD=get_candidates python3 scripts/db/2023.2.0/001_update_default_queue.py
+```
+`update_database` changes the value of every outdated `queue_id` to `-1`.


### PR DESCRIPTION
Closes #548. Redo of #557

### Summary

Adds a simple migration script for changing the default queue_id from `None` to `-1`.

### Local Tests

This appears to work, modifying everything with a queue_id of None to -1.
