### PR TITLE
fix: DB controller now retries for `ExecutionTimeout` and `ConnectionFailure` instead of just `AutoReconnect`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Fixed
 - Link up from UNI will deploy correctly an EVC when it does not have a path.
 - Fixed Path ``choose_vlans`` to be all or nothing, if a path link fails to allocate a vlan, it'll release the allocated vlans.
 - Validate paths from ``pathfinder`` with interface couples, in and out interfaces.
+- DB controller now retries for ``ExecutionTimeout`` and ``ConnectionFailure`` instead of just ``AutoReconnect``
 
 Added
 =====

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -6,7 +6,7 @@ from typing import Dict, Optional
 
 import pymongo
 from pymongo.collection import ReturnDocument
-from pymongo.errors import AutoReconnect
+from pymongo.errors import ConnectionFailure, ExecutionTimeout
 from pymongo.operations import UpdateOne
 from tenacity import retry_if_exception_type, stop_after_attempt, wait_random
 
@@ -26,7 +26,7 @@ from napps.kytos.mef_eline.db.models import EVCBaseDoc, EVCUpdateDoc
         max=int(os.environ.get("MONGO_AUTO_RETRY_WAIT_RANDOM_MAX", "1")),
     ),
     before_sleep=before_sleep,
-    retry=retry_if_exception_type((AutoReconnect,)),
+    retry=retry_if_exception_type((ConnectionFailure, ExecutionTimeout)),
 )
 class ELineController:
     """E-Line Controller"""


### PR DESCRIPTION
Closes https://github.com/kytos-ng/kytos/issues/535

This PR is on top of PR #632 

### Summary

- See updated changelog file 
- Index creation timeout didn't get ajusted since the default is plenty when its first created

### Local Tests

Local tests were done with https://github.com/kytos-ng/kytos/pull/539 

### End-to-End Tests

E2e tests were done with https://github.com/kytos-ng/kytos/pull/539 