### PR TITLE
Fixed Autocomplete

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,7 +40,11 @@ Changed
 - ``primary_path``, ``backup_path``, ``primary_links`` and ``backup_links`` now only accept endpoint IDs in the API request content.
 - Now when installing or deleting a path, a single request to ``flow_manager`` will be sent per path.
 - UI: Added column ``Path Types`` to ``View Connections`` component to indicate if the EVC has a ``dynamic_backup_path``, ``static_primary`` or ``static_backup`` value.
+<<<<<<< HEAD
 - When a link flap happens, now ``mef_eline`` will check on EVC attributes to decide whether to acquire an EVC lock.
+=======
+- UI: The method ``onblur_dpid`` was changed to a computed property.
+>>>>>>> 09547c0 (Updated CHANGELOG.rst)
 
 [2024.1.4] - 2024-09-09
 ***********************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,11 +40,8 @@ Changed
 - ``primary_path``, ``backup_path``, ``primary_links`` and ``backup_links`` now only accept endpoint IDs in the API request content.
 - Now when installing or deleting a path, a single request to ``flow_manager`` will be sent per path.
 - UI: Added column ``Path Types`` to ``View Connections`` component to indicate if the EVC has a ``dynamic_backup_path``, ``static_primary`` or ``static_backup`` value.
-<<<<<<< HEAD
 - When a link flap happens, now ``mef_eline`` will check on EVC attributes to decide whether to acquire an EVC lock.
-=======
 - UI: The method ``onblur_dpid`` was changed to a computed property.
->>>>>>> 09547c0 (Updated CHANGELOG.rst)
 
 [2024.1.4] - 2024-09-09
 ***********************

--- a/ui/k-info-panel/list_connections.kytos
+++ b/ui/k-info-panel/list_connections.kytos
@@ -61,7 +61,7 @@
 </template>
 
 <script>
-module.exports = {
+export default {
   data(){
     return {
       flag_loading: false,

--- a/ui/k-info-panel/show_circuit.kytos
+++ b/ui/k-info-panel/show_circuit.kytos
@@ -260,7 +260,7 @@
     </div>
 </template>
 <script>
-module.exports = {
+export default {
   props: {
     content: {
       type: Object,

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -218,7 +218,7 @@
   </k-toolbar-item>
 </template>
 <script>
-module.exports = {
+export default {
   data(){
     return {
         circuit_name: "",
@@ -302,6 +302,26 @@ module.exports = {
           x => queue_ids.push({value:x?.toString(), description:String(x)})
       )
       return queue_ids;
+    },
+    onblur_dpid() {
+        /**
+        * Update dpid values on event onblur triggered in dpids fields.
+        * It split the value selected from autocomplete list.
+        * It is expected the value as "NAME - DPID".
+        **/
+        let dpid_a = this.endpoint_a;
+        if(dpid_a.lastIndexOf(' ') > 0) {
+            let splitted_dpid = dpid_a.split(' ');
+            this.endpoint_name_a = splitted_dpid[0];
+            this.endpoint_a = splitted_dpid[2];
+        }
+        
+        let dpid_z = this.endpoint_z;
+        if(dpid_z.lastIndexOf(' ') > 0) {
+            let splitted_dpid = dpid_z.split(' ');
+            this.endpoint_name_z = splitted_dpid[0];
+            this.endpoint_z = splitted_dpid[2];
+        }
     },
   },
   methods: {
@@ -595,26 +615,6 @@ module.exports = {
           });
         }
       });
-    },
-    onblur_dpid: function() {
-        /**
-        * Update dpid values on event onblur triggered in dpids fields.
-        * It split the value selected from autocomplete list.
-        * It is expected the value as "NAME - DPID".
-        **/
-        let dpid_a = this.endpoint_a;
-        if(dpid_a.lastIndexOf(' ') > 0) {
-            let splitted_dpid = dpid_a.split(' ');
-            this.endpoint_name_a = splitted_dpid[0];
-            this.endpoint_a = splitted_dpid[2];
-        }
-        
-        let dpid_z = this.endpoint_z;
-        if(dpid_z.lastIndexOf(' ') > 0) {
-            let splitted_dpid = dpid_z.split(' ');
-            this.endpoint_name_z = splitted_dpid[0];
-            this.endpoint_z = splitted_dpid[2];
-        }
     },
   },
   mounted() { // when the Vue app is booted up, this is run automatically.


### PR DESCRIPTION
Closes #630 

### Summary

There was a method called `onblur_dpid` used for the autocomplete that was actually supposed to be a computed property. Because of this, the autocomplete did not function as it should.

### Local Tests

The autocomplete worked after the changes.

### End-to-End Tests
