### PR TITLE
Backport Added EVC checkup before acquiring lock

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [Unreleased]
 ************
 
+[2023.2.11] - 2025-02-27
+************************
+
+Changed
+=======
+-  When a link flap happens, now ``mef_eline`` will check on EVC attributes to decide whether to acquire an EVC lock.
+
 [2023.2.10] - 2025-02-12
 ************************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2023.2.10",
+  "version": "2023.2.11",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],

--- a/main.py
+++ b/main.py
@@ -28,8 +28,9 @@ from napps.kytos.mef_eline.exceptions import (DisabledSwitch,
 from napps.kytos.mef_eline.models import (EVC, DynamicPathManager, EVCDeploy,
                                           Path)
 from napps.kytos.mef_eline.scheduler import CircuitSchedule, Scheduler
-from napps.kytos.mef_eline.utils import (aemit_event, check_disabled_component,
-                                         emit_event, get_vlan_tags_and_masks,
+from napps.kytos.mef_eline.utils import (_does_uni_affect_evc, aemit_event,
+                                         check_disabled_component, emit_event,
+                                         get_vlan_tags_and_masks,
                                          map_evc_event_content)
 
 
@@ -805,10 +806,11 @@ class Main(KytosNApp):
         """
         log.info("Event handle_interface_link_up %s", interface)
         for evc in self.get_evcs_by_svc_level():
-            with evc.lock:
-                evc.handle_interface_link_up(
-                    interface
-                )
+            if _does_uni_affect_evc(evc, interface, 'up'):
+                with evc.lock:
+                    evc.handle_interface_link_up(
+                        interface
+                    )
 
     def handle_interface_link_down(self, interface):
         """
@@ -816,10 +818,11 @@ class Main(KytosNApp):
         """
         log.info("Event handle_interface_link_down %s", interface)
         for evc in self.get_evcs_by_svc_level():
-            with evc.lock:
-                evc.handle_interface_link_down(
-                    interface
-                )
+            if _does_uni_affect_evc(evc, interface, 'down'):
+                with evc.lock:
+                    evc.handle_interface_link_down(
+                        interface
+                    )
 
     @listen_to("kytos/topology.link_down", pool="dynamic_single")
     def on_link_down(self, event):

--- a/models/evc.py
+++ b/models/evc.py
@@ -26,7 +26,8 @@ from napps.kytos.mef_eline import controllers, settings
 from napps.kytos.mef_eline.exceptions import (ActivationError,
                                               DuplicatedNoTagUNI,
                                               FlowModException, InvalidPath)
-from napps.kytos.mef_eline.utils import (check_disabled_component,
+from napps.kytos.mef_eline.utils import (_does_uni_affect_evc,
+                                         check_disabled_component,
                                          compare_endpoint_trace,
                                          compare_uni_out_trace, emit_event,
                                          make_uni_list, map_dl_vlan,
@@ -1801,17 +1802,7 @@ class LinkProtection(EVCDeploy):
         """
         Handler for interface link_up events
         """
-        if self.is_active():
-            return
-        interfaces = (self.uni_a.interface, self.uni_z.interface)
-        if interface not in interfaces:
-            return
-        down_interfaces = [
-            interface
-            for interface in interfaces
-            if interface.status != EntityStatus.UP
-        ]
-        if down_interfaces:
+        if not _does_uni_affect_evc(self, interface, 'up'):
             return
         if self.try_to_handle_uni_as_link_up(interface):
             return
@@ -1821,7 +1812,7 @@ class LinkProtection(EVCDeploy):
                 'status': interface.status.value,
                 'status_reason': interface.status_reason,
             }
-            for interface in interfaces
+            for interface in (self.uni_a.interface, self.uni_z.interface)
         }
         try:
             self.try_to_activate()
@@ -1841,24 +1832,15 @@ class LinkProtection(EVCDeploy):
         """
         Handler for interface link_down events
         """
-        if not self.is_active():
-            return
-        interfaces = (self.uni_a.interface, self.uni_z.interface)
-        if interface not in interfaces:
-            return
-        down_interfaces = [
-            interface
-            for interface in interfaces
-            if interface.status != EntityStatus.UP
-        ]
-        if not down_interfaces:
+        if not _does_uni_affect_evc(self, interface, 'down'):
             return
         interface_dicts = {
             interface.id: {
                 'status': interface.status.value,
                 'status_reason': interface.status_reason,
             }
-            for interface in down_interfaces
+            for interface in (self.uni_a.interface, self.uni_z.interface)
+            if interface.status != EntityStatus.UP
         }
         self.deactivate()
         log.info(

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2277,6 +2277,7 @@ class TestMain:
         event = MagicMock()
         event.content = {'flow': flow, 'error_command': 'add'}
         evc = create_autospec(EVC)
+        evc.archived = False
         evc.remove_current_flows = MagicMock()
         evc.lock = MagicMock()
         self.napp.circuits = {"00000000000011": evc}

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,5 +1,5 @@
 """Module to test the utls.py file."""
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, Mock
 import pytest
 
 
@@ -8,7 +8,8 @@ from napps.kytos.mef_eline.exceptions import DisabledSwitch
 from napps.kytos.mef_eline.utils import (check_disabled_component,
                                          compare_endpoint_trace,
                                          compare_uni_out_trace,
-                                         get_vlan_tags_and_masks, map_dl_vlan)
+                                         get_vlan_tags_and_masks, map_dl_vlan,
+                                         _does_uni_affect_evc)
 
 
 # pylint: disable=too-many-public-methods, too-many-lines
@@ -140,3 +141,71 @@ class TestUtils():
         # There is no disabled component
         uni_z.interface.status = EntityStatus.UP
         check_disabled_component(uni_a, uni_z)
+
+    # pylint: disable=too-many-arguments
+    @pytest.mark.parametrize(
+        "intf_a_status, intf_z_status, is_active, is_uni, event, expected",
+        [
+            # link_DOWN
+            (
+                EntityStatus.DOWN, EntityStatus.DOWN,
+                True, True, 'down', True
+            ),
+            (
+                EntityStatus.UP, EntityStatus.UP,
+                True, True, 'down', False
+            ),
+            (
+                EntityStatus.DOWN, EntityStatus.UP,
+                False, True, 'down', False
+            ),
+            (
+                EntityStatus.UP, EntityStatus.UP,
+                False, True, 'down', False
+            ),
+            (  # Not UNI
+                EntityStatus.DOWN, EntityStatus.DOWN,
+                True, False, 'down', False
+            ),
+            # link_up
+            (
+                EntityStatus.DOWN, EntityStatus.DOWN,
+                True, True, 'up', False
+            ),
+            (
+                EntityStatus.UP, EntityStatus.UP,
+                True, True, 'up', False
+            ),
+            (
+                EntityStatus.DOWN, EntityStatus.UP,
+                False, True, 'up', False
+            ),
+            (
+                EntityStatus.UP, EntityStatus.UP,
+                False, True, 'up', True
+            ),
+            (  # Not UNI
+                EntityStatus.UP, EntityStatus.UP,
+                False, False, 'up', False
+            ),
+        ]
+    )
+    def test_does_uni_affect_evc(
+        self,
+        intf_a_status,
+        intf_z_status,
+        is_active,
+        is_uni,
+        event,
+        expected
+    ):
+        """Test _does_uni_affect_evc when interface."""
+        evc = Mock()
+        evc.uni_a.interface.status = intf_a_status
+        evc.uni_z.interface.status = intf_z_status
+        if is_uni:
+            interface = evc.uni_a.interface
+        else:
+            interface = Mock()
+        evc.is_active.return_value = is_active
+        assert _does_uni_affect_evc(evc, interface, event) is expected

--- a/utils.py
+++ b/utils.py
@@ -145,3 +145,20 @@ def make_uni_list(list_circuits: list) -> list:
                 (circuit.uni_z.interface, tag_z)
             )
     return uni_list
+
+
+def _does_uni_affect_evc(evc, interface: Interface, link_event: str) -> bool:
+    """Check if an interface flap is affecting an EVC UNI."""
+    interface_a = evc.uni_a.interface
+    interface_z = evc.uni_z.interface
+    interface_affected = interface in (interface_a, interface_z)
+    interface_down = (
+        interface_a.status != EntityStatus.UP
+        or interface_z.status != EntityStatus.UP
+    )
+    if link_event == "up":
+        return (not evc.is_active() and interface_affected
+                and not interface_down)
+    if link_event == "down":
+        return evc.is_active() and interface_affected and interface_down
+    return False


### PR DESCRIPTION
Closes #636 

### Summary

Added EVC checkup before acquiring lock

### Local Tests
Tried link flaps and e2e `test_025_uni_link_up_static_path()`
Unit tests updated:
```
==================================================================================================================================================== test session starts ====================================================================================================================================================
platform linux -- Python 3.9.9, pytest-7.2.1, pluggy-1.5.0
cachedir: .tox/py39/.pytest_cache
rootdir: /home/aldo/Desktop/back/mef_eline, configfile: pytest.ini
plugins: anyio-3.6.2, cov-4.0.0, asyncio-0.20.3
asyncio: mode=auto
collected 302 items                                                                                                                                                                                                                                                                                                         

tests/unit/test_controllers.py ........                                                                                                                                                                                                                                                                               [  2%]
tests/unit/test_db_models.py .........................                                                                                                                                                                                                                                                                [ 10%]
tests/unit/test_main.py .............................................................................                                                                                                                                                                                                                 [ 36%]
tests/unit/test_scheduler.py .........                                                                                                                                                                                                                                                                                [ 39%]
tests/unit/test_utils.py ...................                                                                                                                                                                                                                                                                          [ 45%]
tests/unit/models/test_evc_base.py .................................                                                                                                                                                                                                                                                  [ 56%]
tests/unit/models/test_evc_deploy.py ....................................................................................                                                                                                                                                                                             [ 84%]
tests/unit/models/test_link_protection.py ....................                                                                                                                                                                                                                                                        [ 91%]
tests/unit/models/test_path.py ...........................                                                                                                                                                                                                                                                            [100%]
```

### End-to-End Tests
N/A
