### PR TITLE
Added EVC checkup before acquiring lock

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2024.1.14] - 2025-02-27
+************************
+
+Changed
+=======
+-  When a link flap happens, now ``mef_eline`` will check on EVC attributes to decide whether to acquire an EVC lock.
+
 [2024.1.13] - 2025-02-25
 ************************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2024.1.13",
+  "version": "2024.1.14",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],

--- a/main.py
+++ b/main.py
@@ -31,8 +31,9 @@ from napps.kytos.mef_eline.exceptions import (DisabledSwitch,
 from napps.kytos.mef_eline.models import (EVC, DynamicPathManager, EVCDeploy,
                                           Path)
 from napps.kytos.mef_eline.scheduler import CircuitSchedule, Scheduler
-from napps.kytos.mef_eline.utils import (aemit_event, check_disabled_component,
-                                         emit_event, get_vlan_tags_and_masks,
+from napps.kytos.mef_eline.utils import (_does_uni_affect_evc, aemit_event,
+                                         check_disabled_component, emit_event,
+                                         get_vlan_tags_and_masks,
                                          map_evc_event_content,
                                          merge_flow_dicts, prepare_delete_flow,
                                          send_flow_mods_http)
@@ -815,10 +816,11 @@ class Main(KytosNApp):
         """
         log.info("Event handle_interface_link_up %s", interface)
         for evc in self.get_evcs_by_svc_level():
-            with evc.lock:
-                evc.handle_interface_link_up(
-                    interface
-                )
+            if _does_uni_affect_evc(evc, interface, 'up'):
+                with evc.lock:
+                    evc.handle_interface_link_up(
+                        interface
+                    )
 
     def handle_interface_link_down(self, interface):
         """
@@ -826,10 +828,11 @@ class Main(KytosNApp):
         """
         log.info("Event handle_interface_link_down %s", interface)
         for evc in self.get_evcs_by_svc_level():
-            with evc.lock:
-                evc.handle_interface_link_down(
-                    interface
-                )
+            if _does_uni_affect_evc(evc, interface, 'down'):
+                with evc.lock:
+                    evc.handle_interface_link_down(
+                        interface
+                    )
 
     @listen_to("kytos/topology.link_down", pool="dynamic_single")
     def on_link_down(self, event):

--- a/models/evc.py
+++ b/models/evc.py
@@ -26,7 +26,8 @@ from napps.kytos.mef_eline.exceptions import (ActivationError,
                                               DuplicatedNoTagUNI,
                                               EVCPathNotInstalled,
                                               FlowModException, InvalidPath)
-from napps.kytos.mef_eline.utils import (check_disabled_component,
+from napps.kytos.mef_eline.utils import (_does_uni_affect_evc,
+                                         check_disabled_component,
                                          compare_endpoint_trace,
                                          compare_uni_out_trace, emit_event,
                                          make_uni_list, map_dl_vlan,
@@ -1855,17 +1856,7 @@ class LinkProtection(EVCDeploy):
         """
         Handler for interface link_up events
         """
-        if self.is_active():
-            return
-        interfaces = (self.uni_a.interface, self.uni_z.interface)
-        if interface not in interfaces:
-            return
-        down_interfaces = [
-            interface
-            for interface in interfaces
-            if interface.status != EntityStatus.UP
-        ]
-        if down_interfaces:
+        if not _does_uni_affect_evc(self, interface, 'up'):
             return
         if self.try_to_handle_uni_as_link_up(interface):
             return
@@ -1875,7 +1866,7 @@ class LinkProtection(EVCDeploy):
                 'status': interface.status.value,
                 'status_reason': interface.status_reason,
             }
-            for interface in interfaces
+            for interface in (self.uni_a.interface, self.uni_z.interface)
         }
         try:
             self.try_to_activate()
@@ -1895,24 +1886,15 @@ class LinkProtection(EVCDeploy):
         """
         Handler for interface link_down events
         """
-        if not self.is_active():
-            return
-        interfaces = (self.uni_a.interface, self.uni_z.interface)
-        if interface not in interfaces:
-            return
-        down_interfaces = [
-            interface
-            for interface in interfaces
-            if interface.status != EntityStatus.UP
-        ]
-        if not down_interfaces:
+        if not _does_uni_affect_evc(self, interface, 'down'):
             return
         interface_dicts = {
             interface.id: {
                 'status': interface.status.value,
                 'status_reason': interface.status_reason,
             }
-            for interface in down_interfaces
+            for interface in (self.uni_a.interface, self.uni_z.interface)
+            if interface.status != EntityStatus.UP
         }
         self.deactivate()
         log.info(

--- a/tests/unit/models/test_path.py
+++ b/tests/unit/models/test_path.py
@@ -10,6 +10,7 @@ from kytos.core.link import Link
 from kytos.core.switch import Switch
 
 # pylint: disable=wrong-import-position,ungrouped-imports,no-member
+# pylint: disable=too-many-public-methods
 
 sys.path.insert(0, "/var/lib/kytos/napps/..")
 # pylint: enable=wrong-import-position

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2470,6 +2470,7 @@ class TestMain:
         event = MagicMock()
         event.content = {'flow': flow, 'error_command': 'add'}
         evc = create_autospec(EVC)
+        evc.archived = False
         evc.remove_current_flows = MagicMock()
         evc.lock = MagicMock()
         self.napp.circuits = {"00000000000011": evc}

--- a/utils.py
+++ b/utils.py
@@ -243,3 +243,20 @@ def prepare_delete_flow(evc_flows: dict[str, list[dict]]):
                 "cookie_mask": int(0xffffffffffffffff)
             })
     return dpid_flows
+
+
+def _does_uni_affect_evc(evc, interface: Interface, link_event: str) -> bool:
+    """Check if an interface flap is affecting an EVC UNI."""
+    interface_a = evc.uni_a.interface
+    interface_z = evc.uni_z.interface
+    interface_affected = interface in (interface_a, interface_z)
+    interface_down = (
+        interface_a.status != EntityStatus.UP
+        or interface_z.status != EntityStatus.UP
+    )
+    if link_event == "up":
+        return (not evc.is_active() and interface_affected
+                and not interface_down)
+    if link_event == "down":
+        return evc.is_active() and interface_affected and interface_down
+    return False


### PR DESCRIPTION
Closes #635 

### Summary

Added EVC checkup before acquiring lock

### Local Tests
Tried link flaps and e2e `test_025_uni_link_up_static_path()`
Run unit tests:
```
================================================ test session starts =================================================
platform linux -- Python 3.11.2, pytest-8.0.1, pluggy-1.5.0
cachedir: .tox/py311/.pytest_cache
rootdir: /home/aldo/Desktop/old/mef_eline
configfile: pytest.ini
plugins: asyncio-0.23.5, cov-4.1.0, anyio-4.3.0
asyncio: mode=Mode.AUTO
collected 314 items                                                                                                  

tests/unit/models/test_evc_base.py .................................                                           [ 10%]
tests/unit/models/test_evc_deploy.py ......................................................................... [ 33%]
...............                                                                                                [ 38%]
tests/unit/models/test_link_protection.py ..................                                                   [ 44%]
tests/unit/models/test_path.py .............................                                                   [ 53%]
tests/unit/test_controllers.py ........                                                                        [ 56%]
tests/unit/test_db_models.py .........................                                                         [ 64%]
tests/unit/test_main.py ..................................................................................     [ 90%]
tests/unit/test_scheduler.py .........                                                                         [ 92%]
tests/unit/test_utils.py ......................                                                                [100%]
```

### End-to-End Tests
N/A
