### PR TITLE
Added bool to log warnning for failover path

### DIFF
--- a/main.py
+++ b/main.py
@@ -127,7 +127,7 @@ class Main(KytosNApp):
         for circuit in self.get_evcs_by_svc_level(enable_filter=False):
             if self.should_be_checked(circuit):
                 circuits_to_check.append(circuit)
-            circuit.try_setup_failover_path()
+            circuit.try_setup_failover_path(warn_if_not_path=False)
         circuits_checked = EVCDeploy.check_list_traces(circuits_to_check)
         for circuit in circuits_to_check:
             is_checked = circuits_checked.get(circuit.id)

--- a/models/evc.py
+++ b/models/evc.py
@@ -969,7 +969,11 @@ class EVCDeploy(EVCBase):
         log.info(msg)
         return True
 
-    def try_setup_failover_path(self, wait=settings.DEPLOY_EVCS_INTERVAL):
+    def try_setup_failover_path(
+        self,
+        wait=settings.DEPLOY_EVCS_INTERVAL,
+        warn_if_not_path=True
+    ):
         """Try setup failover_path whenever possible."""
         if (
                 self.failover_path or not self.current_path
@@ -978,10 +982,10 @@ class EVCDeploy(EVCBase):
             return
         if (now() - self.affected_by_link_at).seconds >= wait:
             with self.lock:
-                self.setup_failover_path()
+                self.setup_failover_path(warn_if_not_path)
 
     # pylint: disable=too-many-statements
-    def setup_failover_path(self):
+    def setup_failover_path(self, warn_if_not_path=True):
         """Install flows for the failover path of this EVC.
 
         Procedures to deploy:
@@ -1054,7 +1058,7 @@ class EVCDeploy(EVCBase):
             if tag_errors:
                 msg = self.add_tag_errors(msg, tag_errors)
                 log.error(msg)
-            else:
+            elif warn_if_not_path:
                 log.warning(msg)
             return False
         log.info(f"Failover path for {self} was deployed.")

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -146,7 +146,9 @@ class TestMain:
         self.napp.execute_consistency()
         assert evc1.activate.call_count == 1
         assert evc1.sync.call_count == 1
+        evc1.try_setup_failover_path.assert_called_with(warn_if_not_path=False)
         assert evc2.deploy.call_count == 1
+        evc2.try_setup_failover_path.assert_called_with(warn_if_not_path=False)
 
     @patch('napps.kytos.mef_eline.main.settings')
     @patch('napps.kytos.mef_eline.main.Main._load_evc')


### PR DESCRIPTION
Closes #488.

### Summary

Consistency check will not longer warn that a `failover_path` has not been found.
Added bool `warn_if_not_path` at method parameter to deploy `failover_path`.

### Local Tests
Created an dynamic EVC with no possible `failover_path`

### End-to-End Tests
N/A