### PR TITLE
Added new column `Path Types` column to `View Connections`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,7 @@ Changed
 - UI: fixed path constraints fields to be collabsed by default when creating EVC to better usability for listing EVCs
 - ``primary_path``, ``backup_path``, ``primary_links`` and ``backup_links`` now only accept endpoint IDs in the API request content.
 - Now when installing or deleting a path, a single request to ``flow_manager`` will be sent per path.
+- UI: Added column ``Path Types`` to ``View Connections`` component to indicate if the EVC has a dynamic, primary or backup path.
 
 [2024.1.4] - 2024-09-09
 ***********************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,7 +35,7 @@ Changed
 - UI: fixed path constraints fields to be collabsed by default when creating EVC to better usability for listing EVCs
 - ``primary_path``, ``backup_path``, ``primary_links`` and ``backup_links`` now only accept endpoint IDs in the API request content.
 - Now when installing or deleting a path, a single request to ``flow_manager`` will be sent per path.
-- UI: Added column ``Path Types`` to ``View Connections`` component to indicate if the EVC has a dynamic, primary or backup path.
+- UI: Added column ``Path Types`` to ``View Connections`` component to indicate if the EVC has a ``dynamic_backup_path``, ``static_primary`` or ``static_backup`` value.
 
 [2024.1.4] - 2024-09-09
 ***********************

--- a/ui/k-info-panel/list_connections.kytos
+++ b/ui/k-info-panel/list_connections.kytos
@@ -161,9 +161,9 @@ module.exports = {
             let endpoint_data_z = _this.getEndpointData(endpoint_z);
             let tag_z = (evc.uni_z && evc.uni_z.tag) ? evc.uni_z.tag.value : "";
             var path_types = [];
-            evc.dynamic_backup_path && path_types.push("dynamic")
-            evc.primary_path.length && path_types.push("primary")
-            evc.backup_path.length && path_types.push("backup")
+            evc.primary_path.length && path_types.push("static_primary")
+            evc.backup_path.length && path_types.push("static_backup")
+            evc.dynamic_backup_path && path_types.push("dynamic_backup_path")
 
             let connection = {
               "mef_dpid_id": evc.id,

--- a/ui/k-info-panel/list_connections.kytos
+++ b/ui/k-info-panel/list_connections.kytos
@@ -71,10 +71,10 @@ module.exports = {
                       'mef_lst_sw_a', 'mef_lst_prt_a', 'mef_lst_int_a', 'mef_lst_tag_a',
                       'mef_lst_sw_z', 'mef_lst_prt_z', 'mef_lst_int_z', 'mef_lst_tag_z', 
                       'mef_lst_enabled',
-                      'mef_lst_active'],                         
+                      'mef_lst_active', 'path_types'],                         
       data_headers: ['id', 'Name', 'Switch A', 'Port A', 'Interf. A', 'VLAN A',
                       'Switch Z', 'Port Z', 'Interf. Z', 'VLAN Z',
-                      'Enabled', 'Active'],
+                      'Enabled', 'Active', 'Paths Types'],
       data_rows: [],
       currentSort: 0,
       currentSortDir: [],
@@ -159,7 +159,11 @@ module.exports = {
 
             let endpoint_z =  (evc.uni_z) ? evc.uni_z.interface_id : "";
             let endpoint_data_z = _this.getEndpointData(endpoint_z);
-            let tag_z = (evc.uni_z && evc.uni_z.tag) ? evc.uni_z.tag.value : "";  
+            let tag_z = (evc.uni_z && evc.uni_z.tag) ? evc.uni_z.tag.value : "";
+            var path_types = [];
+            evc.dynamic_backup_path && path_types.push("dynamic")
+            evc.primary_path.length && path_types.push("primary")
+            evc.backup_path.length && path_types.push("backup")
 
             let connection = {
               "mef_dpid_id": evc.id,
@@ -173,7 +177,8 @@ module.exports = {
               "mef_lst_int_z": endpoint_data_z.interface_name,
               "mef_lst_tag_z": tag_z, // TAG Vlan to be sorted as int
               "mef_lst_enabled": evc.enabled,
-              "mef_lst_active": evc.active
+              "mef_lst_active": evc.active,
+              "path_types": path_types.toString()
             };
             tableRows.push(connection);
           }


### PR DESCRIPTION
Closes #594

### Summary

Added column `Path Types` to `View Connections` component to indicate if the EVC has a `primary_path`,  `backup_path` and `dynamic_backup_path` with values `static_primary`,  `static_backup` and `dynamic_backup_path` respectively and in that order.
![Screenshot_20250128_141800](https://github.com/user-attachments/assets/ca6e3499-1a9a-4a76-8b52-63d4163e2118)


### Local Tests
Tried the filter
Created EVCs

### End-to-End Tests
N/A
