### PR TITLE
Backport fix for `handle_need redeploy`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2024.1.13] - 2025-02-25
+************************
+
+Fixed
+=====
+- Fixed ``handle_need_redeploy`` deploying dynamic paths, rather than primary/backup paths.
+
 [2024.1.12] - 2025-02-18
 ************************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2024.1.12",
+  "version": "2024.1.13",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],

--- a/main.py
+++ b/main.py
@@ -1103,7 +1103,7 @@ class Main(KytosNApp):
         with evc.lock:
             if not evc.is_enabled() or evc.is_active():
                 return
-            result = evc.deploy_to_path()
+            result = evc.deploy()
         event_name = "error_redeploy_link_down"
         if result:
             log.info(f"{evc} redeployed")


### PR DESCRIPTION
Backport of #632

### Summary

Replaces usage of `deploy_to_path` in `handle_need_redeploy` with `deploy`

### Local Tests

Seems to run as expected in local testing.

### End-to-End Tests

Here are the relevant E2E test results:

```
=================================================================== test session starts ===================================================================
platform linux -- Python 3.11.11, pytest-8.3.4, pluggy-1.5.0
rootdir: /home/ktmi/Documents/kytos-project2024/kytos-end-to-end-tests
plugins: anyio-4.3.0
collected 42 items                                                                                                                                        

tests/test_e2e_10_mef_eline.py ..........ss.....x........................                                                                           [100%]

==================================================================== warnings summary =====================================================================
tests/test_e2e_10_mef_eline.py::TestE2EMefEline::test_010_list_evcs_should_be_empty
  /home/ktmi/Documents/kytos-project2024/.venv/lib/python3.11/site-packages/mininet/log.py:162: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    return fn( *args )

tests/test_e2e_10_mef_eline.py: 17 warnings
  /home/ktmi/Documents/kytos-project2024/.venv/lib/python3.11/site-packages/mininet/node.py:1106: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    return ( StrictVersion( cls.OVSVersion ) <

tests/test_e2e_10_mef_eline.py: 17 warnings
  /home/ktmi/Documents/kytos-project2024/.venv/lib/python3.11/site-packages/mininet/node.py:1107: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    StrictVersion( '1.10' ) )

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
-------------------------------------------------------------------- start/stop times ---------------------------------------------------------------------
=========================================== 39 passed, 2 skipped, 1 xfailed, 35 warnings in 1802.42s (0:30:02) ============================================
```