### PR TITLE
Backport "Fixed bug with parsed data in show_circuits.kytos" to 2023.2.5

### DIFF
--- a/ui/k-info-panel/show_circuit.kytos
+++ b/ui/k-info-panel/show_circuit.kytos
@@ -314,6 +314,13 @@ module.exports = {
     }
   },
   methods: {
+    parse_check: function (val) {
+      try { return JSON.parse(val) }
+      catch (e) {
+        if (e instanceof SyntaxError) { return val }
+        else { throw e }
+      }
+    },
     queue_options: function(queue) {
       let _result = [
         {value: -1, description:"default", selected: (queue.value == -1)},
@@ -813,13 +820,13 @@ module.exports = {
       if(this.endpoints_data["VLAN"][0]["value"]) {
         payload["uni_a"]["tag"] = {
           tag_type: this.TAG_TYPE_VLAN,
-          value: JSON.parse(this.endpoints_data["VLAN"][0]["value"])
+          value: this.parse_check(this.endpoints_data["VLAN"][0]["value"])
         };
       }
       if(this.endpoints_data["VLAN"][1]["value"]) {
         payload["uni_z"]["tag"] = {
           tag_type: this.TAG_TYPE_VLAN,
-          value: JSON.parse(this.endpoints_data["VLAN"][1]["value"])
+          value: this.parse_check(this.endpoints_data["VLAN"][1]["value"])
         };
       }
 


### PR DESCRIPTION
Closes #541

### Summary

The mef_eline infopanel had the same issue as the toolbar. Data that was not JSON was being parsed as JSON and this threw an error.

### Local Tests

The mef_eline infopanel was used and no json parse errors ocurred.
