### PR TITLE
Redeploy static EVC when link_up

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Fixed
 - EVCs activation now take into account UNIs statuses before trying to activate
 - ``EVC.remove_current_flows()`` had its parameter ``current_path`` used when ``evc.current_path`` fails to install flows.
 - ``evc.current_path`` is deleted when an error with TAG type is raised.
+- Link up from UNI will deploy correctly an EVC when it does not have a path.
 
 Added
 =====

--- a/models/evc.py
+++ b/models/evc.py
@@ -1764,6 +1764,10 @@ class LinkProtection(EVCDeploy):
                             and interface),
                 lambda me: (me.deploy_to_primary_path(), 'redeploy')
             ),
+            (
+                lambda me: interface and me.backup_path.status == EntityStatus.UP,
+                lambda me: (me.deploy_to_backup_path(), 'redeploy')
+            ),
             # We tried to deploy(primary_path) without success.
             # And in this case is up by some how. Nothing to do.
             (

--- a/models/evc.py
+++ b/models/evc.py
@@ -1765,7 +1765,8 @@ class LinkProtection(EVCDeploy):
                 lambda me: (me.deploy_to_primary_path(), 'redeploy')
             ),
             (
-                lambda me: interface and me.backup_path.status == EntityStatus.UP,
+                lambda me: (me.backup_path.status == EntityStatus.UP
+                            and interface),
                 lambda me: (me.deploy_to_backup_path(), 'redeploy')
             ),
             # We tried to deploy(primary_path) without success.

--- a/models/evc.py
+++ b/models/evc.py
@@ -1737,7 +1737,7 @@ class LinkProtection(EVCDeploy):
             return True
         return False
 
-    def handle_link_up(self, link):
+    def handle_link_up(self, link=None, interface=None):
         """Handle circuit when link up.
 
         Args:
@@ -1755,6 +1755,13 @@ class LinkProtection(EVCDeploy):
             ),
             (
                 lambda me: me.primary_path.is_affected_by_link(link),
+                lambda me: (me.deploy_to_primary_path(), 'redeploy')
+            ),
+            # For this special case, it reached this point because interface
+            # was previously confirmed to be a UNI and both UNI are UP
+            (
+                lambda me: (me.primary_path.status == EntityStatus.UP
+                            and interface),
                 lambda me: (me.deploy_to_primary_path(), 'redeploy')
             ),
             # We tried to deploy(primary_path) without success.
@@ -1840,7 +1847,7 @@ class LinkProtection(EVCDeploy):
             self.current_path.status != EntityStatus.UP
             and not self.is_intra_switch()
         ):
-            succeeded = self.handle_link_up(interface)
+            succeeded = self.handle_link_up(interface=interface)
             if succeeded:
                 msg = (
                     f"Activated {self} due to successful "

--- a/tests/unit/models/test_link_protection.py
+++ b/tests/unit/models/test_link_protection.py
@@ -739,6 +739,64 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
         assert not self.evc.handle_link_up(MagicMock())
         assert self.evc.deploy_to_path.call_count == 0
 
+    @patch(DEPLOY_TO_BACKUP_PATH)
+    @patch(DEPLOY_TO_PRIMARY_PATH)
+    async def test_handle_link_up_case_8(
+        self, deploy_primary_mock, deploy_backup_mock
+    ):
+        """Test when UNI is UP and dinamic primary_path from
+        EVC is UP as well."""
+        primary_path = [
+            get_link_mocked(
+                endpoint_a_port=9,
+                endpoint_b_port=10,
+                metadata={"s_vlan": 5},
+                status=EntityStatus.UP,
+            ),
+            get_link_mocked(
+                endpoint_a_port=11,
+                endpoint_b_port=12,
+                metadata={"s_vlan": 6},
+                status=EntityStatus.UP,
+            ),
+        ]
+        backup_path = [
+            get_link_mocked(
+                endpoint_a_port=13,
+                endpoint_b_port=14,
+                metadata={"s_vlan": 5},
+                status=EntityStatus.UP,
+            ),
+            get_link_mocked(
+                endpoint_a_port=11,
+                endpoint_b_port=12,
+                metadata={"s_vlan": 6},
+                status=EntityStatus.DOWN,
+            ),
+        ]
+
+        attributes = {
+            "controller": get_controller_mock(),
+            "name": "circuit",
+            "uni_a": get_uni_mocked(is_valid=True),
+            "uni_z": get_uni_mocked(is_valid=True),
+            "primary_path": primary_path,
+            "backup_path": backup_path,
+            "enabled": True,
+            "dynamic_backup_path": True,
+        }
+
+        evc = EVC(**attributes)
+        evc.handle_link_up(interface=evc.uni_a.interface)
+        assert deploy_primary_mock.call_count == 1
+        assert deploy_backup_mock.call_count == 0
+
+        evc.primary_path[0].status = EntityStatus.DOWN
+        evc.backup_path[1].status = EntityStatus.UP
+        evc.handle_link_up(interface=evc.uni_a.interface)
+        assert deploy_primary_mock.call_count == 1
+        assert deploy_backup_mock.call_count == 1
+
     async def test_get_interface_from_switch(self):
         """Test get_interface_from_switch"""
         interface = id_to_interface_mock('00:01:1')


### PR DESCRIPTION
Closes #607

### Summary

Tried in this scenario:
Create an EVC where a UNI is an NNI not related to the path, e.g. uni_a=01:2, uni_z=02:01 where there is a link 01:2 - 04:2 and primary_path is through the link 01:3 - 02:3
In Mininet turn down the link 01:2 - 04:2
Manually delete current_path from the EVC
Turn up the link 01:2 - 04:2. Everything related to the EVC is up but it will not re-deploy from the link-up

### Local Tests
Tried to replicate with previous scenario

### End-to-End Tests
```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /tests
plugins: timeout-2.2.0, rerunfailures-13.0, anyio-4.3.0
collected 277 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  7%]
tests/test_e2e_06_topology.py ....                                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 23%]
.                                                                        [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 28%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 43%]
.                                                                        [ 44%]
tests/test_e2e_14_mef_eline.py x....                                     [ 45%]
tests/test_e2e_15_mef_eline.py .....                                     [ 47%]
tests/test_e2e_16_mef_eline.py ..                                        [ 48%]
tests/test_e2e_20_flow_manager.py ..........................             [ 57%]
tests/test_e2e_21_flow_manager.py ...                                    [ 58%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ...                                         [ 71%]
tests/test_e2e_32_of_lldp.py ...                                         [ 72%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
tests/test_e2e_50_maintenance.py ............................            [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 94%]
tests/test_e2e_70_kytos_stats.py ........                                [ 97%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
```