### PR TITLE
Extending validation of paths

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Fixed
 - ``EVC.remove_current_flows()`` had its parameter ``current_path`` used when ``evc.current_path`` fails to install flows.
 - ``evc.current_path`` is deleted when an error with TAG type is raised.
 - Link up from UNI will deploy correctly an EVC when it does not have a path.
+- Validate paths from ``pathfinder`` with interface couples, in and out interfaces.
 
 Added
 =====

--- a/models/path.py
+++ b/models/path.py
@@ -158,9 +158,24 @@ class DynamicPathManager:
         return reply_data.get("paths", [])
 
     @staticmethod
-    def _clear_path(path):
+    def _clear_path(path: list[str]) -> list[str]:
         """Remove switches from a path, returning only interfaces."""
         return [endpoint for endpoint in path if len(endpoint) > 23]
+
+    @staticmethod
+    def _valid_path(clean_path: list[str]) -> bool:
+        """Check is a path is valid by verifying a in and out interface.
+         Returns False if the path is invalid."""
+        # if len is not even
+        if len(clean_path) % 2:
+            return False
+
+        # Check interfaces in pairs, they should be from the same switch
+        for i in range(0, len(clean_path), 2):
+            if (clean_path[i].split(":")[:8]
+                    != clean_path[i + 1].split(":")[:8]):
+                return False
+        return True
 
     @classmethod
     def get_best_paths(cls, circuit, **kwargs):
@@ -283,8 +298,7 @@ class DynamicPathManager:
         """Return the path containing only the interfaces."""
         new_path = Path()
         clean_path = cls._clear_path(path)
-
-        if len(clean_path) % 2:
+        if not cls._valid_path(clean_path):
             return None
 
         for link in zip(clean_path[1:-1:2], clean_path[2::2]):

--- a/tests/unit/models/test_path.py
+++ b/tests/unit/models/test_path.py
@@ -309,11 +309,41 @@ class TestDynamicPathManager():
                 "00:00:00:00:00:00:00:03:3",
                 "00:00:00:00:00:00:00:04:2"
             ],
+            [
+                "00:00:00:00:00:00:00:02:2",
+                "00:00:00:00:00:00:00:02:3",
+                "00:00:00:00:00:00:00:03:3",
+                "00:00:00:00:00:00:00:04:2"
+                "00:00:00:00:00:00:00:04:3"
+            ]
         ]
     )
     def test_valid_path_invalid(self, invalid_path):
         """Test _valid_path for invalid paths."""
         assert DynamicPathManager._valid_path(invalid_path) is False
+
+    @pytest.mark.parametrize(
+        "valid_path",
+        [
+            [
+                "00:00:00:00:00:00:00:02:1",
+                "00:00:00:00:00:00:00:02:3",
+                "00:00:00:00:00:00:00:03:2",
+                "00:00:00:00:00:00:00:03:3",
+            ],
+            [
+                "00:00:00:00:00:00:00:01:1",
+                "00:00:00:00:00:00:00:01:2",
+                "00:00:00:00:00:00:00:02:2",
+                "00:00:00:00:00:00:00:02:3",
+                "00:00:00:00:00:00:00:03:2",
+                "00:00:00:00:00:00:00:03:5",
+            ],
+        ]
+    )
+    def test_valid_path_valid(self, valid_path):
+        """Test _valid_path for valid paths."""
+        assert DynamicPathManager._valid_path(valid_path) is True
 
     def test_create_path_invalid(self):
         """Test create_path method"""

--- a/tests/unit/models/test_path.py
+++ b/tests/unit/models/test_path.py
@@ -10,7 +10,7 @@ from kytos.core.link import Link
 from kytos.core.switch import Switch
 
 # pylint: disable=wrong-import-position,ungrouped-imports,no-member
-# pylint: disable=too-many-public-methods
+# pylint: disable=too-many-public-methods,too-many-lines
 
 sys.path.insert(0, "/var/lib/kytos/napps/..")
 # pylint: enable=wrong-import-position

--- a/tests/unit/models/test_path.py
+++ b/tests/unit/models/test_path.py
@@ -286,6 +286,34 @@ class TestDynamicPathManager():
         # pylint: disable=protected-access
         assert DynamicPathManager._clear_path(path) == expected_path
 
+    def test_valid_path_invalid(self):
+        """Test _valid_path for invalid paths."""
+        invalid_a = [
+            "00:00:00:00:00:00:00:02:3",
+            "00:00:00:00:00:00:00:03:2",
+            "00:00:00:00:00:00:00:03:3",
+            "00:00:00:00:00:00:00:04:2"
+        ]
+        assert DynamicPathManager._valid_path(invalid_a) is False
+
+        invalid_b = [
+            "00:00:00:00:00:00:00:01:2",
+            "00:00:00:00:00:00:00:02:2",
+            "00:00:00:00:00:00:00:02:3",
+            "00:00:00:00:00:00:00:03:2",
+            "00:00:00:00:00:00:00:03:5",
+        ]
+        assert DynamicPathManager._valid_path(invalid_b) is False
+
+        invalid_c = [
+            "00:00:00:00:00:00:00:02:2",
+            "00:00:00:00:00:00:00:02:3",
+            "00:00:00:00:00:00:00:03:2",
+            "00:00:00:00:00:00:00:03:3",
+            "00:00:00:00:00:00:00:04:2"
+        ]
+        assert DynamicPathManager._valid_path(invalid_c) is False
+
     def test_create_path_invalid(self):
         """Test create_path method"""
         path = [

--- a/tests/unit/models/test_path.py
+++ b/tests/unit/models/test_path.py
@@ -286,33 +286,34 @@ class TestDynamicPathManager():
         # pylint: disable=protected-access
         assert DynamicPathManager._clear_path(path) == expected_path
 
-    def test_valid_path_invalid(self):
+    @pytest.mark.parametrize(
+        "invalid_path",
+        [
+            [
+                "00:00:00:00:00:00:00:02:3",
+                "00:00:00:00:00:00:00:03:2",
+                "00:00:00:00:00:00:00:03:3",
+                "00:00:00:00:00:00:00:04:2"
+            ],
+            [
+                "00:00:00:00:00:00:00:01:2",
+                "00:00:00:00:00:00:00:02:2",
+                "00:00:00:00:00:00:00:02:3",
+                "00:00:00:00:00:00:00:03:2",
+                "00:00:00:00:00:00:00:03:5",
+            ],
+            [
+                "00:00:00:00:00:00:00:02:2",
+                "00:00:00:00:00:00:00:02:3",
+                "00:00:00:00:00:00:00:03:2",
+                "00:00:00:00:00:00:00:03:3",
+                "00:00:00:00:00:00:00:04:2"
+            ],
+        ]
+    )
+    def test_valid_path_invalid(self, invalid_path):
         """Test _valid_path for invalid paths."""
-        invalid_a = [
-            "00:00:00:00:00:00:00:02:3",
-            "00:00:00:00:00:00:00:03:2",
-            "00:00:00:00:00:00:00:03:3",
-            "00:00:00:00:00:00:00:04:2"
-        ]
-        assert DynamicPathManager._valid_path(invalid_a) is False
-
-        invalid_b = [
-            "00:00:00:00:00:00:00:01:2",
-            "00:00:00:00:00:00:00:02:2",
-            "00:00:00:00:00:00:00:02:3",
-            "00:00:00:00:00:00:00:03:2",
-            "00:00:00:00:00:00:00:03:5",
-        ]
-        assert DynamicPathManager._valid_path(invalid_b) is False
-
-        invalid_c = [
-            "00:00:00:00:00:00:00:02:2",
-            "00:00:00:00:00:00:00:02:3",
-            "00:00:00:00:00:00:00:03:2",
-            "00:00:00:00:00:00:00:03:3",
-            "00:00:00:00:00:00:00:04:2"
-        ]
-        assert DynamicPathManager._valid_path(invalid_c) is False
+        assert DynamicPathManager._valid_path(invalid_path) is False
 
     def test_create_path_invalid(self):
         """Test create_path method"""


### PR DESCRIPTION
Closes #425

### Summary

Now for a path to be valid, there should be present an interface in and out. This is done by checking interfaces in pairs and comparing the switches.

### Local Tests
Created EVCs from the issue

### End-to-End Tests
N/A
