### PR TITLE
release 2023.2.10: fixed request timeout that could indefinitely hang + backported vlan path choose vlan fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 Fixed
 =====
 - Parametrized requests timeout when finding paths and when sending flow mods to avoid potentially hanging indefinitely
+- Fixed Path ``choose_vlans`` to be all or nothing, if a path link fails to allocate a vlan, it'll release the allocated vlans.
 
 
 [2023.2.9] - 2025-01-22

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [Unreleased]
 ************
 
+[2023.2.10] - 2025-01-22
+***********************
+
+Fixed
+=====
+- Parametrized requests timeout when finding paths and when sending flow mods to avoid potentially hanging indefinitely
+
+
 [2023.2.9] - 2025-01-22
 ***********************
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,8 +6,8 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [Unreleased]
 ************
 
-[2023.2.10] - 2025-01-22
-***********************
+[2023.2.10] - 2025-02-12
+************************
 
 Fixed
 =====

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2023.2.9",
+  "version": "2023.2.10",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -123,7 +123,7 @@ class TestEVC():
         expected_data = {"flows": flow_mods, "force": False}
         assert requests_mock.post.call_count == 1
         requests_mock.post.assert_called_once_with(
-            expected_endpoint, json=expected_data
+            expected_endpoint, json=expected_data, timeout=30
         )
 
     @patch("napps.kytos.mef_eline.models.evc.requests")
@@ -142,7 +142,7 @@ class TestEVC():
         expected_data = {"flows": flow_mods, "force": True}
         assert requests_mock.post.call_count == 1
         requests_mock.post.assert_called_once_with(
-            expected_endpoint, json=expected_data
+            expected_endpoint, json=expected_data, timeout=30
         )
 
     @patch("napps.kytos.mef_eline.models.evc.requests")

--- a/tests/unit/models/test_path.py
+++ b/tests/unit/models/test_path.py
@@ -454,6 +454,7 @@ class TestDynamicPathManager():
         )
         expected_call = call(
             "http://localhost:8181/api/kytos/pathfinder/v3/",
+            timeout=30,
             json={
                 **{
                     "source": circuit.uni_a.interface.id,
@@ -705,6 +706,7 @@ class TestDynamicPathManager():
         max_paths = 10
         expected_call = call(
             "http://localhost:8181/api/kytos/pathfinder/v3/",
+            timeout=30,
             json={
                 **{
                     "source": evc.uni_a.interface.id,


### PR DESCRIPTION
Closes #623 (for additional information check out this [comment](https://github.com/kytos-ng/mef_eline/issues/623#issuecomment-2653853732))

### Summary

- See updated changelog file
- On issue #623 there's still a potential timeout DB operation issue, on this PR it'll only fix the request for now, and also backported #620. 

### Local Tests

- I simulated a pathfinder request retry, and it retried as expected and deployed the EVC:

```
kytos $> 2025-02-12 14:52:59,866 - WARNING [kytos.core.retry] (AnyIO worker thread) Retry #1 for get_paths, args: (EVC(3a8d3c9b603649, epl),), kwargs: {}, seconds since start: 30.04    
2025-02-12 14:53:03,069 - INFO [uvicorn.access] (MainThread) 127.0.0.1:59302 - "POST /api/kytos/pathfinder/v3/ HTTP/1.1" 200
2025-02-12 14:53:03,086 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: add, force: False,  flows[0, 2]: 
[{'match': {'in_port': 1}, 'cookie': 12266271826541295177, 'actions': [{'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output'
, 'port': 4}], 'owner': 'mef_eline', 'table_group': 'epl', 'table_id': 0, 'priority': 10000}, {'match': {'in_port': 4, 'dl_vlan': 1}, 'cookie': 12266271826541295177, 'actions': [{'actio
n_type': 'pop_vlan'}, {'action_type': 'output', 'port': 1}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}]
2025-02-12 14:53:03,105 - INFO [uvicorn.access] (MainThread) 127.0.0.1:59310 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202
2025-02-12 14:53:03,126 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:03, command: add, force: False,  flows[0, 2]: 
[{'match': {'in_port': 1}, 'cookie': 12266271826541295177, 'actions': [{'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output'
, 'port': 3}], 'owner': 'mef_eline', 'table_group': 'epl', 'table_id': 0, 'priority': 10000}, {'match': {'in_port': 3, 'dl_vlan': 1}, 'cookie': 12266271826541295177, 'actions': [{'actio
n_type': 'pop_vlan'}, {'action_type': 'output', 'port': 1}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}]
2025-02-12 14:53:03,142 - INFO [uvicorn.access] (MainThread) 127.0.0.1:59318 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A03 HTTP/1.1" 202
2025-02-12 14:53:03,151 - INFO [kytos.napps.kytos/mef_eline] (AnyIO worker thread) EVC(3a8d3c9b603649, epl) was deployed.
```

- I made sure that the vlan path rollback worked correctly, it did. Nethertheless, on this version we don't have as much logs as newer ones. 


### End-to-End Tests

I haven't run yet for this only local tested