### PR TITLE
release: 2024.1.11: Fixed Path `choose_vlans` to be all or nothing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,11 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2024.1.11] - 2025-02-12
+************************
+
+- Fixed Path ``choose_vlans`` to be all or nothing, if a path link fails to allocate a vlan, it'll release the allocated vlans.
+
 [2024.1.10] - 2025-01-22
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2024.1.10",
+  "version": "2024.1.11",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],


### PR DESCRIPTION
Backporting PR https://github.com/kytos-ng/mef_eline/pull/621 to 2024.1

### Summary

See updated changelog file 

### Local Tests

- Created EVC, simulated the same case
- Also ran unit tests

```
=========================================================================== 299 passed, 635 warnings in 11.96s ===========================================================================
```

### End-to-End Tests

Same as related PR