### PR TITLE
Fix fields displaying NAN values

### DIFF
--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -91,7 +91,7 @@
                     <k-input 
                     title="Southbound priority:"
                     v-model:value="form_constraints[constraint].spf_max_path_cost"
-                    :action="function(val) {form_constraints[constraint].spf_max_path_cost = parseInt(val)}"></k-input>
+                    :action="function(val) {form_constraints[constraint].spf_max_path_cost = parseInt(val)||''}"></k-input>
                   </div>
                 </div>
 
@@ -101,7 +101,7 @@
                     <k-input 
                     :title="constraint_titles['minimum_flexible_hits']"
                     v-model:value="form_constraints[constraint].minimum_flexible_hits"
-                    :action="function(val) {form_constraints[constraint].minimum_flexible_hits = parseInt(val)}"></k-input>
+                    :action="function(val) {form_constraints[constraint].minimum_flexible_hits = parseInt(val)||''}"></k-input>
                   </div>
                 </div>
 


### PR DESCRIPTION
Closes #595 

### Summary
Fix the form fields `min. flexible hits`  and `SPF max path` changing any value that is not a number to "" (empty).

### Local Tests
UI test:
- click the mef-eline NApp
- try entering any non-numeric value in the fields: **SPF max path cost**  and  **Min. flexible hits**

### End-to-End Tests
