### PR TITLE
fix: fixed Path `choose_vlans` to be all or nothing, if a path link fails to allocate a vlan

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Fixed
 - ``EVC.remove_current_flows()`` had its parameter ``current_path`` used when ``evc.current_path`` fails to install flows.
 - ``evc.current_path`` is deleted when an error with TAG type is raised.
 - Link up from UNI will deploy correctly an EVC when it does not have a path.
+- Fixed Path ``choose_vlans`` to be all or nothing, if a path link fails to allocate a vlan, it'll release the allocated vlans.
 
 Added
 =====

--- a/tests/unit/models/test_path.py
+++ b/tests/unit/models/test_path.py
@@ -10,6 +10,7 @@ from kytos.core.link import Link
 from kytos.core.switch import Switch
 
 # pylint: disable=wrong-import-position,ungrouped-imports,no-member
+# pylint: disable=too-many-public-methods
 
 sys.path.insert(0, "/var/lib/kytos/napps/..")
 # pylint: enable=wrong-import-position


### PR DESCRIPTION
Closes #620 

### Summary

See updated changelog file

### Local Tests

Same as the one on #620, it no longer happens, no longer leaks if it a link can't allocate a vlan:

```
❯ http PATCH http://0.0.0.0:8181/api/kytos/mef_eline/v2/evc/fb5a0d362cf34b/redeploy
HTTP/1.1 409 Conflict
content-length: 50
content-type: application/json
date: Mon, 10 Feb 2025 18:01:03 GMT
server: uvicorn

{
    "response": "Circuit fb5a0d362cf34b is disabled."
}

❯ http http://0.0.0.0:8181/api/kytos/topology/v3/interfaces/00:00:00:00:00:00:00:02:2/tag_ranges | jq
{
  "00:00:00:00:00:00:00:02:2": {
    "available_tags": {
      "vlan": [
        [
          1,
          3798
        ],
        [
          3800,
          4095
        ]
      ]
    },
    "tag_ranges": {
      "vlan": [
        [
          1,
          4095
        ]
      ]
    },
    "special_tags": {
      "vlan": [
        "untagged",
        "any"
      ]
    },
    "special_available_tags": {
      "vlan": [
        "untagged",
        "any"
      ]
    }
  }
}

```

- Now increated tag_ranges again to allow it to be deployed, and it correctly allocated this time as expected:

```
❯ echo '{"tag_type": "vlan", "tag_ranges": [[1, 3799]]}' |  http POST http://0.0.0.0:8181/api/kytos/topology/v3/interfaces/00:00:00:00:00:00:00:03:2/tag_ranges
HTTP/1.1 200 OK
content-length: 22
content-type: application/json
date: Mon, 10 Feb 2025 18:03:08 GMT
server: uvicorn

"Operation Successful"

❯ echo '{"tag_type": "vlan", "tag_ranges": [[1, 3799]]}' |  http POST http://0.0.0.0:8181/api/kytos/topology/v3/interfaces/00:00:00:00:00:00:00:03:3/tag_ranges
HTTP/1.1 200 OK
content-length: 22
content-type: application/json
date: Mon, 10 Feb 2025 18:03:13 GMT
server: uvicorn

"Operation Successful"


❯ http PATCH http://0.0.0.0:8181/api/kytos/mef_eline/v2/evc/fb5a0d362cf34b/redeploy
HTTP/1.1 202 Accepted
content-length: 56
content-type: application/json
date: Mon, 10 Feb 2025 18:03:17 GMT
server: uvicorn

{
    "response": "Circuit fb5a0d362cf34b redeploy received."
}


❯ http http://0.0.0.0:8181/api/kytos/topology/v3/interfaces/00:00:00:00:00:00:00:02:2/tag_ranges | jq
{
  "00:00:00:00:00:00:00:02:2": {
    "available_tags": {
      "vlan": [
        [
          2,
          3798
        ],
        [
          3800,
          4095
        ]
      ]
    },
    "tag_ranges": {
      "vlan": [
        [
          1,
          4095
        ]
      ]
    },
    "special_tags": {
      "vlan": [
        "untagged",
        "any"
      ]
    },
    "special_available_tags": {
      "vlan": [
        "untagged",
        "any"
      ]
    }
  }
}

```

### End-to-End Tests

Added a new e2e `test_006_evc_vlan_allocation_not_available` https://github.com/kytos-ng/kytos-end-to-end-tests/pull/343, it's passing, the rest of e2e tests are executing and I'll update here shortly too:

```
+ python3 -m pytest tests/test_e2e_15_mef_eline.py -k test_006_evc_vlan_allocation_not_available --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 6 items / 5 deselected / 1 selected
tests/test_e2e_15_mef_eline.py .                                         [100%]
=============================== warnings summary ===============================
tests/test_e2e_15_mef_eline.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    return ( StrictVersion( cls.OVSVersion ) <
tests/test_e2e_15_mef_eline.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    StrictVersion( '1.10' ) )
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
=========== 1 passed, 5 deselected, 34 warnings in 71.77s (0:01:11) ============

+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 278 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  7%]
tests/test_e2e_06_topology.py ....                                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x...................R... [ 23%]
..                                                                       [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 28%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 43%]
.                                                                        [ 43%]
tests/test_e2e_14_mef_eline.py x....                                     [ 45%]
tests/test_e2e_15_mef_eline.py ......                                    [ 47%]
tests/test_e2e_16_mef_eline.py ..                                        [ 48%]
tests/test_e2e_20_flow_manager.py ..........................             [ 57%]
tests/test_e2e_21_flow_manager.py ...                                    [ 58%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ...                                         [ 71%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
tests/test_e2e_50_maintenance.py ............................            [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 94%]
tests/test_e2e_70_kytos_stats.py ........                                [ 97%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
=============================== warnings summary ===============================
= 255 passed, 8 skipped, 8 xfailed, 7 xpassed, 1295 warnings, 1 rerun in 13991.57s (3:53:11) 
```