### PR TITLE
Removed this.$set()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Fixed
 
 Changed
 =======
+- UI: Removed the use of this.$set() since it was deprecated
 - UI: changed variable name which was the reserved keyword interface to k_interface
 - UI: changed the interface variable for k_interface since it was a reserved keyword
 - UI: the mef_eline modal now uses the modal component

--- a/ui/k-info-panel/list_connections.kytos
+++ b/ui/k-info-panel/list_connections.kytos
@@ -90,7 +90,7 @@ module.exports = {
       */
       if(newSort === this.currentSort) {
         let sortDir = (this.currentSortDir[newSort] === 'asc') ? 'desc' : 'asc'
-        this.$set(this.currentSortDir, newSort, sortDir);
+        this.currentSortDir[newSort] = sortDir;
         /**
         * It is necessary to use a different syntax to replace arrays values
         * by index because Vue cannot detect when directly set an item with


### PR DESCRIPTION
Closes #602 

### Summary

this.$set() was used in vue js 2 to add reactive properties to objects. Within vue js 3 this is no longer needed since properties are made reactive by default, so it was removed.

### Local Tests

After removing the use of set I no longer got a warning for the using it.

### End-to-End Tests
