### PR TITLE
Added early return for flow_mod error

### DIFF
--- a/main.py
+++ b/main.py
@@ -1190,6 +1190,8 @@ class Main(KytosNApp):
         if command != "add":
             return
         evc = self.circuits.get(EVC.get_id_from_cookie(flow.cookie))
+        if not evc or evc.archived or not evc.is_enabled():
+            return
         with evc.lock:
             evc.remove_current_flows(sync=False)
             evc.remove_failover_flows(sync=True)


### PR DESCRIPTION
Closes #654 

### Summary

Added an early return when FLOW_ERROR is caught.
- If EVC is not found
- If EVC is archived
- If EVC is not enabled

### Local Tests
Manually trigger FLOW_ERROR
Added unit test

### End-to-End Tests
N/A
