### PR TITLE
Switch to using topology links for allocating vlan tags

### DIFF
--- a/models/path.py
+++ b/models/path.py
@@ -5,6 +5,7 @@ from tenacity import (retry, retry_if_exception_type, stop_after_attempt,
 
 from kytos.core import log
 from kytos.core.common import EntityStatus, GenericEntity
+from kytos.core.controller import Controller
 from kytos.core.exceptions import KytosNoTagAvailableError
 from kytos.core.interface import TAG
 from kytos.core.link import Link
@@ -37,7 +38,11 @@ class Path(list[Link], GenericEntity):
                 return link
         return None
 
-    def choose_vlans(self, controller, old_path_dict: dict = None):
+    def choose_vlans(
+        self,
+        controller: Controller,
+        old_path_dict: dict = None
+    ):
         """Choose the VLANs to be used for the circuit.
         If any of the links next tag isn't available, it'll release
         all vlans of the path that have been allocated, all or nothing.
@@ -45,32 +50,48 @@ class Path(list[Link], GenericEntity):
         old_path_dict = old_path_dict if old_path_dict else {}
         try:
             for link in self:
-                tag_value = link.get_next_available_tag(
-                    controller, link.id,
-                    try_avoid_value=old_path_dict.get(link.id)
-                )
+                real_link = controller.get_link(link.id)
+                if real_link is None:
+                    raise KytosNoTagAvailableError(link)
+                with real_link.tag_lock:
+                    tag_value = real_link.get_next_available_tag(
+                        "vlan",
+                        try_avoid_value=old_path_dict.get(link.id)
+                    )
+                    real_link.notify_tag_listeners(
+                        controller
+                    )
                 tag = TAG('vlan', tag_value)
                 link.add_metadata("s_vlan", tag)
         except KytosNoTagAvailableError as exc:
             self.make_vlans_available(controller)
             raise exc
 
-    def make_vlans_available(self, controller):
+    def make_vlans_available(
+        self,
+        controller: Controller
+    ):
         """Make the VLANs used in a path available when undeployed."""
         for link in self:
-            tag = link.get_metadata("s_vlan")
+            tag: TAG = link.get_metadata("s_vlan")
             if not tag:
                 continue
-            conflict_a, conflict_b = link.make_tags_available(
-                controller, tag.value, link.id, tag.tag_type,
-                check_order=False
-            )
-            if conflict_a:
-                log.error(f"Tags {conflict_a} was already available in"
-                          f"{link.endpoint_a.id}")
-            if conflict_b:
-                log.error(f"Tags {conflict_b} was already available in"
-                          f"{link.endpoint_b.id}")
+            real_link = controller.get_link(link.id)
+            if real_link is not None:
+                with real_link.tag_lock:
+                    conflict = real_link.make_tags_available(
+                        tag.tag_type,
+                        tag.value,
+                        check_order=False
+                    )
+                    real_link.notify_tag_listeners(
+                        controller
+                    )
+                if conflict:
+                    log.error(
+                        f"Tags {conflict} was already available in "
+                        f"{link.id}"
+                    )
             link.remove_metadata("s_vlan")
 
     def is_valid(self, switch_a, switch_z, is_scheduled=False):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,5 +1,5 @@
 """Module to help to create tests."""
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 from kytos.core import Controller
 from kytos.core.common import EntityStatus
@@ -48,7 +48,8 @@ def get_link_mocked(**kwargs):
         switch_b,
     )
     link = Mock(spec=Link, endpoint_a=endpoint_a, endpoint_b=endpoint_b)
-    link.make_tags_available.return_value = True, True
+    link.make_tags_available.return_value = True
+    link.tag_lock = MagicMock()
     link.endpoint_a.link = link
     link.endpoint_b.link = link
     link.as_dict.return_value = kwargs.get(
@@ -102,6 +103,7 @@ def get_uni_mocked(**kwargs):
     switch.id = kwargs.get("switch_id", "custom_switch_id")
     switch.dpid = kwargs.get("switch_dpid", "custom_switch_dpid")
     interface = Interface(interface_name, interface_port, switch)
+    interface.notify_tag_listeners = MagicMock()
     if isinstance(tag_value, list):
         tag = TAGRange(tag_type, tag_value)
     else:

--- a/tests/unit/models/test_evc_base.py
+++ b/tests/unit/models/test_evc_base.py
@@ -596,8 +596,8 @@ class TestEVC():  # pylint: disable=too-many-public-methods, no-member
         uni.interface.use_tags = MagicMock()
         evc._use_uni_vlan(uni)
         args = uni.interface.use_tags.call_args[0]
+        assert args[0] == uni.user_tag.tag_type
         assert args[1] == uni.user_tag.value
-        assert args[2] == uni.user_tag.tag_type
         assert uni.interface.use_tags.call_count == 1
 
         uni.user_tag.value = "any"
@@ -639,8 +639,8 @@ class TestEVC():  # pylint: disable=too-many-public-methods, no-member
 
         evc.make_uni_vlan_available(uni)
         args = uni.interface.make_tags_available.call_args[0]
+        assert args[0] == uni.user_tag.tag_type
         assert args[1] == uni.user_tag.value
-        assert args[2] == uni.user_tag.tag_type
         assert uni.interface.make_tags_available.call_count == 1
 
         uni.user_tag.value = [[1, 10]]

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -879,8 +879,17 @@ class TestEVC():
             metadata={"s_vlan": Mock(value=6)},
         )
 
+        links_by_id = {
+            link_a_b.id: link_a_b,
+            link_b_c.id: link_b_c,
+        }
+
+        controller = get_controller_mock()
+
+        controller.links = links_by_id
+
         attributes = {
-            "controller": get_controller_mock(),
+            "controller": controller,
             "name": "custom_name",
             "uni_a": uni_a,
             "uni_z": uni_z,
@@ -1004,28 +1013,40 @@ class TestEVC():
         switch_b = Switch("00:00:00:00:00:00:00:02")
         switch_c = Switch("00:00:00:00:00:00:00:03")
 
+        link_a_b = get_link_mocked(
+            switch_a=switch_a,
+            switch_b=switch_b,
+            endpoint_a_port=9,
+            endpoint_b_port=10,
+            metadata={"s_vlan": Mock(value=5)},
+        )
+        link_b_c = get_link_mocked(
+            switch_a=switch_b,
+            switch_b=switch_c,
+            endpoint_a_port=11,
+            endpoint_b_port=12,
+            metadata={"s_vlan": Mock(value=6)},
+        )
+
+        links_by_id = {
+            link_a_b.id: link_a_b,
+            link_b_c.id: link_b_c,
+        }
+
+        controller = get_controller_mock()
+
+        controller.links = links_by_id
+
         attributes = {
-            "controller": get_controller_mock(),
+            "controller": controller,
             "name": "custom_name",
             "uni_a": uni_a,
             "uni_z": uni_z,
             "active": True,
             "enabled": True,
             "failover_path": [
-                get_link_mocked(
-                    switch_a=switch_a,
-                    switch_b=switch_b,
-                    endpoint_a_port=9,
-                    endpoint_b_port=10,
-                    metadata={"s_vlan": 5},
-                ),
-                get_link_mocked(
-                    switch_a=switch_b,
-                    switch_b=switch_c,
-                    endpoint_a_port=11,
-                    endpoint_b_port=12,
-                    metadata={"s_vlan": 6},
-                ),
+                link_a_b,
+                link_b_c,
             ],
         }
 

--- a/tests/unit/models/test_path.py
+++ b/tests/unit/models/test_path.py
@@ -142,6 +142,11 @@ class TestPath():
         link2 = get_link_mocked(status=EntityStatus.UP)
         link1.id = "def"
         link2.id = "abc"
+        links_by_id = {
+            link1.id: link1,
+            link2.id: link2
+        }
+        controller.get_link = links_by_id.get
         links = [link1, link2]
         path = Path(links)
         path.make_vlans_available = MagicMock()
@@ -159,6 +164,11 @@ class TestPath():
         link2 = get_link_mocked(status=EntityStatus.UP)
         link1.id = "def"
         link2.id = "abc"
+        links_by_id = {
+            link1.id: link1,
+            link2.id: link2
+        }
+        controller.get_link = links_by_id.get
         links = [link1, link2]
         path = Path(links)
         path.make_vlans_available = MagicMock()


### PR DESCRIPTION
Closes #641

### Summary

Makes it so that mef_eline uses the topology links when allocating vlans. This is to support future changes to how tags are allocated, and ensure that there is one data source for tag changes.

### Local Tests

Need to do further local tests, haven't properly exercised this feature.

### End-to-End Tests

Here are my E2E results:

```
======================================================================== test session starts =========================================================================
platform linux -- Python 3.11.11, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/ktmi/Documents/kytos-project/kytos-end-to-end-tests
plugins: anyio-4.3.0
collected 282 items                                                                                                                                                  

tests/test_e2e_01_kytos_startup.py FF                                                                                                                          [  0%]
tests/test_e2e_05_topology.py ..................                                                                                                               [  7%]
tests/test_e2e_06_topology.py ....                                                                                                                             [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x........................                                                                                      [ 23%]
tests/test_e2e_11_mef_eline.py ......                                                                                                                          [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                                                                                                        [ 28%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X............                                                                                      [ 43%]
tests/test_e2e_14_mef_eline.py x....                                                                                                                           [ 45%]
tests/test_e2e_15_mef_eline.py ......                                                                                                                          [ 47%]
tests/test_e2e_16_mef_eline.py ..                                                                                                                              [ 47%]
tests/test_e2e_17_mef_eline.py ....                                                                                                                            [ 49%]
tests/test_e2e_20_flow_manager.py ..........................                                                                                                   [ 58%]
tests/test_e2e_21_flow_manager.py ...                                                                                                                          [ 59%]
tests/test_e2e_22_flow_manager.py ...............                                                                                                              [ 64%]
tests/test_e2e_23_flow_manager.py ..............                                                                                                               [ 69%]
tests/test_e2e_30_of_lldp.py .F..                                                                                                                              [ 71%]
tests/test_e2e_31_of_lldp.py ...                                                                                                                               [ 72%]
tests/test_e2e_32_of_lldp.py ...                                                                                                                               [ 73%]
tests/test_e2e_40_sdntrace.py ................                                                                                                                 [ 79%]
tests/test_e2e_41_kytos_auth.py ........                                                                                                                       [ 81%]
tests/test_e2e_42_sdntrace.py ..                                                                                                                               [ 82%]
tests/test_e2e_50_maintenance.py ............................                                                                                                  [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                                                                                                      [ 94%]
tests/test_e2e_70_kytos_stats.py FFFFFFFF                                                                                                                      [ 97%]
tests/test_e2e_80_pathfinder.py ss......                                                                                                                       [100%]

============================================================================== FAILURES ==============================================================================
____________________________________________________________ TestE2EKytosServer.test_start_kytos_api_core ____________________________________________________________

self = <tests.test_e2e_01_kytos_startup.TestE2EKytosServer object at 0x7392e6e46390>

    def test_start_kytos_api_core(self):
    
        # Check server status if it is UP and running
        api_url = KYTOS_API+'/core/status/'
        response = requests.get(api_url)
        assert response.status_code == 200, response.text
    
        data = response.json()
        assert data['response'] == 'running'
    
        # check the list of enabled napps
        expected_napps = [
                ("kytos", "pathfinder"),
                ("kytos", "mef_eline"),
                ("kytos", "maintenance"),
                ("kytos", "flow_manager"),
                ("kytos", "of_core"),
                ("kytos", "topology"),
                ("kytos", "of_lldp"),
                ("kytos", "of_multi_table"),
                ('amlight', 'sdntrace'),
                ('amlight', 'coloring'),
                ('amlight', 'sdntrace_cp'),
                ('amlight', 'kytos_stats'),
            ]
        api_url = KYTOS_API+'/core/napps_enabled/'
        response = requests.get(api_url)
        assert response.status_code == 200, response.text
    
        data = response.json()
>       assert set([tuple(lst) for lst in data['napps']]) == set(expected_napps)
E       AssertionError: assert {('amlight', ...anager'), ...} == {('amlight', ...enance'), ...}
E         
E         Extra items in the left set:
E         ('amlight', 'noviflow')
E         ('amlight', 'flow_stats')
E         ('kytos', 'telemetry_int')
E         Extra items in the right set:
E         ('amlight', 'kytos_stats')
E         Use -v to get more diff

tests/test_e2e_01_kytos_startup.py:81: AssertionError
----------------------------------------------------------------------- Captured stderr setup ------------------------------------------------------------------------
Unable to contact the remote controller at 127.0.0.1:6653
_________________________________________________________ TestE2EKytosServer.test_start_kytos_without_errors _________________________________________________________

self = <tests.test_e2e_01_kytos_startup.TestE2EKytosServer object at 0x7392e68cc290>

    @pytest.mark.skipif(not os.path.exists('/var/log/syslog'), reason="/var/log/syslog does not exist")
    def test_start_kytos_without_errors(self):
        with open(self.logfile, "r") as f:
>           assert re.findall(r'kytos.*?(error|exception)(.*)?', f.read(), re.I) == []
E           AssertionError: assert [('ERROR', ' ...e pipeline.')] == []
E             
E             Left contains 4 more items, first extra item: ('ERROR', ' main:134:  telemetry_int NApp loaded after pipeline was installed. Flow inconsistencies may have appeared. Try modifying `kytos.json` from telemetry_int then restart or redeploy the pipeline.')
E             Use -v to get more diff

tests/test_e2e_01_kytos_startup.py:124: AssertionError
_______________________________________________________________ TestE2EOfLLDP.test_010_disable_of_lldp _______________________________________________________________

self = <tests.test_e2e_30_of_lldp.TestE2EOfLLDP object at 0x7392e67cd250>

    def test_010_disable_of_lldp(self):
        """ Test if the disabling OF LLDP in an interface worked properly. """
        self.net.start_controller(clean_config=True, enable_all=False)
        self.net.wait_switches_connect()
        time.sleep(5)
        self.enable_all_interfaces()
    
        # disabling all the UNI interfaces
        payload = {
            "interfaces": [
                "00:00:00:00:00:00:00:01:1", "00:00:00:00:00:00:00:01:2", "00:00:00:00:00:00:00:01:4294967294",
                "00:00:00:00:00:00:00:02:1", "00:00:00:00:00:00:00:02:4294967294",
                "00:00:00:00:00:00:00:03:1", "00:00:00:00:00:00:00:03:4294967294"
            ]
        }
        expected_interfaces = [
                "00:00:00:00:00:00:00:01:3", "00:00:00:00:00:00:00:01:4",
                "00:00:00:00:00:00:00:02:2", "00:00:00:00:00:00:00:02:3",
                "00:00:00:00:00:00:00:03:2", "00:00:00:00:00:00:00:03:3"
        ]
    
        api_url = KYTOS_API + '/of_lldp/v1/interfaces/disable/'
        response = requests.post(api_url, json=payload)
        assert response.status_code == 200, response.text
    
        api_url = KYTOS_API + '/of_lldp/v1/interfaces/'
        response = requests.get(api_url)
        data = response.json()
        assert set(data["interfaces"]) == set(expected_interfaces)
    
        h11, h12, h2, h3 = self.net.net.get('h11', 'h12', 'h2', 'h3')
        rx_stats_h11 = self.get_iface_stats_rx_pkt(h11)
        rx_stats_h12 = self.get_iface_stats_rx_pkt(h12)
        rx_stats_h2 = self.get_iface_stats_rx_pkt(h2)
        rx_stats_h3 = self.get_iface_stats_rx_pkt(h3)
        time.sleep(10)
        rx_stats_h11_2 = self.get_iface_stats_rx_pkt(h11)
        rx_stats_h12_2 = self.get_iface_stats_rx_pkt(h12)
        rx_stats_h2_2 = self.get_iface_stats_rx_pkt(h2)
        rx_stats_h3_2 = self.get_iface_stats_rx_pkt(h3)
    
>       assert rx_stats_h11_2 == rx_stats_h11 \
            and rx_stats_h12_2 == rx_stats_h12 \
            and rx_stats_h2_2 == rx_stats_h2 \
            and rx_stats_h3_2 == rx_stats_h3
E       assert (34 == 32)

tests/test_e2e_30_of_lldp.py:127: AssertionError
_______________________________________________________________ TestE2EKytosStats.test_005_flow_stats ________________________________________________________________

self = <tests.test_e2e_70_kytos_stats.TestE2EKytosStats object at 0x7392e4beb5d0>

    def test_005_flow_stats(self):
        """Test flow_stats"""
    
        api_url = KYTOS_STATS + '/flow/stats?dpid=00:00:00:00:00:00:00:01'
        response = requests.get(api_url)
>       assert response.status_code == 200, response.text
E       AssertionError: {"description":"Not Found","code":404}
E       assert 404 == 200
E        +  where 404 = <Response [404]>.status_code

tests/test_e2e_70_kytos_stats.py:35: AssertionError
----------------------------------------------------------------------- Captured stdout setup ------------------------------------------------------------------------
FAIL to stop kytos after 5 seconds -- Kytos pid still exists.. Force stop!
_______________________________________________________________ TestE2EKytosStats.test_010_table_stats _______________________________________________________________

self = <tests.test_e2e_70_kytos_stats.TestE2EKytosStats object at 0x7392e4be9690>

    def test_010_table_stats(self):
        """Test table_stats"""
    
        api_url = KYTOS_STATS + '/table/stats?dpid=00:00:00:00:00:00:00:01'
        response = requests.get(api_url)
>       assert response.status_code == 200, response.text
E       AssertionError: {"description":"Not Found","code":404}
E       assert 404 == 200
E        +  where 404 = <Response [404]>.status_code

tests/test_e2e_70_kytos_stats.py:63: AssertionError
______________________________________________________________ TestE2EKytosStats.test_015_packet_count _______________________________________________________________

self = <tests.test_e2e_70_kytos_stats.TestE2EKytosStats object at 0x7392e4c51190>

    def test_015_packet_count(self):
        """Test packet_count"""
        sw = "00:00:00:00:00:00:00:01"
    
        # install a flow
        cookie = 5
        payload = {
            "flows": [{
                "cookie": cookie,
                "match": {"in_port": 1, 'dl_dst': '33:33:00:00:00:02', 'dl_type': 0x86dd},
                'actions': [{'action_type': 'output', 'port': 2}]
            }]
        }
    
        api_url_flow_manager = KYTOS_API + f'/kytos/flow_manager/v2/flows/{sw}'
        response = requests.post(api_url_flow_manager, data=json.dumps(payload),
                                 headers={'Content-type': 'application/json'})
        assert response.status_code == 202, response.text
        data_flow = response.json()
        assert 'FlowMod Messages Sent' in data_flow['response']
    
        # wait the flow to be installed
        time.sleep(5)
    
        # send N packets, each one containing 1500 bytes
        # (14 ether hdr + 40 ipv6 + 8 icmp + 1438 payload)
        h11 = self.net.net.get('h11')
        n = 20
        h11.cmd(f"ping -6 -b -c {n} -s 1438 FF02::2%h11-eth0 -Mdo -i 0.01 -W 2")
    
        # give enough time for stats gathering (of_core.STATS_INTERVAL)
        time.sleep(10)
    
        api_url = KYTOS_STATS + f'/flow/stats?dpid={sw}'
        response = requests.get(api_url)
>       assert response.status_code == 200, response.text
E       AssertionError: {"description":"Not Found","code":404}
E       assert 404 == 200
E        +  where 404 = <Response [404]>.status_code

tests/test_e2e_70_kytos_stats.py:149: AssertionError
_______________________________________________________________ TestE2EKytosStats.test_020_bytes_count _______________________________________________________________

self = <tests.test_e2e_70_kytos_stats.TestE2EKytosStats object at 0x7392e4c51550>

    def test_020_bytes_count(self):
        """Test bytes_count"""
        sw = "00:00:00:00:00:00:00:01"
    
        # install a flow
        cookie = 5
        payload = {
            "flows": [{
                "cookie": cookie,
                "match": {"in_port": 1, 'dl_dst': '33:33:00:00:00:02', 'dl_type': 0x86dd},
                'actions': [{'action_type': 'output', 'port': 2}]
            }]
        }
    
        api_url_flow_manager = KYTOS_API + f'/kytos/flow_manager/v2/flows/{sw}'
        response = requests.post(api_url_flow_manager, data=json.dumps(payload),
                                 headers={'Content-type': 'application/json'})
        assert response.status_code == 202, response.text
        data_flow = response.json()
        assert 'FlowMod Messages Sent' in data_flow['response']
    
        # wait the flow to be installed
        time.sleep(5)
    
        # send N packets, each one containing 1500 bytes
        # (14 ether hdr + 40 ipv6 + 8 icmp + 1438 payload)
        h11 = self.net.net.get('h11')
        n = 20
        h11.cmd(f"ping -6 -b -c {n} -s 1438 FF02::2%h11-eth0 -Mdo -i 0.01 -W 2")
    
        # waiting to give enough time for stats gathering (of_core.STATS_INTERVAL)
        time.sleep(10)
    
        api_url = KYTOS_STATS + f'/flow/stats?dpid={sw}'
        response = requests.get(api_url)
>       assert response.status_code == 200, response.text
E       AssertionError: {"description":"Not Found","code":404}
E       assert 404 == 200
E        +  where 404 = <Response [404]>.status_code

tests/test_e2e_70_kytos_stats.py:201: AssertionError
__________________________________________________________ TestE2EKytosStats.test_025_packet_count_per_flow __________________________________________________________

self = <tests.test_e2e_70_kytos_stats.TestE2EKytosStats object at 0x7392e4c518d0>

    def test_025_packet_count_per_flow(self):
        """Test packet_count_per_flow"""
        # give enough time for stats gathering (of_core.STATS_INTERVAL)
        time.sleep(10)
    
        api_url = KYTOS_STATS + '/flow/stats?dpid=00:00:00:00:00:00:00:01'
        response = requests.get(api_url)
>       assert response.status_code == 200, response.text
E       AssertionError: {"description":"Not Found","code":404}
E       assert 404 == 200
E        +  where 404 = <Response [404]>.status_code

tests/test_e2e_70_kytos_stats.py:225: AssertionError
__________________________________________________________ TestE2EKytosStats.test_030_bytes_count_per_flow ___________________________________________________________

self = <tests.test_e2e_70_kytos_stats.TestE2EKytosStats object at 0x7392e4c51c50>

    def test_030_bytes_count_per_flow(self):
        """Test bytes_count_per_flow"""
        # give enough time for stats gathering (of_core.STATS_INTERVAL)
        time.sleep(10)
    
        api_url = KYTOS_STATS + '/flow/stats?dpid=00:00:00:00:00:00:00:01'
        response = requests.get(api_url)
>       assert response.status_code == 200, response.text
E       AssertionError: {"description":"Not Found","code":404}
E       assert 404 == 200
E        +  where 404 = <Response [404]>.status_code

tests/test_e2e_70_kytos_stats.py:246: AssertionError
___________________________________________________________ TestE2EKytosStats.test_035_table_fields_update ___________________________________________________________

self = <tests.test_e2e_70_kytos_stats.TestE2EKytosStats object at 0x7392e4c52190>

    def test_035_table_fields_update(self):
        """Test fields are updating on table 0.
        active_count increments only when new flows are added
        matched_count and lookup_count keep incrementing
        """
    
        api_url = KYTOS_STATS + '/table/stats?table=0'
        response = requests.get(api_url)
>       assert response.status_code == 200, response.text
E       AssertionError: {"description":"Not Found","code":404}
E       assert 404 == 200
E        +  where 404 = <Response [404]>.status_code

tests/test_e2e_70_kytos_stats.py:267: AssertionError
_______________________________________________________ TestE2EKytosStats.test_036_table_1_active_count_update _______________________________________________________

self = <tests.test_e2e_70_kytos_stats.TestE2EKytosStats object at 0x7392e4c527d0>

    def test_036_table_1_active_count_update(self):
        """Test active count are increasing on table 1.
        """
    
        api_url = KYTOS_STATS + '/table/stats?table=1'
        response = requests.get(api_url)
>       assert response.status_code == 200, response.text
E       AssertionError: {"description":"Not Found","code":404}
E       assert 404 == 200
E        +  where 404 = <Response [404]>.status_code

tests/test_e2e_70_kytos_stats.py:306: AssertionError
========================================================================== warnings summary ==========================================================================
../kytos/kytos/core/config.py:254
  /home/ktmi/Documents/kytos-project/kytos/kytos/core/config.py:254: UserWarning: Unknown arguments: ['tests/', '-r', 'fEr']
    warnings.warn(f"Unknown arguments: {unknown}")

tests/test_e2e_01_kytos_startup.py::TestE2EKytosServer::test_start_kytos_api_core
  /home/ktmi/Documents/kytos-project/.venv/lib/python3.11/site-packages/mininet/log.py:162: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    return fn( *args )

tests/test_e2e_01_kytos_startup.py: 17 warnings
tests/test_e2e_05_topology.py: 17 warnings
tests/test_e2e_06_topology.py: 76 warnings
tests/test_e2e_10_mef_eline.py: 17 warnings
tests/test_e2e_11_mef_eline.py: 25 warnings
tests/test_e2e_12_mef_eline.py: 17 warnings
tests/test_e2e_13_mef_eline.py: 17 warnings
tests/test_e2e_14_mef_eline.py: 76 warnings
tests/test_e2e_15_mef_eline.py: 17 warnings
tests/test_e2e_16_mef_eline.py: 17 warnings
tests/test_e2e_17_mef_eline.py: 37 warnings
tests/test_e2e_20_flow_manager.py: 17 warnings
tests/test_e2e_21_flow_manager.py: 17 warnings
tests/test_e2e_22_flow_manager.py: 17 warnings
tests/test_e2e_23_flow_manager.py: 17 warnings
tests/test_e2e_30_of_lldp.py: 17 warnings
tests/test_e2e_31_of_lldp.py: 17 warnings
tests/test_e2e_32_of_lldp.py: 11 warnings
tests/test_e2e_40_sdntrace.py: 49 warnings
tests/test_e2e_41_kytos_auth.py: 17 warnings
tests/test_e2e_42_sdntrace.py: 84 warnings
tests/test_e2e_50_maintenance.py: 17 warnings
tests/test_e2e_60_of_multi_table.py: 17 warnings
tests/test_e2e_70_kytos_stats.py: 17 warnings
tests/test_e2e_80_pathfinder.py: 37 warnings
  /home/ktmi/Documents/kytos-project/.venv/lib/python3.11/site-packages/mininet/node.py:1106: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    return ( StrictVersion( cls.OVSVersion ) <

tests/test_e2e_01_kytos_startup.py: 17 warnings
tests/test_e2e_05_topology.py: 17 warnings
tests/test_e2e_06_topology.py: 76 warnings
tests/test_e2e_10_mef_eline.py: 17 warnings
tests/test_e2e_11_mef_eline.py: 25 warnings
tests/test_e2e_12_mef_eline.py: 17 warnings
tests/test_e2e_13_mef_eline.py: 17 warnings
tests/test_e2e_14_mef_eline.py: 76 warnings
tests/test_e2e_15_mef_eline.py: 17 warnings
tests/test_e2e_16_mef_eline.py: 17 warnings
tests/test_e2e_17_mef_eline.py: 37 warnings
tests/test_e2e_20_flow_manager.py: 17 warnings
tests/test_e2e_21_flow_manager.py: 17 warnings
tests/test_e2e_22_flow_manager.py: 17 warnings
tests/test_e2e_23_flow_manager.py: 17 warnings
tests/test_e2e_30_of_lldp.py: 17 warnings
tests/test_e2e_31_of_lldp.py: 17 warnings
tests/test_e2e_32_of_lldp.py: 11 warnings
tests/test_e2e_40_sdntrace.py: 49 warnings
tests/test_e2e_41_kytos_auth.py: 17 warnings
tests/test_e2e_42_sdntrace.py: 84 warnings
tests/test_e2e_50_maintenance.py: 17 warnings
tests/test_e2e_60_of_multi_table.py: 17 warnings
tests/test_e2e_70_kytos_stats.py: 17 warnings
tests/test_e2e_80_pathfinder.py: 37 warnings
  /home/ktmi/Documents/kytos-project/.venv/lib/python3.11/site-packages/mininet/node.py:1107: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    StrictVersion( '1.10' ) )

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
-------------------------------------------------------------------------- start/stop times --------------------------------------------------------------------------
tests/test_e2e_01_kytos_startup.py::TestE2EKytosServer::test_start_kytos_api_core: 2025-04-08,17:03:02.423803 - 2025-04-08,17:03:02.444782
tests/test_e2e_01_kytos_startup.py::TestE2EKytosServer::test_start_kytos_without_errors: 2025-04-08,17:03:17.882549 - 2025-04-08,17:03:17.884002
tests/test_e2e_30_of_lldp.py::TestE2EOfLLDP::test_010_disable_of_lldp: 2025-04-08,19:10:48.968729 - 2025-04-08,19:11:14.285764
tests/test_e2e_70_kytos_stats.py::TestE2EKytosStats::test_005_flow_stats: 2025-04-08,20:04:36.274051 - 2025-04-08,20:04:36.275817
tests/test_e2e_70_kytos_stats.py::TestE2EKytosStats::test_010_table_stats: 2025-04-08,20:04:56.424079 - 2025-04-08,20:04:56.425760
tests/test_e2e_70_kytos_stats.py::TestE2EKytosStats::test_015_packet_count: 2025-04-08,20:05:16.597452 - 2025-04-08,20:05:33.829750
tests/test_e2e_70_kytos_stats.py::TestE2EKytosStats::test_020_bytes_count: 2025-04-08,20:05:56.945519 - 2025-04-08,20:06:14.175696
tests/test_e2e_70_kytos_stats.py::TestE2EKytosStats::test_025_packet_count_per_flow: 2025-04-08,20:06:36.328700 - 2025-04-08,20:06:46.330813
tests/test_e2e_70_kytos_stats.py::TestE2EKytosStats::test_030_bytes_count_per_flow: 2025-04-08,20:07:06.552382 - 2025-04-08,20:07:16.554316
tests/test_e2e_70_kytos_stats.py::TestE2EKytosStats::test_035_table_fields_update: 2025-04-08,20:07:36.738704 - 2025-04-08,20:07:36.740385
tests/test_e2e_70_kytos_stats.py::TestE2EKytosStats::test_036_table_1_active_count_update: 2025-04-08,20:07:56.926884 - 2025-04-08,20:07:56.928741
====================================================================== short test summary info =======================================================================
FAILED tests/test_e2e_01_kytos_startup.py::TestE2EKytosServer::test_start_kytos_api_core - AssertionError: assert {('amlight', ...anager'), ...} == {('amlight', ...enance'), ...}
FAILED tests/test_e2e_01_kytos_startup.py::TestE2EKytosServer::test_start_kytos_without_errors - AssertionError: assert [('ERROR', ' ...e pipeline.')] == []
FAILED tests/test_e2e_30_of_lldp.py::TestE2EOfLLDP::test_010_disable_of_lldp - assert (34 == 32)
FAILED tests/test_e2e_70_kytos_stats.py::TestE2EKytosStats::test_005_flow_stats - AssertionError: {"description":"Not Found","code":404}
FAILED tests/test_e2e_70_kytos_stats.py::TestE2EKytosStats::test_010_table_stats - AssertionError: {"description":"Not Found","code":404}
FAILED tests/test_e2e_70_kytos_stats.py::TestE2EKytosStats::test_015_packet_count - AssertionError: {"description":"Not Found","code":404}
FAILED tests/test_e2e_70_kytos_stats.py::TestE2EKytosStats::test_020_bytes_count - AssertionError: {"description":"Not Found","code":404}
FAILED tests/test_e2e_70_kytos_stats.py::TestE2EKytosStats::test_025_packet_count_per_flow - AssertionError: {"description":"Not Found","code":404}
FAILED tests/test_e2e_70_kytos_stats.py::TestE2EKytosStats::test_030_bytes_count_per_flow - AssertionError: {"description":"Not Found","code":404}
FAILED tests/test_e2e_70_kytos_stats.py::TestE2EKytosStats::test_035_table_fields_update - AssertionError: {"description":"Not Found","code":404}
FAILED tests/test_e2e_70_kytos_stats.py::TestE2EKytosStats::test_036_table_1_active_count_update - AssertionError: {"description":"Not Found","code":404}
==================================== 11 failed, 248 passed, 8 skipped, 8 xfailed, 7 xpassed, 1370 warnings in 11273.89s (3:07:53) ====================================
```

The test failures all seem to be due to factors beyond this change.