### PR TITLE
Getting interfaces from UNIs instead of switches

### DIFF
--- a/main.py
+++ b/main.py
@@ -113,7 +113,7 @@ class Main(KytosNApp):
                 and not circuit.lock.locked()
                 and not circuit.has_recent_removed_flow()
                 and not circuit.is_recent_updated()
-                and circuit.are_unis_active(self.controller.switches)
+                and circuit.are_unis_active()
                 # if a inter-switch EVC does not have current_path, it does not
                 # make sense to run sdntrace on it
                 and (circuit.is_intra_switch() or circuit.current_path)

--- a/models/evc.py
+++ b/models/evc.py
@@ -1832,17 +1832,10 @@ class LinkProtection(EVCDeploy):
 
         return success
 
-    @staticmethod
-    def get_interface_from_switch(uni: UNI, switches: dict) -> Interface:
-        """Get interface from switch by uni"""
-        switch = switches[uni.interface.switch.dpid]
-        interface = switch.interfaces[uni.interface.port_number]
-        return interface
-
-    def are_unis_active(self, switches: dict) -> bool:
+    def are_unis_active(self) -> bool:
         """Determine whether this EVC should be active"""
-        interface_a = self.get_interface_from_switch(self.uni_a, switches)
-        interface_z = self.get_interface_from_switch(self.uni_z, switches)
+        interface_a = self.uni_a.interface
+        interface_z = self.uni_z.interface
         active, _ = self.is_uni_interface_active(interface_a, interface_z)
         return active
 

--- a/tests/unit/models/test_link_protection.py
+++ b/tests/unit/models/test_link_protection.py
@@ -797,34 +797,19 @@ class TestLinkProtection():  # pylint: disable=too-many-public-methods
         assert deploy_primary_mock.call_count == 1
         assert deploy_backup_mock.call_count == 1
 
-    async def test_get_interface_from_switch(self):
-        """Test get_interface_from_switch"""
-        interface = id_to_interface_mock('00:01:1')
-        interface.switch.interfaces = {1: interface}
-        switches = {
-            '00:01': interface.switch
-        }
-        uni = get_uni_mocked(is_valid=True, switch_dpid='00:01')
-        actual_interface = self.evc.get_interface_from_switch(uni, switches)
-        assert interface == actual_interface
-
     async def test_are_unis_active(self):
         """Test are_unis_active"""
-        interface = id_to_interface_mock('00:01:1')
+        self.evc.uni_a.interface._enabled = True
+        self.evc.uni_z.interface._enabled = True
+        assert self.evc.are_unis_active() is True
 
-        interface.switch.interfaces = {1: interface}
-        switches = {
-            'custom_switch_dpid': interface.switch
-        }
+        self.evc.uni_a.interface._active = False
+        self.evc.uni_z.interface._active = False
+        assert self.evc.are_unis_active() is False
 
-        interface.status = EntityStatus.UP
-        assert self.evc.are_unis_active(switches) is True
-
-        interface.status = EntityStatus.DOWN
-        assert self.evc.are_unis_active(switches) is False
-
-        interface.status = EntityStatus.DISABLED
-        assert self.evc.are_unis_active(switches) is False
+        self.evc.uni_a.interface._enabled = False
+        self.evc.uni_z.interface._enabled = False
+        assert self.evc.are_unis_active() is False
 
     async def test_is_uni_interface_active(self):
         """Test is_uni_interface_active"""


### PR DESCRIPTION
Closes #579 

### Summary

Deleted `get_interface_from_switch()` because the interfaces are gotten from the UNIs now.

### Local Tests
Check on kytos console for `are_unis_active()`

### End-to-End Tests
TBA