### PR TITLE
[release 2023.2.7] backport: fix: try to handle uni interface up as link up for inter-EVCs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [Unreleased]
 ************
 
+[2023.2.7] - 2024-11-27
+***********************
+
+Fixed
+=====
+- Try to handle uni interface up as link up for inter-EVCs
+- EVCs activation now take into account UNIs statuses before trying to activate
+
 [2023.2.6] - 2024-11-05
 ***********************
 

--- a/exceptions.py
+++ b/exceptions.py
@@ -25,6 +25,14 @@ class DisabledSwitch(MEFELineException):
     """Exception for disabled switch in path"""
 
 
+class EVCPathNotInstalled(MEFELineException):
+    """Exception raised when a path was not installed properly."""
+
+
+class ActivationError(EVCException):
+    """Exception when an EVC couldn't get activated."""
+
+
 class DuplicatedNoTagUNI(MEFELineException):
     """Exception for duplicated no TAG UNI"""
     def __init__(self, msg: str) -> None:

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2023.2.6",
+  "version": "2023.2.7",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],

--- a/models/evc.py
+++ b/models/evc.py
@@ -20,7 +20,8 @@ from kytos.core.interface import UNI, Interface, TAGRange
 from kytos.core.link import Link
 from kytos.core.tag_ranges import range_difference
 from napps.kytos.mef_eline import controllers, settings
-from napps.kytos.mef_eline.exceptions import (DuplicatedNoTagUNI,
+from napps.kytos.mef_eline.exceptions import (ActivationError,
+                                              DuplicatedNoTagUNI,
                                               FlowModException, InvalidPath)
 from napps.kytos.mef_eline.utils import (check_disabled_component,
                                          compare_endpoint_trace,
@@ -816,7 +817,62 @@ class EVCDeploy(EVCBase):
 
         return False
 
-    def deploy_to_path(self, path=None):  # pylint: disable=too-many-branches
+    @staticmethod
+    def is_uni_interface_active(
+        *interfaces: Interface
+    ) -> tuple[bool, dict]:
+        """Whether UNIs are active and their status & status_reason."""
+        active = True
+        bad_interfaces = [
+            interface
+            for interface in interfaces
+            if interface.status != EntityStatus.UP
+        ]
+        if bad_interfaces:
+            active = False
+            interfaces = bad_interfaces
+        return active, {
+            interface.id: {
+                'status': interface.status.value,
+                'status_reason': interface.status_reason,
+            }
+            for interface in interfaces
+        }
+
+    def try_to_activate(self) -> bool:
+        """Try to activate the EVC."""
+        if self.is_intra_switch():
+            return self._try_to_activate_intra_evc()
+        return self._try_to_activate_inter_evc()
+
+    def _try_to_activate_intra_evc(self) -> bool:
+        """Try to activate intra EVC."""
+        intf_a, intf_z = self.uni_a.interface, self.uni_z.interface
+        is_active, reason = self.is_uni_interface_active(intf_a, intf_z)
+        if not is_active:
+            raise ActivationError(
+                f"Won't be able to activate {self} due to UNIs: {reason}"
+            )
+        self.activate()
+        return True
+
+    def _try_to_activate_inter_evc(self) -> bool:
+        """Try to activate inter EVC."""
+        intf_a, intf_z = self.uni_a.interface, self.uni_z.interface
+        is_active, reason = self.is_uni_interface_active(intf_a, intf_z)
+        if not is_active:
+            raise ActivationError(
+                f"Won't be able to activate {self} due to UNIs: {reason}"
+            )
+        if self.current_path.status != EntityStatus.UP:
+            raise ActivationError(
+                f"Won't be able to activate {self} due to current_path not UP"
+            )
+        self.activate()
+        return True
+
+    # pylint: disable=too-many-branches, too-many-statements
+    def deploy_to_path(self, path=None):
         """Install the flows for this circuit.
 
         Procedures to deploy:
@@ -868,10 +924,14 @@ class EVCDeploy(EVCBase):
             )
             self.remove_current_flows(use_path)
             return False
-        self.activate()
+        msg = f"{self} was deployed."
+        try:
+            self.try_to_activate()
+        except ActivationError as exc:
+            msg = f"{msg} {str(exc)}"
         self.current_path = use_path
         self.sync()
-        log.info(f"{self} was deployed.")
+        log.info(msg)
         return True
 
     def try_setup_failover_path(self, wait=settings.DEPLOY_EVCS_INTERVAL):
@@ -1670,28 +1730,6 @@ class LinkProtection(EVCDeploy):
         active, _ = self.is_uni_interface_active(interface_a, interface_z)
         return active
 
-    @staticmethod
-    def is_uni_interface_active(
-        *interfaces: Interface
-    ) -> tuple[bool, dict]:
-        """Determine whether a UNI should be active"""
-        active = True
-        bad_interfaces = [
-            interface
-            for interface in interfaces
-            if interface.status != EntityStatus.UP
-        ]
-        if bad_interfaces:
-            active = False
-            interfaces = bad_interfaces
-        return active, {
-            interface.id: {
-                'status': interface.status.value,
-                'status_reason': interface.status_reason,
-            }
-            for interface in interfaces
-        }
-
     def try_to_handle_uni_as_link_up(self, interface: Interface) -> bool:
         """Try to handle UNI as link_up to trigger deployment."""
         if (
@@ -1739,12 +1777,19 @@ class LinkProtection(EVCDeploy):
             }
             for interface in interfaces
         }
-        self.activate()
-        log.info(
-            f"Activating EVC {self.id}. Interfaces: "
-            f"{interface_dicts}."
-        )
-        self.sync()
+        try:
+            self.try_to_activate()
+            log.info(
+                f"Activating {self}. Interfaces: "
+                f"{interface_dicts}."
+            )
+            emit_event(self._controller, "uni_active_updated",
+                       content=map_evc_event_content(self))
+            self.sync()
+        except ActivationError as exc:
+            # On this ctx, no ActivationError isn't expected since the
+            # activation pre-requisites states were checked, so handled as err
+            log.error(f"ActivationError: {str(exc)} when handling {interface}")
 
     def handle_interface_link_down(self, interface):
         """

--- a/models/evc.py
+++ b/models/evc.py
@@ -866,7 +866,8 @@ class EVCDeploy(EVCBase):
             )
         if self.current_path.status != EntityStatus.UP:
             raise ActivationError(
-                f"Won't be able to activate {self} due to current_path not UP"
+                f"Won't be able to activate {self} due to current_path "
+                f"status {self.current_path.status}"
             )
         self.activate()
         return True
@@ -924,12 +925,13 @@ class EVCDeploy(EVCBase):
             )
             self.remove_current_flows(use_path)
             return False
+
+        self.current_path = use_path
         msg = f"{self} was deployed."
         try:
             self.try_to_activate()
         except ActivationError as exc:
             msg = f"{msg} {str(exc)}"
-        self.current_path = use_path
         self.sync()
         log.info(msg)
         return True

--- a/models/evc.py
+++ b/models/evc.py
@@ -1692,6 +1692,28 @@ class LinkProtection(EVCDeploy):
             for interface in interfaces
         }
 
+    def try_to_handle_uni_as_link_up(self, interface: Interface) -> bool:
+        """Try to handle UNI as link_up to trigger deployment."""
+        if (
+            self.current_path.status != EntityStatus.UP
+            and not self.is_intra_switch()
+        ):
+            succeeded = self.handle_link_up(interface)
+            if succeeded:
+                msg = (
+                    f"Activated {self} due to successful "
+                    f"deployment triggered by {interface}"
+                )
+                log.info(msg)
+            else:
+                msg = (
+                    f"Couldn't activate {self} due to unsuccessful "
+                    f"deployment triggered by {interface}"
+                )
+                log.info(msg)
+            return True
+        return False
+
     def handle_interface_link_up(self, interface: Interface):
         """
         Handler for interface link_up events
@@ -1708,6 +1730,9 @@ class LinkProtection(EVCDeploy):
         ]
         if down_interfaces:
             return
+        if self.try_to_handle_uni_as_link_up(interface):
+            return
+
         interface_dicts = {
             interface.id: {
                 'status': interface.status.value,

--- a/models/evc.py
+++ b/models/evc.py
@@ -1704,13 +1704,12 @@ class LinkProtection(EVCDeploy):
                     f"Activated {self} due to successful "
                     f"deployment triggered by {interface}"
                 )
-                log.info(msg)
             else:
                 msg = (
                     f"Couldn't activate {self} due to unsuccessful "
                     f"deployment triggered by {interface}"
                 )
-                log.info(msg)
+            log.info(msg)
             return True
         return False
 


### PR DESCRIPTION
Backport of https://github.com/kytos-ng/mef_eline/pull/573

### Summary

- See updated changelog file 
- Unit tests didn't get backported as usual to simplify

### Local Tests

Run one of the cases mentioned in the linked PR but with kytosd on version `2023.2`

```
     _   __      _
    | | / /     | |
    | |/ / _   _| |_ ___  ___          _ __   __ _
    |    \| | | | __/ _ \/ __| ______ | '_ \ / _` |
    | |\  \ |_| | || (_) \__ \|______|| | | | (_| |
    \_| \_/\__, |\__\___/|___/        |_| |_|\__, |
            __/ |                             __/ |
           |___/                             |___/
    
    Welcome to Kytos SDN Platform!

    Kytos website.: https://kytos-ng.github.io/about/
    Documentation.: https://github.com/kytos-ng/documentation/tree/master/tutorials/napps
    OF Address....: tcp://0.0.0.0:6653
    WEB UI........: http://0.0.0.0:8181/
    Kytos Version.: 2023.2.0


kytos $> 2024-11-27 13:24:29,467 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:4 state OFPPS_LIVE                                 
2024-11-27 13:24:29,468 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:03:3 state OFPPS_LIVE
2024-11-27 13:24:29,570 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_20) Event handle_interface_link_up Interface('s1-eth4', 4, Switch('00:00:00:00:00:00:00:01'))
2024-11-27 13:24:29,571 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_17) Event handle_interface_link_up Interface('s3-eth3', 3, Switch('00:00:00:00:00:00:00:03'))
2024-11-27 13:24:31,297 - INFO [uvicorn.access] (MainThread) 127.0.0.1:56392 - "GET /api/kytos/mef_eline/v2/evc/?archived=false HTTP/1.1" 200
kytos $>                                                                                                                                                                                  

kytos $> 2024-11-27 13:24:39,481 - INFO [kytos.napps.kytos/topology] (thread_pool_app_0) Link(Interface('s3-eth3', 3, Switch('00:00:00:00:00:00:00:03')), Interface('s1-eth4', 4, Switch('
00:00:00:00:00:00:00:01')), c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07) changed status EntityStatus.UP, reason: link up
2024-11-27 13:24:39,484 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_13) Event handle_link_up Link(Interface('s3-eth3', 3, Switch('00:00:00:00:00:00:00:03')), Interface('s1-eth4
', 4, Switch('00:00:00:00:00:00:00:01')), c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07)
2024-11-27 13:24:39,493 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:03, command: delete, force: True,  flows[0, 1]:
 [{'cookie': 12303728060200799552, 'cookie_mask': 18446744073709551615}]
2024-11-27 13:24:39,506 - INFO [uvicorn.access] (MainThread) 127.0.0.1:56402 - "POST /api/kytos/flow_manager/v2/delete/00%3A00%3A00%3A00%3A00%3A00%3A00%3A03 HTTP/1.1" 202
2024-11-27 13:24:39,516 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: delete, force: True,  flows[0, 1]:
 [{'cookie': 12303728060200799552, 'cookie_mask': 18446744073709551615}]
2024-11-27 13:24:39,521 - INFO [uvicorn.access] (MainThread) 127.0.0.1:56418 - "POST /api/kytos/flow_manager/v2/delete/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202
2024-11-27 13:24:39,540 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: add, force: False,  flows[0, 2]: [
{'match': {'in_port': 1}, 'cookie': 12303728060200799552, 'actions': [{'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output', 
'port': 4}], 'owner': 'mef_eline', 'table_group': 'epl', 'table_id': 0, 'priority': 10000}, {'match': {'in_port': 4, 'dl_vlan': 1}, 'cookie': 12303728060200799552, 'actions': [{'action_t
ype': 'pop_vlan'}, {'action_type': 'output', 'port': 1}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}]
2024-11-27 13:24:39,546 - INFO [uvicorn.access] (MainThread) 127.0.0.1:56432 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202
2024-11-27 13:24:39,553 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:03, command: add, force: False,  flows[0, 2]: [
{'match': {'in_port': 1}, 'cookie': 12303728060200799552, 'actions': [{'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output', 
'port': 3}], 'owner': 'mef_eline', 'table_group': 'epl', 'table_id': 0, 'priority': 10000}, {'match': {'in_port': 3, 'dl_vlan': 1}, 'cookie': 12303728060200799552, 'actions': [{'action_t
ype': 'pop_vlan'}, {'action_type': 'output', 'port': 1}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}]
2024-11-27 13:24:39,558 - INFO [uvicorn.access] (MainThread) 127.0.0.1:56440 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A03 HTTP/1.1" 202
2024-11-27 13:24:39,563 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_13) EVC(bf9f7b99464d40, epl_static) was deployed. Won't be able to activate EVC(bf9f7b99464d40, epl_static) 
due to UNIs: {'00:00:00:00:00:00:00:01:1': {'status': 'DOWN', 'status_reason': {'deactivated'}}}
kytos $>                                                                                                                                                                                  

kytos $> 2024-11-27 13:24:45,276 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:1 state OFPPS_LIVE                                 
2024-11-27 13:24:45,379 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_7) Event handle_interface_link_up Interface('s1-eth1', 1, Switch('00:00:00:00:00:00:00:01'))
2024-11-27 13:24:45,380 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_7) Activating EVC(bf9f7b99464d40, epl_static). Interfaces: {'00:00:00:00:00:00:00:01:1': {'status': 'UP', 'st
atus_reason': set()}, '00:00:00:00:00:00:00:03:1': {'status': 'UP', 'status_reason': set()}}.
```

### End-to-End Tests

In progress in the linked PR
