### PR TITLE
Backport: Redeploy static EVC when link_up 2024.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2024.1.10] - 2025-01-22
+***********************
+
+Fixed
+=====
+- Link up from UNI will deploy correctly an EVC when it does not have a path.
+
 [2024.1.9] - 2024-12-09
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2024.1.9",
+  "version": "2024.1.10",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],

--- a/models/evc.py
+++ b/models/evc.py
@@ -725,7 +725,7 @@ class EVCDeploy(EVCBase):
         current_path = self.current_path if not current_path else current_path
         if not current_path and not self.is_intra_switch():
             return {}
-        
+
         if return_path:
             for link in current_path:
                 s_vlan = link.metadata.get("s_vlan")
@@ -1721,7 +1721,7 @@ class LinkProtection(EVCDeploy):
             return True
         return False
 
-    def handle_link_up(self, link):
+    def handle_link_up(self, link=None, interface=None):
         """Handle circuit when link up.
 
         Args:
@@ -1740,6 +1740,18 @@ class LinkProtection(EVCDeploy):
             (
                 lambda me: me.primary_path.is_affected_by_link(link),
                 lambda me: (me.deploy_to_primary_path(), 'redeploy')
+            ),
+            # For this special case, it reached this point because interface
+            # was previously confirmed to be a UNI and both UNI are UP
+            (
+                lambda me: (me.primary_path.status == EntityStatus.UP
+                            and interface),
+                lambda me: (me.deploy_to_primary_path(), 'redeploy')
+            ),
+            (
+                lambda me: (me.backup_path.status == EntityStatus.UP
+                            and interface),
+                lambda me: (me.deploy_to_backup_path(), 'redeploy')
             ),
             # We tried to deploy(primary_path) without success.
             # And in this case is up by some how. Nothing to do.
@@ -1824,7 +1836,7 @@ class LinkProtection(EVCDeploy):
             self.current_path.status != EntityStatus.UP
             and not self.is_intra_switch()
         ):
-            succeeded = self.handle_link_up(interface)
+            succeeded = self.handle_link_up(interface=interface)
             if succeeded:
                 msg = (
                     f"Activated {self} due to successful "

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -5,5 +5,5 @@
 #    pip-compile --output-file requirements/dev.txt requirements/dev.in
 #
 -e git+https://github.com/kytos-ng/python-openflow.git#egg=python-openflow
--e git+https://github.com/kytos-ng/kytos.git#egg=kytos[dev]
+-e git+https://github.com/kytos-ng/kytos.git@base/2024.1.4#egg=kytos[dev]
 -e .

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -562,14 +562,14 @@ class TestEVC():
     @patch("napps.kytos.mef_eline.models.evc.EVC._install_nni_flows")
     @patch("napps.kytos.mef_eline.models.evc.EVC._install_uni_flows")
     @patch("napps.kytos.mef_eline.models.evc.EVC._install_direct_uni_flows")
-    @patch("napps.kytos.mef_eline.models.evc.EVC.activate")
+    @patch("napps.kytos.mef_eline.models.evc.EVC.try_to_activate")
     @patch("napps.kytos.mef_eline.models.evc.EVC.should_deploy")
     def test_deploy_successfully(self, *args):
         """Test if all methods to deploy are called."""
         # pylint: disable=too-many-locals
         (
             should_deploy_mock,
-            activate_mock,
+            try_to_activate_mock,
             install_direct_uni_flows_mock,
             install_uni_flows_mock,
             install_nni_flows,
@@ -589,7 +589,7 @@ class TestEVC():
         deployed = evc.deploy_to_path(evc.primary_links)
 
         assert should_deploy_mock.call_count == 1
-        assert activate_mock.call_count == 1
+        assert try_to_activate_mock.call_count == 1
         assert install_uni_flows_mock.call_count == 1
         assert install_nni_flows.call_count == 1
         assert chose_vlans_mock.call_count == 1
@@ -600,7 +600,7 @@ class TestEVC():
         evc = self.create_evc_intra_switch()
         assert evc.deploy_to_path(evc.primary_links) is True
         assert install_direct_uni_flows_mock.call_count == 1
-        assert activate_mock.call_count == 2
+        assert try_to_activate_mock.call_count == 2
         assert log_mock.info.call_count == 2
         log_mock.info.assert_called_with(f"{evc} was deployed.")
 
@@ -827,7 +827,7 @@ class TestEVC():
 
         deployed = evc.deploy_to_backup_path()
 
-        deploy_to_path_mocked.assert_called_once_with()
+        deploy_to_path_mocked.assert_called_once_with(old_path_dict=None)
         assert deployed is True
 
     @patch("httpx.post")
@@ -836,7 +836,7 @@ class TestEVC():
     @patch("napps.kytos.mef_eline.models.path.Path.choose_vlans")
     @patch("napps.kytos.mef_eline.models.evc.EVC._install_nni_flows")
     @patch("napps.kytos.mef_eline.models.evc.EVC._install_uni_flows")
-    @patch("napps.kytos.mef_eline.models.evc.EVC.activate")
+    @patch("napps.kytos.mef_eline.models.evc.EVC.try_to_activate")
     @patch("napps.kytos.mef_eline.models.evc.EVC.should_deploy")
     @patch("napps.kytos.mef_eline.models.evc.EVC.discover_new_paths")
     def test_deploy_without_path_case1(self, *args):
@@ -845,7 +845,7 @@ class TestEVC():
         (
             discover_new_paths_mocked,
             should_deploy_mock,
-            activate_mock,
+            try_to_activate_mock_mock,
             install_uni_flows_mock,
             install_nni_flows,
             chose_vlans_mock,
@@ -903,7 +903,7 @@ class TestEVC():
 
         assert should_deploy_mock.call_count == 1
         assert discover_new_paths_mocked.call_count == 1
-        assert activate_mock.call_count == 1
+        assert try_to_activate_mock_mock.call_count == 1
         assert install_uni_flows_mock.call_count == 1
         assert install_nni_flows.call_count == 1
         assert chose_vlans_mock.call_count == 1

--- a/tests/unit/models/test_link_protection.py
+++ b/tests/unit/models/test_link_protection.py
@@ -449,7 +449,7 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
         current_handle_link_up = evc.handle_link_up(primary_path[0])
         assert deploy_mocked.call_count == 0
         assert deploy_to_path_mocked.call_count == 1
-        deploy_to_path_mocked.assert_called_once_with(evc.primary_path)
+        deploy_to_path_mocked.assert_called_once_with(evc.primary_path, None)
         assert current_handle_link_up
 
     @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.deploy")
@@ -514,7 +514,7 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
 
         assert deploy_mocked.call_count == 0
         assert deploy_to_path_mocked.call_count == 1
-        deploy_to_path_mocked.assert_called_once_with(evc.backup_path)
+        deploy_to_path_mocked.assert_called_once_with(evc.backup_path, None)
         assert current_handle_link_up
 
     @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.deploy_to_path")
@@ -578,7 +578,7 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
         current_handle_link_up = evc.handle_link_up(backup_path[0])
 
         assert deploy_to_path_mocked.call_count == 1
-        deploy_to_path_mocked.assert_called_once_with()
+        deploy_to_path_mocked.assert_called_once_with(old_path_dict=None)
         assert current_handle_link_up
 
     async def test_handle_link_up_case_5(self):
@@ -743,6 +743,64 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
         assert not self.evc.handle_link_up(MagicMock())
         assert self.evc.deploy_to_path.call_count == 0
 
+    @patch(DEPLOY_TO_BACKUP_PATH)
+    @patch(DEPLOY_TO_PRIMARY_PATH)
+    async def test_handle_link_up_case_8(
+        self, deploy_primary_mock, deploy_backup_mock
+    ):
+        """Test when UNI is UP and dinamic primary_path from
+        EVC is UP as well."""
+        primary_path = [
+            get_link_mocked(
+                endpoint_a_port=9,
+                endpoint_b_port=10,
+                metadata={"s_vlan": 5},
+                status=EntityStatus.UP,
+            ),
+            get_link_mocked(
+                endpoint_a_port=11,
+                endpoint_b_port=12,
+                metadata={"s_vlan": 6},
+                status=EntityStatus.UP,
+            ),
+        ]
+        backup_path = [
+            get_link_mocked(
+                endpoint_a_port=13,
+                endpoint_b_port=14,
+                metadata={"s_vlan": 5},
+                status=EntityStatus.UP,
+            ),
+            get_link_mocked(
+                endpoint_a_port=11,
+                endpoint_b_port=12,
+                metadata={"s_vlan": 6},
+                status=EntityStatus.DOWN,
+            ),
+        ]
+
+        attributes = {
+            "controller": get_controller_mock(),
+            "name": "circuit",
+            "uni_a": get_uni_mocked(is_valid=True),
+            "uni_z": get_uni_mocked(is_valid=True),
+            "primary_path": primary_path,
+            "backup_path": backup_path,
+            "enabled": True,
+            "dynamic_backup_path": True,
+        }
+
+        evc = EVC(**attributes)
+        evc.handle_link_up(interface=evc.uni_a.interface)
+        assert deploy_primary_mock.call_count == 1
+        assert deploy_backup_mock.call_count == 0
+
+        evc.primary_path[0].status = EntityStatus.DOWN
+        evc.backup_path[1].status = EntityStatus.UP
+        evc.handle_link_up(interface=evc.uni_a.interface)
+        assert deploy_primary_mock.call_count == 1
+        assert deploy_backup_mock.call_count == 1
+
     async def test_get_interface_from_switch(self):
         """Test get_interface_from_switch"""
         interface = id_to_interface_mock('00:01:1')
@@ -820,7 +878,7 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
         monkeypatch.setattr("napps.kytos.mef_eline.models.evc.emit_event",
                             emit_mock)
 
-        self.evc.activate = MagicMock()
+        self.evc.try_to_activate = MagicMock()
         self.evc.deactivate = MagicMock()
         self.evc.sync = MagicMock()
 
@@ -829,7 +887,7 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
 
         self.evc.handle_interface_link_up(interface_a)
 
-        self.evc.activate.assert_not_called()
+        self.evc.try_to_activate.assert_not_called()
         self.evc.sync.assert_not_called()
 
         # Test deactivating
@@ -854,8 +912,10 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
         interface_a.activate()
 
         assert emit_mock.call_count == 1
+        self.evc.try_to_handle_uni_as_link_up = MagicMock()
+        self.evc.try_to_handle_uni_as_link_up.return_value = False
         self.evc.handle_interface_link_up(interface_a)
 
-        self.evc.activate.assert_called_once()
+        self.evc.try_to_activate.assert_called_once()
         assert self.evc.sync.call_count == 2
         assert emit_mock.call_count == 2

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1669,7 +1669,7 @@ class TestMain:
             "endpoint_b": {"id": "b"}
         }
         with pytest.raises(ValueError):
-            self.napp._link_from_dict(link_dict)
+            self.napp._link_from_dict(link_dict, "current_path")
 
     def test_uni_from_dict_non_existent_intf(self):
         """Test _link_from_dict non existent intf."""


### PR DESCRIPTION
Closes #610

### Summary

Link up from UNI will deploy correctly an EVC when it does not have a path.
Updated unit tests

### Local Tests
Same as backport for 2023.2

### Unit Tests
```
collected 297 items                                                                                                                                                                                              

tests/unit/models/test_evc_base.py .................................                                                          [ 11%]
tests/unit/models/test_evc_deploy.py ........................................................................................ [ 40%]
tests/unit/models/test_link_protection.py ..................                                                                  [ 46%]
tests/unit/models/test_path.py ...........................                                                                    [ 55%]
tests/unit/test_controllers.py ........                                                                                       [ 58%]
tests/unit/test_db_models.py .........................                                                                        [ 67%]
tests/unit/test_main.py .............................................................................                         [ 92%]
tests/unit/test_scheduler.py .........                                                                                        [ 95%]
tests/unit/test_utils.py ............                                                                                         [100%]
```

### End-to-End Tests
N/A