### PR TITLE
Backport: Added redeploy feature to avoid s_vlan

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [Unreleased]
 ************
 
+[2023.2.8] - 2024-12-05
+***********************
+
+Added
+=====
+- Added added paramenter support for redeployment, ``PATCH v2/evc/{evc_id}/redeploy?try_avoid_same_s_vlan=true``. By default it will try to avoid ``s_vlan`` from ``current_path`` links.
+
 [2023.2.7] - 2024-11-27
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2023.2.7",
+  "version": "2023.2.8",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],

--- a/models/path.py
+++ b/models/path.py
@@ -33,10 +33,14 @@ class Path(list[Link], GenericEntity):
                 return link
         return None
 
-    def choose_vlans(self, controller):
+    def choose_vlans(self, controller, old_path_dict: dict = None):
         """Choose the VLANs to be used for the circuit."""
+        old_path_dict = old_path_dict if old_path_dict else {}
         for link in self:
-            tag_value = link.get_next_available_tag(controller, link.id)
+            tag_value = link.get_next_available_tag(
+                controller, link.id,
+                try_avoid_value=old_path_dict.get(link.id)
+            )
             tag = TAG('vlan', tag_value)
             link.add_metadata("s_vlan", tag)
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -140,6 +140,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: try_avoid_same_s_vlan
+          description: Avoid tags from currently deployed current_path.
+          in: query
+          schema:
+            type: boolean
+          required: false
       responses:
         '202':
           description: Accepted

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -541,14 +541,14 @@ class TestEVC():
     @patch("napps.kytos.mef_eline.models.evc.EVC._install_nni_flows")
     @patch("napps.kytos.mef_eline.models.evc.EVC._install_uni_flows")
     @patch("napps.kytos.mef_eline.models.evc.EVC._install_direct_uni_flows")
-    @patch("napps.kytos.mef_eline.models.evc.EVC.activate")
+    @patch("napps.kytos.mef_eline.models.evc.EVC.try_to_activate")
     @patch("napps.kytos.mef_eline.models.evc.EVC.should_deploy")
     def test_deploy_successfully(self, *args):
         """Test if all methods to deploy are called."""
         # pylint: disable=too-many-locals
         (
             should_deploy_mock,
-            activate_mock,
+            try_to_activate_mock,
             install_direct_uni_flows_mock,
             install_uni_flows_mock,
             install_nni_flows,
@@ -567,7 +567,7 @@ class TestEVC():
         deployed = evc.deploy_to_path(evc.primary_links)
 
         assert should_deploy_mock.call_count == 1
-        assert activate_mock.call_count == 1
+        assert try_to_activate_mock.call_count == 1
         assert install_uni_flows_mock.call_count == 1
         assert install_nni_flows.call_count == 1
         assert chose_vlans_mock.call_count == 1
@@ -578,7 +578,7 @@ class TestEVC():
         evc = self.create_evc_intra_switch()
         assert evc.deploy_to_path(evc.primary_links) is True
         assert install_direct_uni_flows_mock.call_count == 1
-        assert activate_mock.call_count == 2
+        assert try_to_activate_mock.call_count == 2
         assert log_mock.info.call_count == 2
         log_mock.info.assert_called_with(f"{evc} was deployed.")
 
@@ -588,7 +588,7 @@ class TestEVC():
     @patch("napps.kytos.mef_eline.models.path.Path.choose_vlans")
     @patch("napps.kytos.mef_eline.models.evc.EVC._install_nni_flows")
     @patch("napps.kytos.mef_eline.models.evc.EVC._install_uni_flows")
-    @patch("napps.kytos.mef_eline.models.evc.EVC.activate")
+    @patch("napps.kytos.mef_eline.models.evc.EVC.try_to_activate")
     @patch("napps.kytos.mef_eline.models.evc.EVC.should_deploy")
     @patch("napps.kytos.mef_eline.models.EVC.sync")
     def test_deploy_fail(self, *args):
@@ -597,7 +597,7 @@ class TestEVC():
         (
             sync_mock,
             should_deploy_mock,
-            activate_mock,
+            try_to_activate_mock,
             install_uni_flows_mock,
             install_nni_flows,
             choose_vlans_mock,
@@ -617,12 +617,12 @@ class TestEVC():
 
         assert discover_new_paths_mock.call_count == 1
         assert should_deploy_mock.call_count == 1
-        assert activate_mock.call_count == 0
+        assert try_to_activate_mock.call_count == 0
         assert install_uni_flows_mock.call_count == 0
         assert install_nni_flows.call_count == 0
         assert choose_vlans_mock.call_count == 0
         assert log_mock.info.call_count == 0
-        assert sync_mock.call_count == 1
+        assert sync_mock.call_count == 0
         assert deployed is False
 
         # NoTagAvailable on static path
@@ -800,7 +800,7 @@ class TestEVC():
 
         deployed = evc.deploy_to_backup_path()
 
-        deploy_to_path_mocked.assert_called_once_with()
+        deploy_to_path_mocked.assert_called_once_with(old_path_dict=None)
         assert deployed is True
 
     @patch("requests.post")
@@ -809,7 +809,7 @@ class TestEVC():
     @patch("napps.kytos.mef_eline.models.path.Path.choose_vlans")
     @patch("napps.kytos.mef_eline.models.evc.EVC._install_nni_flows")
     @patch("napps.kytos.mef_eline.models.evc.EVC._install_uni_flows")
-    @patch("napps.kytos.mef_eline.models.evc.EVC.activate")
+    @patch("napps.kytos.mef_eline.models.evc.EVC.try_to_activate")
     @patch("napps.kytos.mef_eline.models.evc.EVC.should_deploy")
     @patch("napps.kytos.mef_eline.models.evc.EVC.discover_new_paths")
     def test_deploy_without_path_case1(self, *args):
@@ -818,7 +818,7 @@ class TestEVC():
         (
             discover_new_paths_mocked,
             should_deploy_mock,
-            activate_mock,
+            try_to_activate_mock,
             install_uni_flows_mock,
             install_nni_flows,
             chose_vlans_mock,
@@ -876,7 +876,7 @@ class TestEVC():
 
         assert should_deploy_mock.call_count == 1
         assert discover_new_paths_mocked.call_count == 1
-        assert activate_mock.call_count == 1
+        assert try_to_activate_mock.call_count == 1
         assert install_uni_flows_mock.call_count == 1
         assert install_nni_flows.call_count == 1
         assert chose_vlans_mock.call_count == 1

--- a/tests/unit/models/test_path.py
+++ b/tests/unit/models/test_path.py
@@ -16,7 +16,7 @@ from napps.kytos.mef_eline.exceptions import InvalidPath  # NOQA pycodestyle
 from napps.kytos.mef_eline.models import (  # NOQA pycodestyle
     DynamicPathManager, Path)
 from napps.kytos.mef_eline.tests.helpers import (  # NOQA pycodestyle
-    MockResponse, get_link_mocked, get_mocked_requests, id_to_interface_mock)
+    get_link_mocked, get_mocked_requests, id_to_interface_mock)
 
 
 class TestPath():
@@ -72,72 +72,33 @@ class TestPath():
         current_path = Path(links)
         assert current_path.status == EntityStatus.DISABLED
 
-    # This method will be used by the mock to replace requests.get
-    def _mocked_requests_get_status_case_4(self):
-        return MockResponse(
-            {
-                "links": {
-                    "abc": {"active": True, "enabled": True},
-                    "def": {"active": True, "enabled": True},
-                }
-            },
-            200,
-        )
-
-    @patch("requests.get", side_effect=_mocked_requests_get_status_case_4)
-    def test_status_case_4(self, requests_mocked):
+    def test_status_case_4(self):
         # pylint: disable=unused-argument
         """Test if link status is UP."""
-        link1 = get_link_mocked()
-        link2 = get_link_mocked()
+        link1 = get_link_mocked(status=EntityStatus.UP)
+        link2 = get_link_mocked(status=EntityStatus.UP)
         link1.id = "def"
         link2.id = "abc"
         links = [link1, link2]
         current_path = Path(links)
         assert current_path.status == EntityStatus.UP
 
-    # This method will be used by the mock to replace requests.get
-    def _mocked_requests_get_status_case_5(self):
-        return MockResponse(
-            {
-                "links": {
-                    "abc": {"active": True, "enabled": True},
-                    "def": {"active": False, "enabled": False},
-                }
-            },
-            200,
-        )
-
-    @patch("requests.get", side_effect=_mocked_requests_get_status_case_5)
-    def test_status_case_5(self, requests_mocked):
+    def test_status_case_5(self):
         # pylint: disable=unused-argument
         """Test if link status is UP."""
-        link1 = get_link_mocked()
-        link2 = get_link_mocked()
+        link1 = get_link_mocked(status=EntityStatus.UP)
+        link2 = get_link_mocked(status=EntityStatus.DISABLED)
         link1.id = "def"
         link2.id = "abc"
         links = [link1, link2]
         current_path = Path(links)
         assert current_path.status == EntityStatus.DISABLED
 
-    # This method will be used by the mock to replace requests.get
-    def _mocked_requests_get_status_case_6(self):
-        return MockResponse(
-            {
-                "links": {
-                    "abc": {"active": False, "enabled": False},
-                    "def": {"active": False, "enabled": True},
-                }
-            },
-            200,
-        )
-
-    @patch("requests.get", side_effect=_mocked_requests_get_status_case_6)
-    def test_status_case_6(self, requests_mocked):
+    def test_status_case_6(self):
         # pylint: disable=unused-argument
         """Test if link status is UP."""
-        link1 = get_link_mocked()
-        link2 = get_link_mocked()
+        link1 = get_link_mocked(status=EntityStatus.DISABLED)
+        link2 = get_link_mocked(status=EntityStatus.UP)
         link1.id = "def"
         link2.id = "abc"
         links = [link1, link2]


### PR DESCRIPTION
Closes #580 

### Summary

- Added support for `try_avoid_same_s_vlan` as parameter variable for `PATCH` redeploy for EVCs.
- `remove_current_flows()` will not longer try to delete `failover_path` flows.

### Local Tests
Updated unit tests but not added missing ones.

### End-to-End Tests
N/A
