### PR TITLE
Fixed missing port numbers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Added
 Fixed
 =======
 - UI: fixed issue where non-JSON data was being parsed as JSON data.
+- UI: fixed issue were port numbers were not displaying within the Circuit Details info panel.
 
 Changed
 =======

--- a/ui/k-info-panel/show_circuit.kytos
+++ b/ui/k-info-panel/show_circuit.kytos
@@ -593,7 +593,7 @@ module.exports = {
                   let metadata = k_interface.metadata;
                   _interface_data[k_interface.id] = {
                     "name": k_interface.name,
-                    "link_name": (metadata && "link_name" in metadata) ? k_interface.metadata.link_name : "",
+                    "link_name": (metadata && "link_name" in metadata) ? k_interface.metadata.link_name : (k_interface.link || ""),
                     "port_name": (metadata && "port_name" in metadata) ? k_interface.metadata.port_name : (k_interface.port_number || "")
                   };
                   // store autocomplete dpids

--- a/ui/k-info-panel/show_circuit.kytos
+++ b/ui/k-info-panel/show_circuit.kytos
@@ -594,7 +594,7 @@ module.exports = {
                   _interface_data[k_interface.id] = {
                     "name": k_interface.name,
                     "link_name": (metadata && "link_name" in metadata) ? k_interface.metadata.link_name : "",
-                    "port_name": (metadata && "port_name" in metadata) ? k_interface.metadata.port_name : ""
+                    "port_name": (metadata && "port_name" in metadata) ? k_interface.metadata.port_name : (k_interface.port_number || "")
                   };
                   // store autocomplete dpids
                   let value = k_interface.id;


### PR DESCRIPTION
Closes #605 

### Summary

The port numbers were missing from the Circuit Details info panel.

### Local Tests

The port numbers can be seen again:
![image](https://github.com/user-attachments/assets/d6fc8cdb-9bc3-4cd3-85c7-5a5e6a22dd6c)

### End-to-End Tests
