### PR TITLE
Backport: rechoose S_VLAN from primary path.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,17 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [Unreleased]
 ************
 
+[2023.2.6] - 2024-11-05
+***********************
+
+Changed
+=======
+- ``primary_path``, ``backup_path``, ``primary_links`` and ``backup_links`` now only accept endpoint IDs in the API request content.
+
+Fixed
+=====
+- Fixed ``current_path`` taking the ``s_vlan`` from ``primary_path`` without checking in the interface for availability
+
 [2023.2.5] - 2024-11-04
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2023.2.5",
+  "version": "2023.2.6",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],

--- a/main.py
+++ b/main.py
@@ -1030,7 +1030,7 @@ class Main(KytosNApp):
             #     backup_links_cache
             if "links" in attribute:
                 data[attribute] = [
-                    self._link_from_dict(link) for link in value
+                    self._link_from_dict(link, attribute) for link in value
                 ]
 
             # Ex: current_path,
@@ -1038,7 +1038,7 @@ class Main(KytosNApp):
             #     backup_path
             if "path" in attribute and attribute != "dynamic_backup_path":
                 data[attribute] = Path(
-                    [self._link_from_dict(link) for link in value]
+                    [self._link_from_dict(link, attribute) for link in value]
                 )
 
         return data
@@ -1078,7 +1078,7 @@ class Main(KytosNApp):
         uni = UNI(interface, tag)
         return uni
 
-    def _link_from_dict(self, link_dict):
+    def _link_from_dict(self, link_dict: dict, attribute: str) -> Link:
         """Return a Link object from python dict."""
         id_a = link_dict.get("endpoint_a").get("id")
         id_b = link_dict.get("endpoint_b").get("id")
@@ -1093,7 +1093,8 @@ class Main(KytosNApp):
             raise ValueError(error_msg)
 
         link = Link(endpoint_a, endpoint_b)
-        if "metadata" in link_dict:
+        allowed_paths = {"current_path", "failover_path"}
+        if "metadata" in link_dict and attribute in allowed_paths:
             link.extend_metadata(link_dict.get("metadata"))
 
         s_vlan = link.get_metadata("s_vlan")

--- a/models/path.py
+++ b/models/path.py
@@ -9,7 +9,7 @@ from napps.kytos.mef_eline import settings
 from napps.kytos.mef_eline.exceptions import InvalidPath
 
 
-class Path(list, GenericEntity):
+class Path(list[Link], GenericEntity):
     """Class to represent a Path."""
 
     def __eq__(self, other=None):

--- a/openapi.yml
+++ b/openapi.yml
@@ -403,19 +403,19 @@ components:
         primary_links:
           type: array
           items:
-            $ref: '#/components/schemas/NewLink'
+            $ref: '#/components/schemas/Link'
         backup_links:
           type: array
           items:
-            $ref: '#/components/schemas/NewLink'
+            $ref: '#/components/schemas/Link'
         primary_path:
           type: array
           items:
-            $ref: '#/components/schemas/NewLink'
+            $ref: '#/components/schemas/Link'
         backup_path:
           type: array
           items:
-            $ref: '#/components/schemas/NewLink'
+            $ref: '#/components/schemas/Link'
         primary_constraints:
           $ref: '#/components/schemas/PathConstraints'
         secondary_constraints:
@@ -492,9 +492,17 @@ components:
         id:
           type: string
         endpoint_a:
-          $ref: '#/components/schemas/Endpoint'
+          type: object
+          additionalProperties: false
+          properties:
+            id:
+              type: string
         endpoint_b:
-          $ref: '#/components/schemas/Endpoint'
+          type: object
+          additionalProperties: false
+          properties:
+            id:
+              type: string
 
     Path: # Can be referenced via '#/components/schemas/Path'
       type: object
@@ -619,11 +627,11 @@ components:
         primary_links:
           type: array
           items:
-            $ref: '#/components/schemas/Path'
+            $ref: '#/components/schemas/Link'
         backup_links:
           type: array
           items:
-            $ref: '#/components/schemas/Path'
+            $ref: '#/components/schemas/Link'
 
         current_path:
           type: array
@@ -636,11 +644,11 @@ components:
         primary_path:
           type: array
           items:
-            $ref: '#/components/schemas/NewLink'
+            $ref: '#/components/schemas/Link'
         backup_path:
           type: array
           items:
-            $ref: '#/components/schemas/NewLink'
+            $ref: '#/components/schemas/Link'
         primary_constraints:
           $ref: '#/components/schemas/PathConstraints'
         secondary_constraints:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1682,7 +1682,27 @@ class TestMain:
             "endpoint_b": {"id": "b"}
         }
         with pytest.raises(ValueError):
-            self.napp._link_from_dict(link_dict)
+            self.napp._link_from_dict(link_dict, "current_path")
+
+    def test_link_from_dict_vlan_metadata(self):
+        """Test that link_from_dict only accepts vlans for current_path
+         and failover_path."""
+        intf = MagicMock(id="01:1")
+        self.napp.controller.get_interface_by_id = MagicMock(return_value=intf)
+        link_dict = {
+            'id': 'mock_link',
+            'endpoint_a': {'id': '00:00:00:00:00:00:00:01:4'},
+            'endpoint_b': {'id': '00:00:00:00:00:00:00:05:2'},
+            'metadata': {'s_vlan': {'tag_type': 'vlan', 'value': 1}}
+        }
+        link = self.napp._link_from_dict(link_dict, "current_path")
+        assert link.metadata.get('s_vlan', None)
+
+        link = self.napp._link_from_dict(link_dict, "failover_path")
+        assert link.metadata.get('s_vlan', None)
+
+        link = self.napp._link_from_dict(link_dict, "primary_path")
+        assert link.metadata.get('s_vlan', None) is None
 
     def test_uni_from_dict_non_existent_intf(self):
         """Test _link_from_dict non existent intf."""


### PR DESCRIPTION
Closes #551 

### Summary

Fixed backporting error for paths. `primary_path` S_VLAN was not being updated when passing to `current_path`.

### Local Tests
Modified DB so:
- `"current_path": Path([])`
- `"failover_path": Path([])`
- `"primary_path": **previous current_path with modified s_vlans**`
- `"dynamic_backup_path": false`

### End-to-End Tests
N/A
