### PR TITLE
Tweak formatting of logging tracebacks

### DIFF
--- a/main.py
+++ b/main.py
@@ -846,7 +846,7 @@ class Main(KytosNApp):
             install_flows = evc.get_failover_flows()
         # pylint: disable=broad-except
         except Exception:
-            err = traceback.format_exc().replace("\n", ", ")
+            err = traceback.format_exc()
             log.error(
                 "Ignore Failover path for "
                 f"{evc} due to error: {err}"
@@ -910,7 +910,7 @@ class Main(KytosNApp):
             )
         # pylint: disable=broad-except
         except Exception:
-            err = traceback.format_exc().replace("\n", ", ")
+            err = traceback.format_exc()
             log.error(f"Fail to remove {evc} old_path: {err}")
         return del_flows
 
@@ -973,7 +973,7 @@ class Main(KytosNApp):
             )
         # pylint: disable=broad-except
         except Exception:
-            err = traceback.format_exc().replace("\n", ", ")
+            err = traceback.format_exc()
             log.error(f"Fail to undeploy {evc}: {err}")
         return del_flows
 

--- a/models/evc.py
+++ b/models/evc.py
@@ -772,7 +772,7 @@ class EVCDeploy(EVCBase):
             nni_flows = self._prepare_nni_flows(path)
         # pylint: disable=broad-except
         except Exception:
-            err = traceback.format_exc().replace("\n", ", ")
+            err = traceback.format_exc()
             log.error(f"Fail to remove NNI failover flows for {self}: {err}")
             nni_flows = {}
 
@@ -791,7 +791,7 @@ class EVCDeploy(EVCBase):
             uni_flows = self._prepare_uni_flows(path, skip_in=True)
         # pylint: disable=broad-except
         except Exception:
-            err = traceback.format_exc().replace("\n", ", ")
+            err = traceback.format_exc()
             log.error(f"Fail to remove UNI failover flows for {self}: {err}")
             uni_flows = {}
 


### PR DESCRIPTION
Follow up to kytos-ng/kytos#548

### Summary

Tweaked the format of logging tracebacks to no longer replace the newline character `\n` with `, `

### Local Tests

Tracebacks are easier to read now.

### End-to-End Tests

Not really relevant to E2E