### PR TITLE
Made changes for vue3sfcloader compatibility k-info-panel

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,7 +25,8 @@ Fixed
 
 Changed
 =======
-- The mef_eline modal now uses the modal component
+- UI: changed the interface variable for k_interface since it was a reserved keyword
+- UI: the mef_eline modal now uses the modal component
 - UI: fixed premature submit when pressing Enter during autocomplete on inputs
 - UI: fixed path constraints fields to be collabsed by default when creating EVC to better usability for listing EVCs
 - ``primary_path``, ``backup_path``, ``primary_links`` and ``backup_links`` now only accept endpoint IDs in the API request content.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Fixed
 
 Changed
 =======
+- UI: changed variable name which was the reserved keyword interface to k_interface
 - UI: changed the interface variable for k_interface since it was a reserved keyword
 - UI: the mef_eline modal now uses the modal component
 - UI: fixed premature submit when pressing Enter during autocomplete on inputs

--- a/ui/k-info-panel/list_connections.kytos
+++ b/ui/k-info-panel/list_connections.kytos
@@ -210,8 +210,8 @@ module.exports = {
                 _dpid_names[sw.dpid] = sw.metadata.node_name;
               }
               if(sw.interfaces) {
-                $.each(sw.interfaces, function(j , interface) {
-                  _interface_names[interface.id] = interface.name;
+                $.each(sw.interfaces, function(j , k_interface) {
+                  _interface_names[k_interface.id] = k_interface.name;
                 });
               }
             });

--- a/ui/k-info-panel/show_circuit.kytos
+++ b/ui/k-info-panel/show_circuit.kytos
@@ -588,18 +588,18 @@ module.exports = {
                 _dpid_names[sw.dpid] = sw.metadata.node_name;
               }
               if(sw.interfaces) {
-                $.each(sw.interfaces, function(j , interface) {
+                $.each(sw.interfaces, function(j , k_interface) {
                   // store interface name data 
-                  let metadata = interface.metadata;
-                  _interface_data[interface.id] = {
-                    "name": interface.name,
-                    "link_name": (metadata && "link_name" in metadata) ? interface.metadata.link_name : "",
-                    "port_name": (metadata && "port_name" in metadata) ? interface.metadata.port_name : ""
+                  let metadata = k_interface.metadata;
+                  _interface_data[k_interface.id] = {
+                    "name": k_interface.name,
+                    "link_name": (metadata && "link_name" in metadata) ? k_interface.metadata.link_name : "",
+                    "port_name": (metadata && "port_name" in metadata) ? k_interface.metadata.port_name : ""
                   };
                   // store autocomplete dpids
-                  let value = interface.id;
-                  if(interface.name) {
-                    value = interface.name + " - " + value;
+                  let value = k_interface.id;
+                  if(k_interface.name) {
+                    value = k_interface.name + " - " + value;
                   }
                   if(!_this.dpids.includes(value)) {
                     _this.dpids.push(value);


### PR DESCRIPTION
Closes #593 

### Summary

Interface is a reserved keyword, so it was replaced with k_interface.

### Local Tests

After applying the changes I no longer got an error for utilizing a reserved keyword.
