### PR TITLE
release 2024.1.15: DB controller now retries for `ExecutionTimeout` and `ConnectionFailure` instead of just `AutoReconnect`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2024.1.15] - 2025-03-03
+************************
+
+Fixed
+=====
+- DB controller now retries for ``ExecutionTimeout`` and ``ConnectionFailure`` instead of just ``AutoReconnect``
+
 [2024.1.14] - 2025-02-27
 ************************
 

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -6,7 +6,7 @@ from typing import Dict, Optional
 
 import pymongo
 from pymongo.collection import ReturnDocument
-from pymongo.errors import AutoReconnect
+from pymongo.errors import ConnectionFailure, ExecutionTimeout
 from pymongo.operations import UpdateOne
 from tenacity import retry_if_exception_type, stop_after_attempt, wait_random
 
@@ -26,7 +26,7 @@ from napps.kytos.mef_eline.db.models import EVCBaseDoc, EVCUpdateDoc
         max=int(os.environ.get("MONGO_AUTO_RETRY_WAIT_RANDOM_MAX", "1")),
     ),
     before_sleep=before_sleep,
-    retry=retry_if_exception_type((AutoReconnect,)),
+    retry=retry_if_exception_type((ConnectionFailure, ExecutionTimeout)),
 )
 class ELineController:
     """E-Line Controller"""

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2024.1.14",
+  "version": "2024.1.15",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -5,5 +5,5 @@
 #    pip-compile --output-file requirements/dev.txt requirements/dev.in
 #
 -e git+https://github.com/kytos-ng/python-openflow.git#egg=python-openflow
--e git+https://github.com/kytos-ng/kytos.git@base/2024.1.4#egg=kytos[dev]
+-e git+https://github.com/kytos-ng/kytos.git#egg=kytos[dev]
 -e .


### PR DESCRIPTION
Closes https://github.com/kytos-ng/kytos/issues/538

- See updated changelog file 
- Index creation timeout didn't get adjusted since the default is plenty when its first created

### Local Tests

Local tests were done with https://github.com/kytos-ng/kytos/pull/541

### Unit tests

```
coverage: OK ✔ in 54.34 seconds
lint: recreate env because env type changed from {'name': 'coverage', 'type': 'VirtualEnvRunner'} to {'name': 'lint', 'type': 'VirtualEnvRunner'}
lint: remove tox env folder /tmp/mef_eline/.tox/py311
lint: install_deps> python -I -m pip install -r requirements/dev.in

lint: commands[0]> python3 setup.py lint
running lint
Yala is running. It may take several seconds...
INFO: Finished isort
INFO: Finished pycodestyle
INFO: Finished pylint
[isort] Skipped 4 files
:) No issues found.
No linter error found.
  coverage: OK (54.34=setup[29.85]+cmd[24.49] seconds)
  lint: OK (43.96=setup[29.76]+cmd[14.21] seconds)
  congratulations :) (98.34 seconds)

```

### End-to-End Tests

E2e tests were done with https://github.com/kytos-ng/kytos/pull/541 