### PR TITLE
Updated to update `primary_path` `s_vlan`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,17 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2024.1.8] - 2024-12-05
+***********************
+
+Changed
+=======
+- ``primary_path``, ``backup_path``, ``primary_links`` and ``backup_links`` now only accept endpoint IDs in the API request content.
+
+Fixed
+=====
+- Fixed ``current_path`` taking the ``s_vlan`` from ``primary_path`` without checking in the interface for availability
+
 [2024.1.7] - 2024-11-27
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2024.1.7",
+  "version": "2024.1.8",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],

--- a/main.py
+++ b/main.py
@@ -1057,7 +1057,7 @@ class Main(KytosNApp):
             #     backup_links_cache
             if "links" in attribute:
                 data[attribute] = [
-                    self._link_from_dict(link) for link in value
+                    self._link_from_dict(link, attribute) for link in value
                 ]
 
             # Ex: current_path,
@@ -1065,7 +1065,7 @@ class Main(KytosNApp):
             #     backup_path
             if "path" in attribute and attribute != "dynamic_backup_path":
                 data[attribute] = Path(
-                    [self._link_from_dict(link) for link in value]
+                    [self._link_from_dict(link, attribute) for link in value]
                 )
 
         return data
@@ -1105,7 +1105,7 @@ class Main(KytosNApp):
         uni = UNI(interface, tag)
         return uni
 
-    def _link_from_dict(self, link_dict):
+    def _link_from_dict(self, link_dict: dict, attribute: str) -> Link:
         """Return a Link object from python dict."""
         id_a = link_dict.get("endpoint_a").get("id")
         id_b = link_dict.get("endpoint_b").get("id")
@@ -1120,7 +1120,8 @@ class Main(KytosNApp):
             raise ValueError(error_msg)
 
         link = Link(endpoint_a, endpoint_b)
-        if "metadata" in link_dict:
+        allowed_paths = {"current_path", "failover_path"}
+        if "metadata" in link_dict and attribute in allowed_paths:
             link.extend_metadata(link_dict.get("metadata"))
 
         s_vlan = link.get_metadata("s_vlan")

--- a/models/path.py
+++ b/models/path.py
@@ -12,7 +12,7 @@ from napps.kytos.mef_eline import settings
 from napps.kytos.mef_eline.exceptions import InvalidPath, PathFinderException
 
 
-class Path(list, GenericEntity):
+class Path(list[Link], GenericEntity):
     """Class to represent a Path."""
 
     def __eq__(self, other=None):

--- a/openapi.yml
+++ b/openapi.yml
@@ -405,19 +405,19 @@ components:
         primary_links:
           type: array
           items:
-            $ref: '#/components/schemas/NewLink'
+            $ref: '#/components/schemas/Link'
         backup_links:
           type: array
           items:
-            $ref: '#/components/schemas/NewLink'
+            $ref: '#/components/schemas/Link'
         primary_path:
           type: array
           items:
-            $ref: '#/components/schemas/NewLink'
+            $ref: '#/components/schemas/Link'
         backup_path:
           type: array
           items:
-            $ref: '#/components/schemas/NewLink'
+            $ref: '#/components/schemas/Link'
         primary_constraints:
           $ref: '#/components/schemas/PathConstraints'
         secondary_constraints:
@@ -494,9 +494,17 @@ components:
         id:
           type: string
         endpoint_a:
-          $ref: '#/components/schemas/Endpoint'
+          type: object
+          additionalProperties: false
+          properties:
+            id:
+              type: string
         endpoint_b:
-          $ref: '#/components/schemas/Endpoint'
+          type: object
+          additionalProperties: false
+          properties:
+            id:
+              type: string
 
     Path: # Can be referenced via '#/components/schemas/Path'
       type: object
@@ -621,11 +629,11 @@ components:
         primary_links:
           type: array
           items:
-            $ref: '#/components/schemas/Path'
+            $ref: '#/components/schemas/Link'
         backup_links:
           type: array
           items:
-            $ref: '#/components/schemas/Path'
+            $ref: '#/components/schemas/Link'
 
         current_path:
           type: array
@@ -638,11 +646,11 @@ components:
         primary_path:
           type: array
           items:
-            $ref: '#/components/schemas/NewLink'
+            $ref: '#/components/schemas/Link'
         backup_path:
           type: array
           items:
-            $ref: '#/components/schemas/NewLink'
+            $ref: '#/components/schemas/Link'
         primary_constraints:
           $ref: '#/components/schemas/PathConstraints'
         secondary_constraints:


### PR DESCRIPTION
Closes #566

### Summary

Ignoring `primary_path` `s_vlan` so it can be populated with `current_path` `s_vlan`

### Local Tests
Same as in the backport for 2023.2

### End-to-End Tests
N/A
