### PR TITLE
Backport "Fixed issue with parsed data" to 2024.1.6

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2024.1.6] - 2024-11-04
+***********************
+
+Fixed
+=======
+- UI: fixed issue where non-JSON data was being parsed as JSON data.
+
 [2024.1.5] - 2024-10-07
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2024.1.5",
+  "version": "2024.1.6",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],

--- a/ui/k-info-panel/show_circuit.kytos
+++ b/ui/k-info-panel/show_circuit.kytos
@@ -307,6 +307,13 @@ module.exports = {
     }
   },
   methods: {
+    parse_check: function (val) {
+      try { return JSON.parse(val) }
+      catch (e) {
+        if (e instanceof SyntaxError) { return val }
+        else { throw e }
+      }
+    },
     queue_options: function(queue) {
       let _result = [
         {value: -1, description:"default", selected: (queue.value == -1)},
@@ -807,13 +814,13 @@ module.exports = {
       if(this.endpoints_data["VLAN"][0]["value"]) {
         payload["uni_a"]["tag"] = {
           tag_type: this.TAG_TYPE_VLAN,
-          value: JSON.parse(this.endpoints_data["VLAN"][0]["value"])
+          value: this.parse_check(this.endpoints_data["VLAN"][0]["value"])
         };
       }
       if(this.endpoints_data["VLAN"][1]["value"]) {
         payload["uni_z"]["tag"] = {
           tag_type: this.TAG_TYPE_VLAN,
-          value: JSON.parse(this.endpoints_data["VLAN"][1]["value"])
+          value: this.parse_check(this.endpoints_data["VLAN"][1]["value"])
         };
       }
 

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -309,6 +309,13 @@ module.exports = {
     },
   },
   methods: {
+    parse_check: function (val) {
+      try { return JSON.parse(val) }
+      catch (e) {
+        if (e instanceof SyntaxError) { return val }
+        else { throw e }
+      }
+    },
     get_spf_attribute_options: function() {
       /**
        * Method to build option items for spf attribute.
@@ -479,11 +486,11 @@ module.exports = {
         
         if (this.tag_type_a != "" && this.tag_value_a != "") {
             request.uni_a['tag'] = {tag_type: this.tag_type_a,
-                                    value: JSON.parse(this.tag_value_a)}
+                                    value: this.parse_check(this.tag_value_a)}
         }
         if (this.tag_type_z != "" && this.tag_value_z != "") {
             request.uni_z['tag'] = {tag_type: this.tag_type_z,
-                                    value: JSON.parse(this.tag_value_z)}
+                                    value: this.parse_check(this.tag_value_z)}
         }
         if (this.service_level !== undefined && this.service_level !== "") {
             request.service_level = parseInt(this.service_level)


### PR DESCRIPTION
Closes #541 

Summary

Backport to 2024.1.6.

Issue #541  was being caused because all data typed into the vlan sections of the mef_eline UI were being treated as JSON data and were being parsed as such, which would then throw an error. To fix this, a check was implemented to see if the data was indeed JSON and if it needed to be parsed.

Local Tests
Tested the UI, and an error was no longer displayed when typing a string into the vlan section.
