### PR TITLE
Backport: Redeploy static EVC when link_up 2023.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [Unreleased]
 ************
 
+[2023.2.9] - 2025-01-22
+***********************
+
+Fixed
+=====
+- Link up from UNI will deploy correctly an EVC when it does not have a path.
+
 [2023.2.8] - 2024-12-05
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2023.2.8",
+  "version": "2023.2.9",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],

--- a/models/evc.py
+++ b/models/evc.py
@@ -1651,11 +1651,12 @@ class LinkProtection(EVCDeploy):
 
         return False
 
-    def handle_link_up(self, link):
+    def handle_link_up(self, link=None, interface=None):
         """Handle circuit when link up.
 
         Args:
             link(Link): Link affected by link.up event.
+            interface(Interface): UNI affected by link.up event.
 
         """
         condition_pairs = [
@@ -1670,6 +1671,18 @@ class LinkProtection(EVCDeploy):
             (
                 lambda me: me.primary_path.is_affected_by_link(link),
                 lambda me: (me.deploy_to_primary_path(), 'redeploy')
+            ),
+            # For this special case, it reached this point because interface
+            # was previously confirmed to be a UNI and both UNI are UP
+            (
+                lambda me: (me.primary_path.status == EntityStatus.UP
+                            and interface),
+                lambda me: (me.deploy_to_primary_path(), 'redeploy')
+            ),
+            (
+                lambda me: (me.backup_path.status == EntityStatus.UP
+                            and interface),
+                lambda me: (me.deploy_to_backup_path(), 'redeploy')
             ),
             # We tried to deploy(primary_path) without success.
             # And in this case is up by some how. Nothing to do.
@@ -1754,7 +1767,7 @@ class LinkProtection(EVCDeploy):
             self.current_path.status != EntityStatus.UP
             and not self.is_intra_switch()
         ):
-            succeeded = self.handle_link_up(interface)
+            succeeded = self.handle_link_up(interface=interface)
             if succeeded:
                 msg = (
                     f"Activated {self} due to successful "


### PR DESCRIPTION
Closes #609 

### Summary

- Link up from UNI will deploy correctly an EVC when it does not have a path.

### Local Tests
Tried [this](https://github.com/kytos-ng/mef_eline/pull/608#pullrequestreview-2564458471) scenario

### Unit Tests
```
collected 290 items

tests/unit/test_controllers.py ........                                                                                   [  2%]
tests/unit/test_db_models.py .........................                                                                    [ 11%]
tests/unit/test_main.py .............................................................................                     [ 37%]
tests/unit/test_scheduler.py .........                                                                                    [ 41%]
tests/unit/test_utils.py .........                                                                                        [ 44%]
tests/unit/models/test_evc_base.py .................................                                                      [ 55%]
tests/unit/models/test_evc_deploy.py .................................................................................... [ 84%]
tests/unit/models/test_link_protection.py ....................                                                            [ 91%]
tests/unit/models/test_path.py .........................                                                                  [100%]
```

### End-to-End Tests
N/A
