### PR TITLE
[release 2024.1.7] backport: fix: try to handle uni interface up as link up for inter-EVCs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2024.1.7] - 2024-11-27
+***********************
+
+Fixed
+=====
+- Try to handle uni interface up as link up for inter-EVCs
+- EVCs activation now take into account UNIs statuses before trying to activate
+
 [2024.1.6] - 2024-11-04
 ***********************
 

--- a/exceptions.py
+++ b/exceptions.py
@@ -33,6 +33,10 @@ class EVCPathNotInstalled(MEFELineException):
     """Exception raised when a path was not installed properly."""
 
 
+class ActivationError(EVCException):
+    """Exception when an EVC couldn't get activated."""
+
+
 class DuplicatedNoTagUNI(MEFELineException):
     """Exception for duplicated no TAG UNI"""
     def __init__(self, msg: str) -> None:

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2024.1.6",
+  "version": "2024.1.7",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],

--- a/models/evc.py
+++ b/models/evc.py
@@ -1776,13 +1776,12 @@ class LinkProtection(EVCDeploy):
                     f"Activated {self} due to successful "
                     f"deployment triggered by {interface}"
                 )
-                log.info(msg)
             else:
                 msg = (
                     f"Couldn't activate {self} due to unsuccessful "
                     f"deployment triggered by {interface}"
                 )
-                log.info(msg)
+            log.info(msg)
             return True
         return False
 

--- a/models/evc.py
+++ b/models/evc.py
@@ -876,7 +876,8 @@ class EVCDeploy(EVCBase):
             )
         if self.current_path.status != EntityStatus.UP:
             raise ActivationError(
-                f"Won't be able to activate {self} due to current_path not UP"
+                f"Won't be able to activate {self} due to current_path "
+                f"status {self.current_path.status}"
             )
         self.activate()
         return True
@@ -939,12 +940,13 @@ class EVCDeploy(EVCBase):
             )
             self.remove_current_flows(use_path, sync=True)
             return False
+
+        self.current_path = use_path
         msg = f"{self} was deployed."
         try:
             self.try_to_activate()
         except ActivationError as exc:
             msg = f"{msg} {str(exc)}"
-        self.current_path = use_path
         self.sync()
         log.info(msg)
         return True


### PR DESCRIPTION
Backport of https://github.com/kytos-ng/mef_eline/pull/573

### Summary

- See updated changelog file 
- Unit tests didn't get backported as usual to simplify

### Local Tests

Run one of the cases mentioned in the linked PR but with kytosd on version `2024.1`

```
     _   __      _
    | | / /     | |
    | |/ / _   _| |_ ___  ___          _ __   __ _
    |    \| | | | __/ _ \/ __| ______ | '_ \ / _` |
    | |\  \ |_| | || (_) \__ \|______|| | | | (_| |
    \_| \_/\__, |\__\___/|___/        |_| |_|\__, |
            __/ |                             __/ |
           |___/                             |___/
    
    Welcome to Kytos SDN Platform!

    Kytos website.: https://kytos-ng.github.io/about/
    Documentation.: https://github.com/kytos-ng/documentation/tree/master/tutorials/napps
    OF Address....: tcp://0.0.0.0:6653
    WEB UI........: http://0.0.0.0:8181/
    Kytos Version.: 2024.1.2

kytos $> 2024-11-27 13:43:54,377 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:1 state OFPPS_LIVE
2024-11-27 13:43:54,478 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_19) Event handle_interface_link_up Interface('s1-eth1', 1, Switch('00:00:00:00:00:00:00:01'))
2024-11-27 13:43:54,500 - INFO [uvicorn.access] (MainThread) 127.0.0.1:44046 - "POST /api/kytos/pathfinder/v3/ HTTP/1.1" 200
2024-11-27 13:43:54,514 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: add, force: False, total_length: 2
,  flows[0, 2]: [{'match': {'in_port': 1, 'dl_vlan': 301}, 'cookie': 12269258295837687372, 'actions': [{'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id
': 1}, {'action_type': 'output', 'port': 4}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}, {'match': {'in_port': 4, 'dl_vlan': 1}, 'cookie': 1226925829
5837687372, 'actions': [{'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 1}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}]
2024-11-27 13:43:54,524 - INFO [uvicorn.access] (MainThread) 127.0.0.1:44052 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202
2024-11-27 13:43:54,541 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:03, command: add, force: False, total_length: 2
,  flows[0, 2]: [{'match': {'in_port': 1, 'dl_vlan': 301}, 'cookie': 12269258295837687372, 'actions': [{'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id
': 1}, {'action_type': 'output', 'port': 3}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}, {'match': {'in_port': 3, 'dl_vlan': 1}, 'cookie': 1226925829
5837687372, 'actions': [{'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 1}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}]
2024-11-27 13:43:54,556 - INFO [uvicorn.access] (MainThread) 127.0.0.1:44054 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A03 HTTP/1.1" 202
2024-11-27 13:43:54,559 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_19) EVC(45296a2ceb7e4c, inter_evpl) was deployed.
2024-11-27 13:43:54,560 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_19) Activated EVC(45296a2ceb7e4c, inter_evpl) due to successful deployment triggered by Interface('s1-eth1', 
1, Switch('00:00:00:00:00:00:00:01'))
kytos $> 
```

### End-to-End Tests

In progress in the linked PR
