### PR TITLE
Fixed current_path not being deleted

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ Fixed
 =====
 - Try to handle uni interface up as link up for inter-EVCs
 - EVCs activation now take into account UNIs statuses before trying to activate
+- ``EVC.remove_current_flows()`` had its parameter ``current_path`` used when ``evc.current_path`` fails to install flows.
+- ``evc.current_path`` is deleted when an error with TAG type is raised.
 
 Added
 =====

--- a/models/evc.py
+++ b/models/evc.py
@@ -710,6 +710,7 @@ class EVCDeploy(EVCBase):
 
     def remove_current_flows(
         self,
+        current_path=None,
         force=True,
         sync=True,
         return_path=False
@@ -717,8 +718,8 @@ class EVCDeploy(EVCBase):
         """Remove all flows from current path or path intended for
          current path if exists."""
         switches, old_path_dict = set(), {}
-
-        if not self.current_path and not self.is_intra_switch():
+        current_path = self.current_path if not current_path else current_path
+        if not current_path and not self.is_intra_switch():
             return {}
 
         if return_path:
@@ -727,7 +728,6 @@ class EVCDeploy(EVCBase):
                 if s_vlan:
                     old_path_dict[link.id] = s_vlan.value
 
-        current_path = self.current_path
         for link in current_path:
             switches.add(link.endpoint_a.switch.id)
             switches.add(link.endpoint_b.switch.id)
@@ -751,7 +751,6 @@ class EVCDeploy(EVCBase):
             current_path.make_vlans_available(self._controller)
         except KytosTagError as err:
             log.error(f"Error removing {self} current_path: {err}")
-            return old_path_dict
         self.current_path = Path([])
         self.deactivate()
         if sync:

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -6,7 +6,8 @@ import pytest
 from kytos.lib.helpers import get_controller_mock
 
 from kytos.core.common import EntityStatus
-from kytos.core.exceptions import KytosNoTagAvailableError
+from kytos.core.exceptions import (KytosNoTagAvailableError,
+                                   KytosTagtypeNotSupported)
 from kytos.core.interface import Interface
 from kytos.core.switch import Switch
 from httpx import TimeoutException
@@ -895,6 +896,61 @@ class TestEVC():
 
         send_flow_mods_mocked.side_effect = FlowModException("error")
         evc.remove_current_flows()
+        log_error_mock.assert_called()
+
+    @patch("napps.kytos.mef_eline.controllers.ELineController.upsert_evc")
+    @patch("napps.kytos.mef_eline.models.evc.EVC._send_flow_mods")
+    @patch("napps.kytos.mef_eline.models.evc.log.error")
+    def test_remove_current_flows_error(self, *args):
+        """Test remove current flows with KytosTagError from vlans."""
+        (log_error_mock, __, _) = args
+        uni_a = get_uni_mocked(
+            interface_port=2,
+            tag_value=82,
+            switch_id="switch_uni_a",
+            is_valid=True,
+        )
+        uni_z = get_uni_mocked(
+            interface_port=3,
+            tag_value=83,
+            switch_id="switch_uni_z",
+            is_valid=True,
+        )
+
+        switch_a = Switch("00:00:00:00:00:01")
+        switch_b = Switch("00:00:00:00:00:02")
+        switch_c = Switch("00:00:00:00:00:03")
+        current_path = MagicMock()
+        current_path.return_value = [
+            get_link_mocked(
+                switch_a=switch_a,
+                switch_b=switch_b,
+                endpoint_a_port=9,
+                endpoint_b_port=10,
+                metadata={"s_vlan": 5},
+            ),
+            get_link_mocked(
+                switch_a=switch_b,
+                switch_b=switch_c,
+                endpoint_a_port=11,
+                endpoint_b_port=12,
+                metadata={"s_vlan": 6},
+            )
+        ]
+        attributes = {
+            "controller": get_controller_mock(),
+            "name": "custom_name",
+            "uni_a": uni_a,
+            "uni_z": uni_z,
+            "active": True,
+            "enabled": True,
+            "primary_links": [],
+        }
+        evc = EVC(**attributes)
+        current_path.make_vlans_available.side_effect = (
+            KytosTagtypeNotSupported("")
+        )
+        evc.remove_current_flows(current_path)
         log_error_mock.assert_called()
 
     @patch("napps.kytos.mef_eline.controllers.ELineController.upsert_evc")

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -947,11 +947,13 @@ class TestEVC():
             "primary_links": [],
         }
         evc = EVC(**attributes)
+        assert evc.is_active()
         current_path.make_vlans_available.side_effect = (
             KytosTagtypeNotSupported("")
         )
         evc.remove_current_flows(current_path)
         log_error_mock.assert_called()
+        assert not evc.is_active()
 
     @patch("napps.kytos.mef_eline.controllers.ELineController.upsert_evc")
     @patch("napps.kytos.mef_eline.models.evc.EVC._send_flow_mods")


### PR DESCRIPTION
Closes #585 

### Summary

`remove_current_flows` parameter `current_path` was still being used, so I brought it back.
Early return when the TAG type was invalid (e.g. `!= "vlan") would have left EVC with a `current_path`

### Local Tests
Tested the scenarios and added a unit test

### End-to-End Tests
N/A