### PR TITLE
Fixed issue with parsed data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ Added
 =====
 - Added migration script for updating the default ``queue_id`` from ``None`` to ``-1``
 
+Fixed
+=======
+- UI: fixed issue where non-JSON data was being parsed as JSON data.
+
 Changed
 =======
 - The mef_eline modal now uses the modal component

--- a/ui/k-info-panel/show_circuit.kytos
+++ b/ui/k-info-panel/show_circuit.kytos
@@ -288,6 +288,13 @@ module.exports = {
     }
   },
   methods: {
+    parse_check: function (val) {
+      try { return JSON.parse(val) }
+      catch (e) {
+        if (e instanceof SyntaxError) { return val }
+        else { throw e }
+      }
+    },
     queue_options: function(queue) {
       let _result = [
         {value: -1, description:"default", selected: (queue.value == -1)},
@@ -775,13 +782,13 @@ module.exports = {
       if(this.endpoints_data["VLAN"][0]["value"]) {
         payload["uni_a"]["tag"] = {
           tag_type: this.TAG_TYPE_VLAN,
-          value: JSON.parse(this.endpoints_data["VLAN"][0]["value"])
+          value: this.parse_check(this.endpoints_data["VLAN"][0]["value"])
         };
       }
       if(this.endpoints_data["VLAN"][1]["value"]) {
         payload["uni_z"]["tag"] = {
           tag_type: this.TAG_TYPE_VLAN,
-          value: JSON.parse(this.endpoints_data["VLAN"][1]["value"])
+          value: this.parse_check(this.endpoints_data["VLAN"][1]["value"])
         };
       }
 

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -309,6 +309,13 @@ module.exports = {
     },
   },
   methods: {
+    parse_check: function (val) {
+      try { return JSON.parse(val) }
+      catch (e) {
+        if (e instanceof SyntaxError) { return val }
+        else { throw e }
+      }
+    },
     get_spf_attribute_options: function() {
       /**
        * Method to build option items for spf attribute.
@@ -479,11 +486,11 @@ module.exports = {
         
         if (this.tag_type_a != "" && this.tag_value_a != "") {
             request.uni_a['tag'] = {tag_type: this.tag_type_a,
-                                    value: JSON.parse(this.tag_value_a)}
+                                    value: this.parse_check(this.tag_value_a)}
         }
         if (this.tag_type_z != "" && this.tag_value_z != "") {
             request.uni_z['tag'] = {tag_type: this.tag_type_z,
-                                    value: JSON.parse(this.tag_value_z)}
+                                    value: this.parse_check(this.tag_value_z)}
         }
         if (this.service_level !== undefined && this.service_level !== "") {
             request.service_level = parseInt(this.service_level)


### PR DESCRIPTION
Closes #541

Summary
Issue #541 was being caused because all data typed into the vlan sections of the mef_eline UI were being treated as JSON data and were being parsed as such, which would then throw an error. To fix this, a check was implemented to see if the data was indeed JSON and if it needed to be parsed.

Local Tests
Tested the UI, and an error was no longer displayed when typing a string into the vlan section.
