### PR TITLE
Added support to avoid previous `current_path` tag for redeployment

### DIFF
--- a/main.py
+++ b/main.py
@@ -552,10 +552,12 @@ class Main(KytosNApp):
     def redeploy(self, request: Request) -> JSONResponse:
         """Endpoint to force the redeployment of an EVC."""
         circuit_id = request.path_params["circuit_id"]
-        try_avoid_same_s_vlan = request.query_params.get("avoid_vlan", "true")
+        try_avoid_same_s_vlan = request.query_params.get(
+            "try_avoid_same_s_vlan", "true"
+        )
         try_avoid_same_s_vlan = try_avoid_same_s_vlan.lower()
         if try_avoid_same_s_vlan not in {"true", "false"}:
-            msg = "Parameter avoid_vlan does not have a valid value."
+            msg = "Parameter try_avoid_same_s_vlan has an invalid value."
             raise HTTPException(400, detail=msg)
         log.debug("redeploy /v2/evc/%s/redeploy", circuit_id)
         try:

--- a/models/evc.py
+++ b/models/evc.py
@@ -579,7 +579,7 @@ class EVCDeploy(EVCBase):
             return True
         return False
 
-    def deploy_to_backup_path(self):
+    def deploy_to_backup_path(self, path_dict: dict = None):
         """Deploy the backup path into the datapaths of this circuit.
 
         If the backup_path attribute is valid and up, this method will try to
@@ -595,17 +595,19 @@ class EVCDeploy(EVCBase):
 
         success = False
         if self.backup_path.status is EntityStatus.UP:
-            success = self.deploy_to_path(self.backup_path)
+            success = self.deploy_to_path(
+                self.backup_path, path_dict=path_dict
+            )
 
         if success:
             return True
 
         if self.dynamic_backup_path or self.is_intra_switch():
-            return self.deploy_to_path()
+            return self.deploy_to_path(path_dict=path_dict)
 
         return False
 
-    def deploy_to_primary_path(self):
+    def deploy_to_primary_path(self, path_dict: dict = None):
         """Deploy the primary path into the datapaths of this circuit.
 
         If the primary_path attribute is valid and up, this method will try to
@@ -617,10 +619,10 @@ class EVCDeploy(EVCBase):
             return True
 
         if self.primary_path.status is EntityStatus.UP:
-            return self.deploy_to_path(self.primary_path)
+            return self.deploy_to_path(self.primary_path, path_dict=path_dict)
         return False
 
-    def deploy(self):
+    def deploy(self, path_dict: dict = None):
         """Deploy EVC to best path.
 
         Best path can be the primary path, if available. If not, the backup
@@ -629,9 +631,9 @@ class EVCDeploy(EVCBase):
         if self.archived:
             return False
         self.enable()
-        success = self.deploy_to_primary_path()
+        success = self.deploy_to_primary_path(path_dict)
         if not success:
-            success = self.deploy_to_backup_path()
+            success = self.deploy_to_backup_path(path_dict)
 
         if success:
             emit_event(self._controller, "deployed",
@@ -711,13 +713,20 @@ class EVCDeploy(EVCBase):
         if sync:
             self.sync()
 
-    def remove_current_flows(self, force=True, sync=True):
+    def remove_current_flows(self, force=True, sync=True, return_path=False):
         """Remove all flows from current path or path intended for
          current path if exists."""
-        switches = set()
+        switches, path_dict = set(), {}
 
         if not self.current_path and not self.is_intra_switch():
-            return
+            return {}
+
+        if return_path:
+            for link in self.current_path:
+                s_vlan = link.metadata.get("s_vlan")
+                if s_vlan:
+                    path_dict[link.id] = s_vlan.value
+
         current_path = self.current_path
         for link in current_path:
             switches.add(link.endpoint_a.switch)
@@ -740,10 +749,12 @@ class EVCDeploy(EVCBase):
             current_path.make_vlans_available(self._controller)
         except KytosTagError as err:
             log.error(f"Error when removing current path flows: {err}")
+            return path_dict
         self.current_path = Path([])
         self.deactivate()
         if sync:
             self.sync()
+        return path_dict
 
     def remove_path_flows(
         self, path=None, force=True
@@ -827,7 +838,7 @@ class EVCDeploy(EVCBase):
         return False
 
     # pylint: disable=too-many-branches, too-many-statements
-    def deploy_to_path(self, path=None):
+    def deploy_to_path(self, path=None, path_dict=None):
         """Install the flows for this circuit.
 
         Procedures to deploy:
@@ -844,10 +855,12 @@ class EVCDeploy(EVCBase):
         """
         self.remove_current_flows(sync=False)
         use_path = path or Path([])
+        if not path_dict:
+            path_dict = {}
         tag_errors = []
         if self.should_deploy(use_path):
             try:
-                use_path.choose_vlans(self._controller)
+                use_path.choose_vlans(self._controller, path_dict=path_dict)
             except KytosNoTagAvailableError as e:
                 tag_errors.append(str(e))
                 use_path = None
@@ -856,7 +869,9 @@ class EVCDeploy(EVCBase):
                 if use_path is None:
                     continue
                 try:
-                    use_path.choose_vlans(self._controller)
+                    use_path.choose_vlans(
+                        self._controller, path_dict=path_dict
+                    )
                     break
                 except KytosNoTagAvailableError as e:
                     tag_errors.append(str(e))

--- a/models/evc.py
+++ b/models/evc.py
@@ -579,7 +579,7 @@ class EVCDeploy(EVCBase):
             return True
         return False
 
-    def deploy_to_backup_path(self, path_dict: dict = None):
+    def deploy_to_backup_path(self, old_path_dict: dict = None):
         """Deploy the backup path into the datapaths of this circuit.
 
         If the backup_path attribute is valid and up, this method will try to
@@ -595,19 +595,17 @@ class EVCDeploy(EVCBase):
 
         success = False
         if self.backup_path.status is EntityStatus.UP:
-            success = self.deploy_to_path(
-                self.backup_path, path_dict=path_dict
-            )
+            success = self.deploy_to_path(self.backup_path, old_path_dict)
 
         if success:
             return True
 
         if self.dynamic_backup_path or self.is_intra_switch():
-            return self.deploy_to_path(path_dict=path_dict)
+            return self.deploy_to_path(old_path_dict=old_path_dict)
 
         return False
 
-    def deploy_to_primary_path(self, path_dict: dict = None):
+    def deploy_to_primary_path(self, old_path_dict: dict = None):
         """Deploy the primary path into the datapaths of this circuit.
 
         If the primary_path attribute is valid and up, this method will try to
@@ -619,10 +617,10 @@ class EVCDeploy(EVCBase):
             return True
 
         if self.primary_path.status is EntityStatus.UP:
-            return self.deploy_to_path(self.primary_path, path_dict=path_dict)
+            return self.deploy_to_path(self.primary_path, old_path_dict)
         return False
 
-    def deploy(self, path_dict: dict = None):
+    def deploy(self, old_path_dict: dict = None):
         """Deploy EVC to best path.
 
         Best path can be the primary path, if available. If not, the backup
@@ -631,9 +629,9 @@ class EVCDeploy(EVCBase):
         if self.archived:
             return False
         self.enable()
-        success = self.deploy_to_primary_path(path_dict)
+        success = self.deploy_to_primary_path(old_path_dict)
         if not success:
-            success = self.deploy_to_backup_path(path_dict)
+            success = self.deploy_to_backup_path(old_path_dict)
 
         if success:
             emit_event(self._controller, "deployed",
@@ -713,10 +711,15 @@ class EVCDeploy(EVCBase):
         if sync:
             self.sync()
 
-    def remove_current_flows(self, force=True, sync=True, return_path=False):
+    def remove_current_flows(
+        self,
+        force=True,
+        sync=True,
+        return_path=False
+    ) -> dict[str, int]:
         """Remove all flows from current path or path intended for
          current path if exists."""
-        switches, path_dict = set(), {}
+        switches, old_path_dict = set(), {}
 
         if not self.current_path and not self.is_intra_switch():
             return {}
@@ -725,7 +728,7 @@ class EVCDeploy(EVCBase):
             for link in self.current_path:
                 s_vlan = link.metadata.get("s_vlan")
                 if s_vlan:
-                    path_dict[link.id] = s_vlan.value
+                    old_path_dict[link.id] = s_vlan.value
 
         current_path = self.current_path
         for link in current_path:
@@ -749,12 +752,12 @@ class EVCDeploy(EVCBase):
             current_path.make_vlans_available(self._controller)
         except KytosTagError as err:
             log.error(f"Error when removing current path flows: {err}")
-            return path_dict
+            return old_path_dict
         self.current_path = Path([])
         self.deactivate()
         if sync:
             self.sync()
-        return path_dict
+        return old_path_dict
 
     def remove_path_flows(
         self, path=None, force=True
@@ -838,7 +841,7 @@ class EVCDeploy(EVCBase):
         return False
 
     # pylint: disable=too-many-branches, too-many-statements
-    def deploy_to_path(self, path=None, path_dict=None):
+    def deploy_to_path(self, path=None, old_path_dict: dict = None):
         """Install the flows for this circuit.
 
         Procedures to deploy:
@@ -855,12 +858,12 @@ class EVCDeploy(EVCBase):
         """
         self.remove_current_flows(sync=False)
         use_path = path or Path([])
-        if not path_dict:
-            path_dict = {}
+        if not old_path_dict:
+            old_path_dict = {}
         tag_errors = []
         if self.should_deploy(use_path):
             try:
-                use_path.choose_vlans(self._controller, path_dict=path_dict)
+                use_path.choose_vlans(self._controller, old_path_dict)
             except KytosNoTagAvailableError as e:
                 tag_errors.append(str(e))
                 use_path = None
@@ -869,9 +872,7 @@ class EVCDeploy(EVCBase):
                 if use_path is None:
                     continue
                 try:
-                    use_path.choose_vlans(
-                        self._controller, path_dict=path_dict
-                    )
+                    use_path.choose_vlans(self._controller, old_path_dict)
                     break
                 except KytosNoTagAvailableError as e:
                     tag_errors.append(str(e))

--- a/models/path.py
+++ b/models/path.py
@@ -36,12 +36,13 @@ class Path(list[Link], GenericEntity):
                 return link
         return None
 
-    def choose_vlans(self, controller, path_dict: dict = None):
+    def choose_vlans(self, controller, old_path_dict: dict = None):
         """Choose the VLANs to be used for the circuit."""
-        path_dict = path_dict if path_dict else {}
+        old_path_dict = old_path_dict if old_path_dict else {}
         for link in self:
             tag_value = link.get_next_available_tag(
-                controller, link.id, try_avoid_value=path_dict.get(link.id)
+                controller, link.id,
+                try_avoid_value=old_path_dict.get(link.id)
             )
             tag = TAG('vlan', tag_value)
             link.add_metadata("s_vlan", tag)

--- a/models/path.py
+++ b/models/path.py
@@ -36,10 +36,13 @@ class Path(list[Link], GenericEntity):
                 return link
         return None
 
-    def choose_vlans(self, controller):
+    def choose_vlans(self, controller, path_dict: dict = None):
         """Choose the VLANs to be used for the circuit."""
+        path_dict = path_dict if path_dict else {}
         for link in self:
-            tag_value = link.get_next_available_tag(controller, link.id)
+            tag_value = link.get_next_available_tag(
+                controller, link.id, try_avoid_value=path_dict.get(link.id)
+            )
             tag = TAG('vlan', tag_value)
             link.add_metadata("s_vlan", tag)
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -142,6 +142,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: avoid_vlan
+          description: Avoid tags from currently deployed current_path.
+          in: query
+          schema:
+            type: boolean
+          required: false
       responses:
         '202':
           description: Accepted

--- a/openapi.yml
+++ b/openapi.yml
@@ -142,7 +142,7 @@ paths:
           required: true
           schema:
             type: string
-        - name: avoid_vlan
+        - name: try_avoid_same_s_vlan
           description: Avoid tags from currently deployed current_path.
           in: query
           schema:

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -827,7 +827,7 @@ class TestEVC():
 
         deployed = evc.deploy_to_backup_path()
 
-        deploy_to_path_mocked.assert_called_once_with(path_dict=None)
+        deploy_to_path_mocked.assert_called_once_with(old_path_dict=None)
         assert deployed is True
 
     @patch("httpx.post")

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -838,6 +838,20 @@ class TestEVC():
         switch_a = Switch("00:00:00:00:00:01")
         switch_b = Switch("00:00:00:00:00:02")
         switch_c = Switch("00:00:00:00:00:03")
+        link_a_b = get_link_mocked(
+            switch_a=switch_a,
+            switch_b=switch_b,
+            endpoint_a_port=9,
+            endpoint_b_port=10,
+            metadata={"s_vlan": Mock(value=5)},
+        )
+        link_b_c = get_link_mocked(
+            switch_a=switch_b,
+            switch_b=switch_c,
+            endpoint_a_port=11,
+            endpoint_b_port=12,
+            metadata={"s_vlan": Mock(value=6)},
+        )
 
         attributes = {
             "controller": get_controller_mock(),
@@ -846,29 +860,20 @@ class TestEVC():
             "uni_z": uni_z,
             "active": True,
             "enabled": True,
-            "primary_links": [
-                get_link_mocked(
-                    switch_a=switch_a,
-                    switch_b=switch_b,
-                    endpoint_a_port=9,
-                    endpoint_b_port=10,
-                    metadata={"s_vlan": 5},
-                ),
-                get_link_mocked(
-                    switch_a=switch_b,
-                    switch_b=switch_c,
-                    endpoint_a_port=11,
-                    endpoint_b_port=12,
-                    metadata={"s_vlan": 6},
-                ),
-            ],
+            "primary_links": [link_a_b, link_b_c]
+
+        }
+
+        expected_old_path = {
+            link_a_b.id: 5,
+            link_b_c.id: 6
         }
 
         evc = EVC(**attributes)
 
         evc.current_path = evc.primary_links
-        evc.remove_current_flows()
-
+        old_path = evc.remove_current_flows(return_path=True)
+        assert old_path == expected_old_path
         assert send_flow_mods_mocked.call_count == 1
         assert evc.is_active() is False
         flows = [

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -827,7 +827,7 @@ class TestEVC():
 
         deployed = evc.deploy_to_backup_path()
 
-        deploy_to_path_mocked.assert_called_once_with()
+        deploy_to_path_mocked.assert_called_once_with(path_dict=None)
         assert deployed is True
 
     @patch("httpx.post")

--- a/tests/unit/models/test_link_protection.py
+++ b/tests/unit/models/test_link_protection.py
@@ -449,7 +449,9 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
         current_handle_link_up = evc.handle_link_up(primary_path[0])
         assert deploy_mocked.call_count == 0
         assert deploy_to_path_mocked.call_count == 1
-        deploy_to_path_mocked.assert_called_once_with(evc.primary_path)
+        deploy_to_path_mocked.assert_called_once_with(
+            evc.primary_path, path_dict=None
+        )
         assert current_handle_link_up
 
     @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.deploy")
@@ -514,7 +516,9 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
 
         assert deploy_mocked.call_count == 0
         assert deploy_to_path_mocked.call_count == 1
-        deploy_to_path_mocked.assert_called_once_with(evc.backup_path)
+        deploy_to_path_mocked.assert_called_once_with(
+            evc.backup_path, path_dict=None
+        )
         assert current_handle_link_up
 
     @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.deploy_to_path")
@@ -578,7 +582,7 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
         current_handle_link_up = evc.handle_link_up(backup_path[0])
 
         assert deploy_to_path_mocked.call_count == 1
-        deploy_to_path_mocked.assert_called_once_with()
+        deploy_to_path_mocked.assert_called_once_with(path_dict=None)
         assert current_handle_link_up
 
     async def test_handle_link_up_case_5(self):

--- a/tests/unit/models/test_link_protection.py
+++ b/tests/unit/models/test_link_protection.py
@@ -449,9 +449,7 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
         current_handle_link_up = evc.handle_link_up(primary_path[0])
         assert deploy_mocked.call_count == 0
         assert deploy_to_path_mocked.call_count == 1
-        deploy_to_path_mocked.assert_called_once_with(
-            evc.primary_path, path_dict=None
-        )
+        deploy_to_path_mocked.assert_called_once_with(evc.primary_path, None)
         assert current_handle_link_up
 
     @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.deploy")
@@ -516,9 +514,7 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
 
         assert deploy_mocked.call_count == 0
         assert deploy_to_path_mocked.call_count == 1
-        deploy_to_path_mocked.assert_called_once_with(
-            evc.backup_path, path_dict=None
-        )
+        deploy_to_path_mocked.assert_called_once_with(evc.backup_path, None)
         assert current_handle_link_up
 
     @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.deploy_to_path")
@@ -582,7 +578,7 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
         current_handle_link_up = evc.handle_link_up(backup_path[0])
 
         assert deploy_to_path_mocked.call_count == 1
-        deploy_to_path_mocked.assert_called_once_with(path_dict=None)
+        deploy_to_path_mocked.assert_called_once_with(old_path_dict=None)
         assert current_handle_link_up
 
     async def test_handle_link_up_case_5(self):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -828,7 +828,9 @@ class TestMain:
         url = f"{self.base_endpoint}/v2/evc/1/redeploy"
         response = await self.api_client.patch(url)
         evc1.remove_failover_flows.assert_called()
-        evc1.remove_current_flows.assert_called()
+        evc1.remove_current_flows.assert_called_with(
+            sync=False, return_path=True
+        )
         assert response.status_code == 202, response.data
 
     async def test_redeploy_evc_disabled(self):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -833,6 +833,20 @@ class TestMain:
         )
         assert response.status_code == 202, response.data
 
+        url = f"{self.base_endpoint}/v2/evc/1/redeploy"
+        url = url + "?try_avoid_same_s_vlan=false"
+        response = await self.api_client.patch(url)
+        evc1.remove_current_flows.assert_called_with(
+            sync=False, return_path=False
+        )
+
+        url = f"{self.base_endpoint}/v2/evc/1/redeploy"
+        url = url + "?try_avoid_same_s_vlan=True"
+        response = await self.api_client.patch(url)
+        evc1.remove_current_flows.assert_called_with(
+            sync=False, return_path=True
+        )
+
     async def test_redeploy_evc_disabled(self):
         """Test endpoint to redeploy an EVC."""
         evc1 = MagicMock()


### PR DESCRIPTION
Closes #543 

### Summary

- API request `PATCH /api/kytos/mef_eline/v2/evc/{evc_id}/redeploy` now allows paramenter `?avoid_vlan=true`.

### Local Tests
Redeployed EVCs with new feature

### End-to-End Tests
Additionally ran e2e test [PR](https://github.com/kytos-ng/kytos-end-to-end-tests/pull/338#pullrequestreview-2478370898):
```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 274 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  7%]
tests/test_e2e_06_topology.py ....                                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x......................  [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 28%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 43%]
.                                                                        [ 43%]
tests/test_e2e_14_mef_eline.py x...                                      [ 45%]
tests/test_e2e_15_mef_eline.py .....                                     [ 47%]
tests/test_e2e_16_mef_eline.py ..                                        [ 47%]
tests/test_e2e_20_flow_manager.py .R.........................            [ 57%]
tests/test_e2e_21_flow_manager.py ...                                    [ 58%]
tests/test_e2e_22_flow_manager.py ...............                        [ 63%]
tests/test_e2e_23_flow_manager.py ..............                         [ 68%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ...                                         [ 71%]
tests/test_e2e_32_of_lldp.py ...                                         [ 72%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
tests/test_e2e_50_maintenance.py ............................            [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 94%]
tests/test_e2e_70_kytos_stats.py ........                                [ 97%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
```

