### PR TITLE
fix: try to handle uni interface up as link up for inter-EVCs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Fixed
+=====
+- Try to handle uni interface up as link up for inter-EVCs
+
 [2024.1.2] - 2024-08-26
 ***********************
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 Fixed
 =====
 - Try to handle uni interface up as link up for inter-EVCs
+- EVCs activation now take into account UNIs statuses before trying to activate
 
 Added
 =====
@@ -42,7 +43,6 @@ Fixed
 - Fixed evc.old_path clean up
 
 
->>>>>>> master
 [2024.1.2] - 2024-08-26
 ***********************
 

--- a/exceptions.py
+++ b/exceptions.py
@@ -33,6 +33,10 @@ class EVCPathNotInstalled(MEFELineException):
     """Exception raised when a path was not installed properly."""
 
 
+class ActivationError(EVCException):
+    """Exception when an EVC couldn't get activated."""
+
+
 class DuplicatedNoTagUNI(MEFELineException):
     """Exception for duplicated no TAG UNI"""
     def __init__(self, msg: str) -> None:

--- a/models/evc.py
+++ b/models/evc.py
@@ -1776,13 +1776,12 @@ class LinkProtection(EVCDeploy):
                     f"Activated {self} due to successful "
                     f"deployment triggered by {interface}"
                 )
-                log.info(msg)
             else:
                 msg = (
                     f"Couldn't activate {self} due to unsuccessful "
                     f"deployment triggered by {interface}"
                 )
-                log.info(msg)
+            log.info(msg)
             return True
         return False
 

--- a/models/evc.py
+++ b/models/evc.py
@@ -876,7 +876,8 @@ class EVCDeploy(EVCBase):
             )
         if self.current_path.status != EntityStatus.UP:
             raise ActivationError(
-                f"Won't be able to activate {self} due to current_path not UP"
+                f"Won't be able to activate {self} due to current_path "
+                f"status {self.current_path.status}"
             )
         self.activate()
         return True
@@ -939,12 +940,13 @@ class EVCDeploy(EVCBase):
             )
             self.remove_current_flows(use_path, sync=True)
             return False
+
+        self.current_path = use_path
         msg = f"{self} was deployed."
         try:
             self.try_to_activate()
         except ActivationError as exc:
             msg = f"{msg} {str(exc)}"
-        self.current_path = use_path
         self.sync()
         log.info(msg)
         return True

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -562,7 +562,7 @@ class TestEVC():
     @patch("napps.kytos.mef_eline.models.evc.EVC._install_nni_flows")
     @patch("napps.kytos.mef_eline.models.evc.EVC._install_uni_flows")
     @patch("napps.kytos.mef_eline.models.evc.EVC._install_direct_uni_flows")
-    @patch("napps.kytos.mef_eline.models.evc.EVC.activate")
+    @patch("napps.kytos.mef_eline.models.evc.EVC.try_to_activate")
     @patch("napps.kytos.mef_eline.models.evc.EVC.should_deploy")
     def test_deploy_successfully(self, *args):
         """Test if all methods to deploy are called."""
@@ -836,7 +836,7 @@ class TestEVC():
     @patch("napps.kytos.mef_eline.models.path.Path.choose_vlans")
     @patch("napps.kytos.mef_eline.models.evc.EVC._install_nni_flows")
     @patch("napps.kytos.mef_eline.models.evc.EVC._install_uni_flows")
-    @patch("napps.kytos.mef_eline.models.evc.EVC.activate")
+    @patch("napps.kytos.mef_eline.models.evc.EVC.try_to_activate")
     @patch("napps.kytos.mef_eline.models.evc.EVC.should_deploy")
     @patch("napps.kytos.mef_eline.models.evc.EVC.discover_new_paths")
     def test_deploy_without_path_case1(self, *args):

--- a/tests/unit/models/test_link_protection.py
+++ b/tests/unit/models/test_link_protection.py
@@ -854,6 +854,8 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
         interface_a.activate()
 
         assert emit_mock.call_count == 1
+        self.evc.try_to_handle_uni_as_link_up = MagicMock()
+        self.evc.try_to_handle_uni_as_link_up.return_value = False
         self.evc.handle_interface_link_up(interface_a)
 
         self.evc.activate.assert_called_once()

--- a/tests/unit/models/test_link_protection.py
+++ b/tests/unit/models/test_link_protection.py
@@ -820,7 +820,7 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
         monkeypatch.setattr("napps.kytos.mef_eline.models.evc.emit_event",
                             emit_mock)
 
-        self.evc.activate = MagicMock()
+        self.evc.try_to_activate = MagicMock()
         self.evc.deactivate = MagicMock()
         self.evc.sync = MagicMock()
 
@@ -829,7 +829,7 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
 
         self.evc.handle_interface_link_up(interface_a)
 
-        self.evc.activate.assert_not_called()
+        self.evc.try_to_activate.assert_not_called()
         self.evc.sync.assert_not_called()
 
         # Test deactivating
@@ -858,6 +858,6 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
         self.evc.try_to_handle_uni_as_link_up.return_value = False
         self.evc.handle_interface_link_up(interface_a)
 
-        self.evc.activate.assert_called_once()
+        self.evc.try_to_activate.assert_called_once()
         assert self.evc.sync.call_count == 2
         assert emit_mock.call_count == 2


### PR DESCRIPTION
Closes #572 
Closes #574 

### Summary

See updated changelog file 

### Local Tests

- Tried out the same case reported on issue 572 no longer happens
- Transition cases locally explored:


1) Dynamic inter EVPL UNI down but going up with UNIs down -> OK
2) Dynamic inter EVPL UNI down but going up with UNIs up -> OK
3) Dynamic inter EVPL UNI down and up with UNIs up with existing path -> OK
4) Dynamic inter EVPL UNI down but going up with UNIs going up concurrently -> OK


5) Static inter EVPL UNI down but going up with UNIs down -> OK
6) Static inter EVPL UNI down but going up with UNIs up -> OK
7) Static inter EVPL UNI down and up with UNIs up with existing path -> OK
8) Static inter EVPL UNI down but going up with UNIs going up concurrently -> OK


9) Intra EVPL initially UP, all UNIs go down then go up -> OK
10) Intra EVPL just one intf go down -> OK


Case 1)

```
kytos $> 2024-11-27 10:17:18,725 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:1 state OFPPS_LIVE
2024-11-27 10:17:18,828 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_13) Event handle_interface_link_up Interface('s1-eth1', 1, Switch('00:00:00:00:00:00:00:01'))
2024-11-27 10:17:18,843 - INFO [uvicorn.access] (MainThread) 127.0.0.1:49860 - "POST /api/kytos/pathfinder/v3/ HTTP/1.1" 200
2024-11-27 10:17:18,844 - WARNING [kytos.napps.kytos/mef_eline] (thread_pool_sb_13) EVC(3acf54c961454d, evpl2) was not deployed. No available path was found.
2024-11-27 10:17:18,844 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_13) Couldn't activate EVC(3acf54c961454d, evpl2) due to unsuccessful deployment triggered by Interface('s1-e
th1', 1, Switch('00:00:00:00:00:00:00:01'))
```

Case 2)

```
2024-11-27 10:25:25,064 - INFO [uvicorn.access] (MainThread) 127.0.0.1:37796 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A03 HTTP/1.1" 202
2024-11-27 10:25:25,070 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_20) EVC(3acf54c961454d, evpl2) was deployed.
2024-11-27 10:25:25,071 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_20) Activated EVC(3acf54c961454d, evpl2) due to successful deployment triggered by Interface('s1-eth1', 1, S
witch('00:00:00:00:00:00:00:01'))
2024-11-27 10:25:25,080 - INFO [uvicorn.access] (MainThread) 127.0.0.1:37806 - "POST /api/kytos/pathfinder/v3/ HTTP/1.1" 200
```

Case 3)

```
kytos $> 2024-11-27 10:28:18,526 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:1 state 0
2024-11-27 10:28:18,526 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:1 state OFPPS_LINK_DOWN
2024-11-27 10:28:18,627 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_22) Event handle_interface_link_down Interface('s1-eth1', 1, Switch('00:00:00:00:00:00:00:01'))
2024-11-27 10:28:18,628 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_22) Deactivating EVC(3acf54c961454d, evpl2). Interfaces: {'00:00:00:00:00:00:00:01:1': {'status': 'DOWN', 's
tatus_reason': {'deactivated'}}}.
2024-11-27 10:28:19,791 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:1 state OFPPS_LIVE
2024-11-27 10:28:19,894 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_4) Event handle_interface_link_up Interface('s1-eth1', 1, Switch('00:00:00:00:00:00:00:01'))
2024-11-27 10:28:19,895 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_4) Activating EVC(3acf54c961454d, evpl2). Interfaces: {'00:00:00:00:00:00:00:01:1': {'status': 'UP', 'status
_reason': set()}, '00:00:00:00:00:00:00:03:1': {'status': 'UP', 'status_reason': set()}}.
```

Case 4)

```
2024-11-27 10:29:38,653 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_3) Couldn't activate EVC(3acf54c961454d, evpl2) due to unsuccessful deployment triggered by Interface('s1-et
h1', 1, Switch('00:00:00:00:00:00:00:01'))
2024-11-27 10:29:47,155 - INFO [kytos.napps.kytos/topology] (thread_pool_app_2) Link(Interface('s2-eth2', 2, Switch('00:00:00:00:00:00:00:02')), Interface('s1-eth3', 3, Switch('00:00:00
:00:00:00:00:01')), 78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0) changed status EntityStatus.UP, reason: link up
2024-11-27 10:29:47,161 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_17) Event handle_link_up Link(Interface('s2-eth2', 2, Switch('00:00:00:00:00:00:00:02')), Interface('s1-eth
3', 3, Switch('00:00:00:00:00:00:00:01')), 78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0)
2024-11-27 10:29:47,190 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request command: add, force: False, dpids: ['00:00:00:00:00:00:00:02'], flows[0, 
2]: [{'match': {'in_port': 2, 'dl_vlan': 2}, 'cookie': 12266344498159764813, 'actions': [{'action_type': 'set_vlan', 'vlan_id': 2}, {'action_type': 'output', 'port': 3}], 'owner': 'mef_
eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}, {'match': {'in_port': 3, 'dl_vlan': 2}, 'cookie': 12266344498159764813, 'actions': [{'action_type': 'set_vlan', 'vlan_i
d': 2}, {'action_type': 'output', 'port': 2}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}]
2024-11-27 10:29:47,190 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Flows received summary:  switches:['00:00:00:00:00:00:00:02'], flows_by_switch:2,  total_flows_leng
th: 2
2024-11-27 10:29:47,202 - INFO [uvicorn.access] (MainThread) 127.0.0.1:54510 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A02 HTTP/1.1" 202
2024-11-27 10:29:47,210 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request command: add, force: False, dpids: ['00:00:00:00:00:00:00:01'], flows[0, 
2]: [{'match': {'in_port': 1, 'dl_vlan': 7}, 'cookie': 12266344498159764813, 'actions': [{'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 2}, {'acti
on_type': 'output', 'port': 3}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}, {'match': {'in_port': 3, 'dl_vlan': 2}, 'cookie': 12266344498159764813, 
'actions': [{'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 1}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}]
2024-11-27 10:29:47,210 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Flows received summary:  switches:['00:00:00:00:00:00:00:01'], flows_by_switch:2,  total_flows_leng
th: 2
2024-11-27 10:29:47,222 - INFO [uvicorn.access] (MainThread) 127.0.0.1:54520 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202
2024-11-27 10:29:47,231 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request command: add, force: False, dpids: ['00:00:00:00:00:00:00:03'], flows[0, 
2]: [{'match': {'in_port': 1, 'dl_vlan': 7}, 'cookie': 12266344498159764813, 'actions': [{'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 2}, {'acti
on_type': 'output', 'port': 2}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}, {'match': {'in_port': 2, 'dl_vlan': 2}, 'cookie': 12266344498159764813, 
'actions': [{'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 1}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}]
2024-11-27 10:29:47,231 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Flows received summary:  switches:['00:00:00:00:00:00:00:03'], flows_by_switch:2,  total_flows_leng
th: 2
2024-11-27 10:29:47,238 - INFO [uvicorn.access] (MainThread) 127.0.0.1:54532 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A03 HTTP/1.1" 202
2024-11-27 10:29:47,244 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_17) EVC(3acf54c961454d, evpl2) was deployed.
```

Case 5)


```
kytos $> 2024-11-27 10:35:00,102 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:1 state OFPPS_LIVE
2024-11-27 10:35:00,204 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_21) Event handle_interface_link_up Interface('s1-eth1', 1, Switch('00:00:00:00:00:00:00:01'))
2024-11-27 10:35:00,205 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_21) Couldn't activate EVC(395b6173614843, epl_static) due to unsuccessful deployment triggered by Interface(
's1-eth1', 1, Switch('00:00:00:00:00:00:00:01'))
```

Case 6)

```
2024-11-27 10:36:29,482 - INFO [uvicorn.access] (MainThread) 127.0.0.1:37728 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A03 HTTP/1.1" 202
2024-11-27 10:36:29,490 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_6) EVC(395b6173614843, epl_static) was deployed. Won't be able to activate EVC(395b6173614843, epl_static) 
due to UNIs: {'00:00:00:00:00:00:00:01:1': {'status': 'DOWN', 'status_reason': {'deactivated'}}}
```

Case 7)

```
kytos $> 2024-11-27 10:37:43,954 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:1 state OFPPS_LIVE
2024-11-27 10:37:44,056 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_12) Event handle_interface_link_up Interface('s1-eth1', 1, Switch('00:00:00:00:00:00:00:01'))
2024-11-27 10:37:44,057 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_12) Activating EVC(395b6173614843, epl_static). Interfaces: {'00:00:00:00:00:00:00:01:1': {'status': 'UP', '
status_reason': set()}, '00:00:00:00:00:00:00:03:1': {'status': 'UP', 'status_reason': set()}}.
kytos $> 

kytos $> 2024-11-27 10:38:01,575 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:1 state 0
2024-11-27 10:38:01,576 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:1 state OFPPS_LINK_DOWN
2024-11-27 10:38:01,678 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_9) Event handle_interface_link_down Interface('s1-eth1', 1, Switch('00:00:00:00:00:00:00:01'))
2024-11-27 10:38:01,679 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_9) Deactivating EVC(395b6173614843, epl_static). Interfaces: {'00:00:00:00:00:00:00:01:1': {'status': 'DOWN'
, 'status_reason': {'deactivated'}}}.
```

Case 8)

```
2024-11-27 10:38:29,550 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_7) Couldn't activate EVC(395b6173614843, epl_static) due to unsuccessful deployment triggered by Interface('
s1-eth1', 1, Switch('00:00:00:00:00:00:00:01'))
kytos $> 2024-11-27 10:38:38,048 - INFO [kytos.napps.kytos/topology] (thread_pool_app_16) Link(Interface('s2-eth2', 2, Switch('00:00:00:00:00:00:00:02')), Interface('s1-eth3', 3, Switch
('00:00:00:00:00:00:00:01')), 78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0) changed status EntityStatus.UP, reason: link up
2024-11-27 10:38:38,057 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_9) Event handle_link_up Link(Interface('s2-eth2', 2, Switch('00:00:00:00:00:00:00:02')), Interface('s1-eth3
', 3, Switch('00:00:00:00:00:00:00:01')), 78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0)
2024-11-27 10:38:38,138 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_9) EVC(395b6173614843, epl_static) was deployed.
```

Case 9)

```

kytos $> 2024-11-27 10:40:51,459 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:1 state 0
2024-11-27 10:40:51,460 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:1 state OFPPS_LINK_DOWN
2024-11-27 10:40:51,562 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_16) Event handle_interface_link_down Interface('s1-eth1', 1, Switch('00:00:00:00:00:00:00:01'))
2024-11-27 10:40:51,563 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_16) Deactivating EVC(dcd45fa4b5f54f, intraevpl). Interfaces: {'00:00:00:00:00:00:00:01:1': {'status': 'DOWN'
, 'status_reason': {'deactivated'}}}.
2024-11-27 10:40:59,559 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:2 state 0
2024-11-27 10:40:59,559 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:2 state OFPPS_LINK_DOWN
2024-11-27 10:40:59,661 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_20) Event handle_interface_link_down Interface('s1-eth2', 2, Switch('00:00:00:00:00:00:00:01'))
2024-11-27 10:41:05,366 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:2 state OFPPS_LIVE
2024-11-27 10:41:05,467 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_2) Event handle_interface_link_up Interface('s1-eth2', 2, Switch('00:00:00:00:00:00:00:01'))
kytos $> 

kytos $> 2024-11-27 10:41:09,399 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:1 state OFPPS_LIVE
2024-11-27 10:41:09,500 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_15) Event handle_interface_link_up Interface('s1-eth1', 1, Switch('00:00:00:00:00:00:00:01'))
2024-11-27 10:41:09,501 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_15) Activating EVC(dcd45fa4b5f54f, intraevpl). Interfaces: {'00:00:00:00:00:00:00:01:1': {'status': 'UP', 's
tatus_reason': set()}, '00:00:00:00:00:00:00:01:2': {'status': 'UP', 'status_reason': set()}}.
kytos $> 
```

Case 10)

```
kytos $> 2024-11-27 10:42:30,539 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:1 state 0
2024-11-27 10:42:30,540 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:1 state OFPPS_LINK_DOWN
2024-11-27 10:42:30,643 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_18) Event handle_interface_link_down Interface('s1-eth1', 1, Switch('00:00:00:00:00:00:00:01'))
2024-11-27 10:42:30,644 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_18) Deactivating EVC(dcd45fa4b5f54f, intraevpl). Interfaces: {'00:00:00:00:00:00:00:01:1': {'status': 'DOWN'
, 'status_reason': {'deactivated'}}}.
```

Link flaps

I stress tested with UNI link flaps 100 quick short flaps, without changing mef_eline.settings.UNI_STATE_CHANGE_DELAY, it behaved well as expected, on APM it's performing well with 100 EVCs the 95 percentile was around 100 ms, later on we might consider increasing UNI_STATE_CHANGE_DELAY, but for now to minimize other changes and since no other immediate issues were observed let's keep as it is:

```
link_flap test iteration 0
[sudo] password for viniarck: 
         waiting for 0.05 secs before next iteration
link_flap test iteration 1
         waiting for 0.05 secs before next iteration
link_flap test iteration 2
         waiting for 0.05 secs before next iteration
link_flap test iteration 3
         waiting for 0.05 secs before next iteration
link_flap test iteration 4
         waiting for 0.05 secs before next iteration

```
![20241127_104914](https://github.com/user-attachments/assets/506bf029-24e7-4750-b806-ae6c01a35459)


### End-to-End Tests

mef_eline test suites including with https://github.com/kytos-ng/kytos-end-to-end-tests/pull/336

```
+ python3 -m pytest tests/ -k mef_eline --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 273 items / 166 deselected / 107 selected
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 38%]
.                                                                        [ 39%]
tests/test_e2e_11_mef_eline.py ......                                    [ 44%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 52%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 90%]
.                                                                        [ 91%]
tests/test_e2e_14_mef_eline.py x                                         [ 92%]
tests/test_e2e_15_mef_eline.py .....                                     [ 97%]
tests/test_e2e_16_mef_eline.py ..                                        [ 99%]
tests/test_e2e_60_of_multi_table.py .                                    [100%]
=============================== warnings summary ===============================
------------------------------- start/stop times -------------------------------
= 86 passed, 6 skipped, 166 deselected, 8 xfailed, 7 xpassed, 407 warnings in 4672.35s (1:17:52) =
```
