### PR TITLE
Backport "Fixed issue with parsed data" to 2023.2.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [Unreleased]
 ************
 
+[2023.2.5] - 2024-11-04
+***********************
+
+Fixed
+=====
+- [backport] Fixed issue where non-JSON data was being parsed as JSON data.
+
 [2023.2.4] - 2024-10-24
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2023.2.4",
+  "version": "2023.2.5",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -319,6 +319,13 @@ module.exports = {
     },
   },
   methods: {
+    parse_check: function (val) {
+      try { return JSON.parse(val) }
+      catch (e) {
+        if (e instanceof SyntaxError) { return val }
+        else { throw e }
+      }
+    },
     get_spf_attribute_options: function() {
       /**
        * Method to build option items for spf attribute.
@@ -486,11 +493,11 @@ module.exports = {
         
         if (this.tag_type_a != "" && this.tag_value_a != "") {
             request.uni_a['tag'] = {tag_type: this.tag_type_a,
-                                    value: JSON.parse(this.tag_value_a)}
+                                    value: this.parse_check(this.tag_value_a)}
         }
         if (this.tag_type_z != "" && this.tag_value_z != "") {
             request.uni_z['tag'] = {tag_type: this.tag_type_z,
-                                    value: JSON.parse(this.tag_value_z)}
+                                    value: this.parse_check(this.tag_value_z)}
         }
         if (this.service_level !== undefined && this.service_level !== "") {
             request.service_level = parseInt(this.service_level)


### PR DESCRIPTION
Closes #541 

### Summary

Backport to 2023.2.5.

Issue #541 was being caused because all data typed into the vlan sections of the mef_eline UI were being treated as JSON data and were being parsed as such, which would then throw an error. To fix this, a check was implemented to see if the data was indeed JSON and if it needed to be parsed.

### Local Tests

Tested the UI, and an error was no longer displayed when typing a string into the vlan section.
