### PR TITLE
Fix handle_evc_need_redeploy to use `deploy` instead of `deploy_to_path`

### DIFF
--- a/main.py
+++ b/main.py
@@ -1106,7 +1106,7 @@ class Main(KytosNApp):
         with evc.lock:
             if not evc.is_enabled() or evc.is_active():
                 return
-            result = evc.deploy_to_path()
+            result = evc.deploy()
         event_name = "error_redeploy_link_down"
         if result:
             log.info(f"{evc} redeployed")


### PR DESCRIPTION
### Summary

Fixes faulty need_redeploy behaviour, where deployment to dynamic path would be done rather than to primary/backup path.

### Local Tests

Running this locally, the behavior now matches the expected.

### End-to-End Tests

Issue was identified in E2E tests. E2E test now passes:

```
=================================================================== test session starts ===================================================================
platform linux -- Python 3.11.11, pytest-8.3.4, pluggy-1.5.0
rootdir: /home/ktmi/Documents/kytos-project/kytos-end-to-end-tests
plugins: anyio-4.3.0
collected 46 items                                                                                                                                        

tests/test_e2e_10_mef_eline.py ..........ss.....x........................                                                                           [ 91%]
tests/test_e2e_17_mef_eline.py ....                                                                                                                 [100%]

==================================================================== warnings summary =====================================================================
tests/test_e2e_10_mef_eline.py::TestE2EMefEline::test_010_list_evcs_should_be_empty
  /home/ktmi/Documents/kytos-project/.venv/lib/python3.11/site-packages/mininet/log.py:162: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    return fn( *args )

tests/test_e2e_10_mef_eline.py: 17 warnings
tests/test_e2e_17_mef_eline.py: 37 warnings
  /home/ktmi/Documents/kytos-project/.venv/lib/python3.11/site-packages/mininet/node.py:1106: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    return ( StrictVersion( cls.OVSVersion ) <

tests/test_e2e_10_mef_eline.py: 17 warnings
tests/test_e2e_17_mef_eline.py: 37 warnings
  /home/ktmi/Documents/kytos-project/.venv/lib/python3.11/site-packages/mininet/node.py:1107: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    StrictVersion( '1.10' ) )

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
-------------------------------------------------------------------- start/stop times ---------------------------------------------------------------------
=========================================== 43 passed, 2 skipped, 1 xfailed, 109 warnings in 1964.36s (0:32:44) ===========================================
```