### PR TITLE
Added `take_last` to EVC

### DIFF
--- a/db/models.py
+++ b/db/models.py
@@ -139,6 +139,7 @@ class EVCBaseDoc(DocumentBaseModel):
     metadata: Dict = {}
     active: bool
     enabled: bool
+    take_last: bool
 
     @staticmethod
     def projection() -> Dict:

--- a/models/path.py
+++ b/models/path.py
@@ -36,10 +36,12 @@ class Path(list, GenericEntity):
                 return link
         return None
 
-    def choose_vlans(self, controller):
+    def choose_vlans(self, controller, take_last):
         """Choose the VLANs to be used for the circuit."""
         for link in self:
-            tag_value = link.get_next_available_tag(controller, link.id)
+            tag_value = link.get_next_available_tag(
+                controller, link.id, take_last=take_last
+            )
             tag = TAG('vlan', tag_value)
             link.add_metadata("s_vlan", tag)
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -690,6 +690,8 @@ components:
         request_time:
           type: string
           format: date-time
+        take_last:
+          type: boolean
 
     UpdateCircuit: # Can be referenced via '#/components/schemas/UpdateCircuit'
       type: object
@@ -761,6 +763,8 @@ components:
         metadata:
           type: object
         enabled:
+          type: boolean
+        take_last:
           type: boolean
 
     Tag: # Can be referenced via '#/components/schemas/Tag'

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -5,5 +5,5 @@
 #    pip-compile --output-file requirements/dev.txt requirements/dev.in
 #
 -e git+https://github.com/kytos-ng/python-openflow.git#egg=python-openflow
--e git+https://github.com/kytos-ng/kytos.git#egg=kytos[dev]
+-e git+https://github.com/kytos-ng/kytos.git@feature/last_tag#egg=kytos[dev]
 -e .

--- a/tests/unit/test_controllers.py
+++ b/tests/unit/test_controllers.py
@@ -32,7 +32,8 @@ class TestControllers():
             "priority": 100,
             "active": False,
             "enabled": True,
-            "circuit_scheduler": []
+            "circuit_scheduler": [],
+            "take_last": False,
         }
 
     def test_bootstrap_indexes(self):

--- a/tests/unit/test_db_models.py
+++ b/tests/unit/test_db_models.py
@@ -33,7 +33,8 @@ class TestDBModels():
             "active": False,
             "enabled": False,
             "circuit_scheduler": [],
-            "queue_id": None
+            "queue_id": None,
+            "take_last": False,
         }
         self.evc_update = {
             "uni_a": {
@@ -55,7 +56,7 @@ class TestDBModels():
             "sb_priority": 81,
             "enabled": False,
             "circuit_scheduler": [],
-            "queue_id": None
+            "queue_id": None,
         }
 
     def test_evcbasedoc(self):
@@ -71,6 +72,7 @@ class TestDBModels():
         assert not evc.active
         assert not evc.enabled
         assert not evc.circuit_scheduler
+        assert not evc.take_last
 
     def test_evcupdatedoc(self):
         """Test EVCUpdateDoc model"""


### PR DESCRIPTION
Closes #543

### Summary

First iteration of `take_last`, this [PR](https://github.com/kytos-ng/kytos/pull/515) needs kytos PR to work.
Added option to EVC, `take_last` which indicates which VLAN will be taken next for `current_path` and `failover_path`

### Local Tests
Create an EVC and redeploy

### End-to-End Tests
To be added.
