### PR TITLE
Added `max_paths` to EVC document

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Added
 - Added migration script for updating the default ``queue_id`` from ``None`` to ``-1``
 - Added added paramenter support for redeployment, ``PATCH v2/evc/{evc_id}/redeploy?try_avoid_same_s_vlan=true``. By default it will try to avoid ``s_vlan`` from ``current_path`` links.
 - Added option to opt out from trying to avoid previous ``s_vlan`` when redeploying EVCs.
+- Added option to analyze more paths when EVCs tries to find a valid path. This option is in a new patchable field in EVC document called ``max_paths``.
 
 Fixed
 =======
@@ -42,6 +43,7 @@ Changed
 - UI: Added column ``Path Types`` to ``View Connections`` component to indicate if the EVC has a ``dynamic_backup_path``, ``static_primary`` or ``static_backup`` value.
 - When a link flap happens, now ``mef_eline`` will check on EVC attributes to decide whether to acquire an EVC lock.
 - UI: The method ``onblur_dpid`` was changed to a computed property.
+- Log now will notify if all paths for a ``current_path`` are invalid and suggest to increase ``max_paths``.
 
 [2024.1.4] - 2024-09-09
 ***********************

--- a/db/models.py
+++ b/db/models.py
@@ -139,6 +139,7 @@ class EVCBaseDoc(DocumentBaseModel):
     metadata: Dict = {}
     active: bool
     enabled: bool
+    max_paths: Optional[int] = 2
 
     @staticmethod
     def projection() -> Dict:
@@ -163,6 +164,7 @@ class EVCBaseDoc(DocumentBaseModel):
             "metadata": 1,
             "active": 1,
             "enabled": 1,
+            "max_paths": 1,
             "execution_rounds": {"$ifNull": ["$execution_rounds", 0]},
             "owner": {"$ifNull": ["$owner", None]},
             "queue_id": {"$ifNull": ["$queue_id", None]},

--- a/main.py
+++ b/main.py
@@ -1229,7 +1229,8 @@ class Main(KytosNApp):
             # Ex: current_path,
             #     primary_path,
             #     backup_path
-            if "path" in attribute and attribute != "dynamic_backup_path":
+            if (attribute.endswith("path") and
+                    attribute != "dynamic_backup_path"):
                 data[attribute] = Path(
                     [self._link_from_dict(link, attribute) for link in value]
                 )

--- a/models/path.py
+++ b/models/path.py
@@ -188,10 +188,10 @@ class DynamicPathManager:
         return True
 
     @classmethod
-    def get_best_paths(cls, circuit, **kwargs):
+    def get_best_paths(cls, circuit, max_paths=2, **kwargs):
         """Return the best paths available for a circuit, if they exist."""
         try:
-            for path in cls.get_paths(circuit, **kwargs):
+            for path in cls.get_paths(circuit, max_paths=max_paths, **kwargs):
                 yield cls.create_path(path["hops"])
         except PathFinderException as err:
             log.error(

--- a/openapi.yml
+++ b/openapi.yml
@@ -458,6 +458,12 @@ components:
           type: boolean
         metadata:
           type: object
+        max_paths:
+          type: integer
+          format: int32
+          description: Maximum number of paths to be considered. Default value is 2.
+          minimum: 2
+          maximum: 10
     NewLink: # Can be referenced via '#/components/schemas/NewLink'
       type: object
       required:
@@ -704,6 +710,12 @@ components:
         request_time:
           type: string
           format: date-time
+        max_paths:
+          type: integer
+          format: int32
+          description: Maximum number of paths to be considered. Default value is 2.
+          minimum: 2
+          maximum: 10
 
     UpdateCircuit: # Can be referenced via '#/components/schemas/UpdateCircuit'
       type: object
@@ -776,6 +788,12 @@ components:
           type: object
         enabled:
           type: boolean
+        max_paths:
+          type: integer
+          format: int32
+          description: Maximum number of paths to be considered. Default value is 2.
+          minimum: 2
+          maximum: 10
 
     Tag: # Can be referenced via '#/components/schemas/Tag'
       type: object

--- a/openapi.yml
+++ b/openapi.yml
@@ -461,7 +461,8 @@ components:
         max_paths:
           type: integer
           format: int32
-          description: Maximum number of paths to be considered. Default value is 2.
+          description: Maximum number of paths to be considered.
+          default: 2
           minimum: 2
           maximum: 10
     NewLink: # Can be referenced via '#/components/schemas/NewLink'
@@ -713,7 +714,8 @@ components:
         max_paths:
           type: integer
           format: int32
-          description: Maximum number of paths to be considered. Default value is 2.
+          description: Maximum number of paths to be considered.
+          default: 2
           minimum: 2
           maximum: 10
 
@@ -791,7 +793,8 @@ components:
         max_paths:
           type: integer
           format: int32
-          description: Maximum number of paths to be considered. Default value is 2.
+          description: Maximum number of paths to be considered.
+          default: 2
           minimum: 2
           maximum: 10
 

--- a/tests/unit/models/test_evc_base.py
+++ b/tests/unit/models/test_evc_base.py
@@ -65,7 +65,8 @@ class TestEVC():  # pylint: disable=too-many-public-methods, no-member
             "service_level",
             "circuit_scheduler",
             "metadata",
-            "enabled"
+            "enabled",
+            "max_paths",
         ]
         assert EVC.updatable_attributes == set(expected)
 

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -413,6 +413,29 @@ class TestEVC():
         assert log_mock.info.call_count == 2
         log_mock.info.assert_called_with(f"{evc} was deployed.")
 
+    @patch("httpx.post")
+    @patch("napps.kytos.mef_eline.models.evc.log")
+    @patch("napps.kytos.mef_eline.models.evc.EVC.discover_new_paths")
+    @patch("napps.kytos.mef_eline.controllers.ELineController.upsert_evc")
+    def test_create_evc_all_paths_invalid(self, *args):
+        """Test create an EVC where all paths are invalid."""
+        (
+            _,
+            discover_new_paths_mock,
+            log_mock,
+            httpx_mock,
+        ) = args
+
+        response = MagicMock(status_code=201, is_server_error=False)
+        httpx_mock.return_value = response
+        evc = self.create_evc_inter_switch()
+
+        discover_new_paths_mock.return_value = iter([None, None])
+        evc.deploy_to_path()
+        msg_expected = "try increasing `max_paths`"
+        assert log_mock.warning.call_count == 1
+        assert msg_expected in log_mock.warning.call_args[0][0]
+
     def test_try_to_activate_intra_evc(self) -> None:
         """Test try_to_activate for intra EVC."""
 


### PR DESCRIPTION
Closes #643 

### Summary

Improved LOG, now notifies that all obtained paths were invalid and suggests to increase `max_paths`
Added `max_paths` field to EVC document. It is also updatable.

### Local Tests
Deployed EVC for `00:00:00:00:00:00:00:16:5` and `00:00:00:00:00:00:00:11:1` with `"max_paths": 10`

### End-to-End Tests
To be added, [issue](https://github.com/kytos-ng/kytos-end-to-end-tests/issues/347). [PR](https://github.com/kytos-ng/kytos-end-to-end-tests/pull/353#pullrequestreview-2737449227)
