### PR TITLE
Checking on EVCs before acquiring lock

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,7 @@ Changed
 - ``primary_path``, ``backup_path``, ``primary_links`` and ``backup_links`` now only accept endpoint IDs in the API request content.
 - Now when installing or deleting a path, a single request to ``flow_manager`` will be sent per path.
 - UI: Added column ``Path Types`` to ``View Connections`` component to indicate if the EVC has a ``dynamic_backup_path``, ``static_primary`` or ``static_backup`` value.
+- When a link flap happens, now ``mef_eline`` will check on EVC attributes to decide whether to acquire an EVC lock.
 
 [2024.1.4] - 2024-09-09
 ***********************

--- a/main.py
+++ b/main.py
@@ -30,8 +30,8 @@ from napps.kytos.mef_eline.exceptions import (DisabledSwitch,
 from napps.kytos.mef_eline.models import (EVC, DynamicPathManager, EVCDeploy,
                                           Path)
 from napps.kytos.mef_eline.scheduler import CircuitSchedule, Scheduler
-from napps.kytos.mef_eline.utils import (aemit_event, check_disabled_component,
-                                         check_interface_on_evc, emit_event,
+from napps.kytos.mef_eline.utils import (_does_uni_affect_evc, aemit_event,
+                                         check_disabled_component, emit_event,
                                          get_vlan_tags_and_masks,
                                          map_evc_event_content,
                                          merge_flow_dicts, prepare_delete_flow,
@@ -814,7 +814,7 @@ class Main(KytosNApp):
         """
         log.info("Event handle_interface_link_up %s", interface)
         for evc in self.get_evcs_by_svc_level():
-            if check_interface_on_evc(evc, interface, lambda x: x):
+            if _does_uni_affect_evc(evc, interface, "up"):
                 with evc.lock:
                     evc.handle_interface_link_up(
                         interface
@@ -826,7 +826,7 @@ class Main(KytosNApp):
         """
         log.info("Event handle_interface_link_down %s", interface)
         for evc in self.get_evcs_by_svc_level():
-            if check_interface_on_evc(evc, interface, not_):
+            if _does_uni_affect_evc(evc, interface, "down"):
                 with evc.lock:
                     evc.handle_interface_link_down(
                         interface

--- a/main.py
+++ b/main.py
@@ -8,7 +8,6 @@ import time
 import traceback
 from collections import defaultdict
 from copy import deepcopy
-from operator import not_
 from threading import Lock
 from typing import Optional
 

--- a/main.py
+++ b/main.py
@@ -812,10 +812,11 @@ class Main(KytosNApp):
         """
         log.info("Event handle_interface_link_up %s", interface)
         for evc in self.get_evcs_by_svc_level():
-            with evc.lock:
-                evc.handle_interface_link_up(
-                    interface
-                )
+            if evc.is_enabled() and not evc.archived:
+                with evc.lock:
+                    evc.handle_interface_link_up(
+                        interface
+                    )
 
     def handle_interface_link_down(self, interface):
         """
@@ -823,10 +824,11 @@ class Main(KytosNApp):
         """
         log.info("Event handle_interface_link_down %s", interface)
         for evc in self.get_evcs_by_svc_level():
-            with evc.lock:
-                evc.handle_interface_link_down(
-                    interface
-                )
+            if evc.is_enabled() and not evc.archived:
+                with evc.lock:
+                    evc.handle_interface_link_down(
+                        interface
+                    )
 
     @listen_to("kytos/topology.link_down", pool="dynamic_single")
     def on_link_down(self, event):
@@ -1033,7 +1035,7 @@ class Main(KytosNApp):
         if command != "add":
             return
         evc = self.circuits.get(EVC.get_id_from_cookie(flow.cookie))
-        if evc:
+        if evc and evc.is_enabled() and not evc.archived:
             with evc.lock:
                 evc.remove_current_flows(sync=False)
                 evc.remove_failover_flows(sync=True)

--- a/models/evc.py
+++ b/models/evc.py
@@ -1865,8 +1865,6 @@ class LinkProtection(EVCDeploy):
         """
         Handler for interface link_up events
         """
-        if self.is_active():
-            return
         if not _does_uni_affect_evc(self, interface, "up"):
             return
         if self.try_to_handle_uni_as_link_up(interface):
@@ -1897,8 +1895,6 @@ class LinkProtection(EVCDeploy):
         """
         Handler for interface link_down events
         """
-        if not self.is_active():
-            return
         if not _does_uni_affect_evc(self, interface, "down"):
             return
         interface_dicts = {

--- a/models/evc.py
+++ b/models/evc.py
@@ -26,7 +26,8 @@ from napps.kytos.mef_eline.exceptions import (ActivationError,
                                               DuplicatedNoTagUNI,
                                               EVCPathNotInstalled,
                                               FlowModException, InvalidPath)
-from napps.kytos.mef_eline.utils import (check_disabled_component,
+from napps.kytos.mef_eline.utils import (_does_uni_affect_evc,
+                                         check_disabled_component,
                                          compare_endpoint_trace,
                                          compare_uni_out_trace, emit_event,
                                          make_uni_list, map_dl_vlan,
@@ -1866,15 +1867,7 @@ class LinkProtection(EVCDeploy):
         """
         if self.is_active():
             return
-        interfaces = (self.uni_a.interface, self.uni_z.interface)
-        if interface not in interfaces:
-            return
-        down_interfaces = [
-            interface
-            for interface in interfaces
-            if interface.status != EntityStatus.UP
-        ]
-        if down_interfaces:
+        if not _does_uni_affect_evc(self, interface, "up"):
             return
         if self.try_to_handle_uni_as_link_up(interface):
             return
@@ -1884,7 +1877,7 @@ class LinkProtection(EVCDeploy):
                 'status': interface.status.value,
                 'status_reason': interface.status_reason,
             }
-            for interface in interfaces
+            for interface in (self.uni_a.interface, self.uni_z.interface)
         }
         try:
             self.try_to_activate()
@@ -1906,22 +1899,15 @@ class LinkProtection(EVCDeploy):
         """
         if not self.is_active():
             return
-        interfaces = (self.uni_a.interface, self.uni_z.interface)
-        if interface not in interfaces:
-            return
-        down_interfaces = [
-            interface
-            for interface in interfaces
-            if interface.status != EntityStatus.UP
-        ]
-        if not down_interfaces:
+        if not _does_uni_affect_evc(self, interface, "down"):
             return
         interface_dicts = {
             interface.id: {
                 'status': interface.status.value,
                 'status_reason': interface.status_reason,
             }
-            for interface in down_interfaces
+            for interface in (self.uni_a.interface, self.uni_z.interface)
+            if interface.status != EntityStatus.UP
         }
         self.deactivate()
         log.info(

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2345,6 +2345,7 @@ class TestMain:
         event = MagicMock()
         event.content = {'flow': flow, 'error_command': 'add'}
         evc = create_autospec(EVC)
+        evc.archived = False
         evc.remove_current_flows = MagicMock()
         evc.lock = MagicMock()
         self.napp.circuits = {"00000000000011": evc}

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,5 @@
 """Module to test the utls.py file."""
 from unittest.mock import MagicMock, Mock
-from operator import not_
 import pytest
 
 from kytos.core.common import EntityStatus
@@ -10,7 +9,7 @@ from napps.kytos.mef_eline.utils import (check_disabled_component,
                                          compare_uni_out_trace,
                                          get_vlan_tags_and_masks, map_dl_vlan,
                                          merge_flow_dicts, prepare_delete_flow,
-                                         check_interface_on_evc)
+                                         _does_uni_affect_evc)
 
 
 # pylint: disable=too-many-public-methods, too-many-lines
@@ -199,62 +198,62 @@ class TestUtils:
 
     # pylint: disable=too-many-arguments
     @pytest.mark.parametrize(
-        "intf_a_status, intf_z_status, is_active, is_uni, function, expected",
+        "intf_a_status, intf_z_status, is_active, is_uni, event, expected",
         [
             # link_DOWN
             (
                 EntityStatus.DOWN, EntityStatus.DOWN,
-                True, True, lambda x: x, True
+                True, True, 'down', True
             ),
             (
                 EntityStatus.UP, EntityStatus.UP,
-                True, True, lambda x: x, False
+                True, True, 'down', False
             ),
             (
                 EntityStatus.DOWN, EntityStatus.UP,
-                False, True, lambda x: x, False
+                False, True, 'down', False
             ),
             (
                 EntityStatus.UP, EntityStatus.UP,
-                False, True, lambda x: x, False
+                False, True, 'down', False
             ),
             (  # Not UNI
                 EntityStatus.DOWN, EntityStatus.DOWN,
-                True, False, lambda x: x, False
+                True, False, 'down', False
             ),
             # link_up
             (
                 EntityStatus.DOWN, EntityStatus.DOWN,
-                True, True, not_, False
+                True, True, 'up', False
             ),
             (
                 EntityStatus.UP, EntityStatus.UP,
-                True, True, not_, False
+                True, True, 'up', False
             ),
             (
                 EntityStatus.DOWN, EntityStatus.UP,
-                False, True, not_, False
+                False, True, 'up', False
             ),
             (
                 EntityStatus.UP, EntityStatus.UP,
-                False, True, not_, True
+                False, True, 'up', True
             ),
             (  # Not UNI
                 EntityStatus.UP, EntityStatus.UP,
-                False, False, not_, False
+                False, False, 'up', False
             ),
         ]
     )
-    def test_check_interface_on_evc(
+    def test_does_uni_affect_evc(
         self,
         intf_a_status,
         intf_z_status,
         is_active,
         is_uni,
-        function,
+        event,
         expected
     ):
-        """Test check_interface_on_evc when interface."""
+        """Test _does_uni_affect_evc when interface."""
         evc = Mock()
         evc.uni_a.interface.status = intf_a_status
         evc.uni_z.interface.status = intf_z_status
@@ -263,4 +262,4 @@ class TestUtils:
         else:
             interface = Mock()
         evc.is_active.return_value = is_active
-        assert check_interface_on_evc(evc, interface, function) is expected
+        assert _does_uni_affect_evc(evc, interface, event) is expected

--- a/utils.py
+++ b/utils.py
@@ -203,8 +203,10 @@ def _does_uni_affect_evc(evc, interface: Interface, link_event: str) -> bool:
     interface_a = evc.uni_a.interface
     interface_z = evc.uni_z.interface
     interface_affected = interface in (interface_a, interface_z)
-    interface_down = (EntityStatus.DOWN in
-                      (interface_a.status, interface_z.status))
+    interface_down = (
+        interface_a.status != EntityStatus.UP
+        or interface_z.status != EntityStatus.UP
+    )
     if link_event == "up":
         return (not evc.is_active() and interface_affected
                 and not interface_down)

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,5 @@
 """Utility functions."""
-from typing import Callable, Union
+from typing import Union
 
 from kytos.core.common import EntityStatus
 from kytos.core.events import KytosEvent
@@ -198,13 +198,16 @@ def prepare_delete_flow(evc_flows: dict[str, list[dict]]):
     return dpid_flows
 
 
-def check_interface_on_evc(evc, interface: Interface, operation: Callable):
-    """Check if an interface flap is affecting an evc."""
+def _does_uni_affect_evc(evc, interface: Interface, link_event: str) -> bool:
+    """Check if an interface flap is affecting an EVC UNI."""
     interface_a = evc.uni_a.interface
     interface_z = evc.uni_z.interface
-    if (operation(evc.is_active()) and
-        interface in (interface_a, interface_z) and
-        operation(interface_a.status != EntityStatus.UP or
-                  interface_z.status != EntityStatus.UP)):
-        return True
+    interface_affected = interface in (interface_a, interface_z)
+    interface_down = (EntityStatus.DOWN in
+                      (interface_a.status, interface_z.status))
+    if link_event == "up":
+        return (not evc.is_active() and interface_affected
+                and not interface_down)
+    if link_event == "down":
+        return evc.is_active() and interface_affected and interface_down
     return False

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,5 @@
 """Utility functions."""
-from typing import Union
+from typing import Callable, Union
 
 from kytos.core.common import EntityStatus
 from kytos.core.events import KytosEvent
@@ -196,3 +196,15 @@ def prepare_delete_flow(evc_flows: dict[str, list[dict]]):
                 "cookie_mask": int(0xffffffffffffffff)
             })
     return dpid_flows
+
+
+def check_interface_on_evc(evc, interface: Interface, operation: Callable):
+    """Check if an interface flap is affecting an evc."""
+    interface_a = evc.uni_a.interface
+    interface_z = evc.uni_z.interface
+    if (operation(evc.is_active()) and
+        interface in (interface_a, interface_z) and
+        operation(interface_a.status != EntityStatus.UP or
+                  interface_z.status != EntityStatus.UP)):
+        return True
+    return False


### PR DESCRIPTION
Closes #622

### Summary

Confirmed that the listed issue is related to issue #623 by locking a second EVC with:
```
def test2(evc):
    from threading import Thread

    def locking(evc):
        with evc.lock:
            while True:
                continue
    
    thread = Thread(target=locking, args=(evc,))
    thread.start()
```
Added checks for EVC before acquiring lock to reduce the possibility of this happening again.

### Local Tests
Replicated the issue but the problem is handled in another issue.

### End-to-End Tests
```
python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 278 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  7%]
tests/test_e2e_06_topology.py ....                                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 23%]
.                                                                        [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 28%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 43%]
.                                                                        [ 43%]
tests/test_e2e_14_mef_eline.py x....                                     [ 45%]
tests/test_e2e_15_mef_eline.py ......                                    [ 47%]
tests/test_e2e_16_mef_eline.py ..                                        [ 48%]
tests/test_e2e_20_flow_manager.py ..........................             [ 57%]
tests/test_e2e_21_flow_manager.py ...                                    [ 58%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py .R...                                       [ 70%]
tests/test_e2e_31_of_lldp.py ...                                         [ 71%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
tests/test_e2e_50_maintenance.py ............................            [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 94%]
tests/test_e2e_70_kytos_stats.py ........                                [ 97%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]

```