### PR TITLE
release 2025.1.1: `set_queue` action is now set before `output`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,9 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2025.1.1] - 2025-06-23
+***********************
+
 Fixed
 =====
 - ``set_queue`` action is now set before ``output``

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Fixed
+=====
+- ``set_queue`` action is now set before ``output``
+
 [2025.1.0] - 2025-04-14
 ***********************
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Fixed
 =====
 - ``set_queue`` action is now set before ``output``
 
+General Information
+===================
+- ``scripts/console/2025.1.1/001_redeploy_set_queue.py`` is supposed to be used if you have EVCs created in prior versions that have ``set_queue`` action, this script will reploy them which will result in ``set_queue`` being placed before ``output`` action
+
 [2025.1.0] - 2025-04-14
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2025.1.0",
+  "version": "2025.1.1",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],

--- a/models/evc.py
+++ b/models/evc.py
@@ -1434,7 +1434,8 @@ class EVCDeploy(EVCBase):
         ]
         queue_id = settings.QUEUE_ID if queue_id == -1 else queue_id
         if queue_id is not None:
-            default_actions.append(
+            default_actions.insert(
+                0,
                 {"action_type": "set_queue", "queue_id": queue_id}
             )
 

--- a/scripts/console/2025.1.1/001_redeploy_set_queue.py
+++ b/scripts/console/2025.1.1/001_redeploy_set_queue.py
@@ -1,0 +1,66 @@
+import concurrent.futures
+# Change to False so this script makes changes
+DRY_RUN = True
+# Batch size to redeploy EVCs with set_queue
+BATCH_SIZE = 10
+
+mef_eline = controller.napps[("kytos", "mef_eline")]
+flow_manager = controller.napps[("kytos", "flow_manager")]
+
+
+def list_cookies_with_set_queue(flow_manager) -> set[int]:
+    """List unique mef_eline cookies from the flows collection
+    where the set_queue action is set (incorrectly) as the last action
+    with output action."""
+    return set(
+        map(
+            lambda doc: int(doc["flow"]["cookie"].to_decimal()),
+            filter(
+                lambda doc: len(doc["flow"]["actions"]) > 1
+                and doc["flow"]["actions"][-1]["action_type"] == "set_queue"
+                and doc["flow"]["actions"][-2]["action_type"] == "output",
+                flow_manager.flow_controller.db.flows.find(
+                    {
+                        "flow.owner": "mef_eline",
+                        "flow.actions": {"$elemMatch": {"action_type": "set_queue"}},
+                    }
+                ),
+            ),
+        )
+    )
+
+
+def get_id_from_cookie(cookie) -> str:
+    """Return the evc id given a cookie value."""
+    evc_id = cookie & 0xFFFFFFFFFFFFFF
+    return f"{evc_id:x}".zfill(14)
+
+
+def redeploy_evc(evc_id):
+    """Redeploy an EVC."""
+    import httpx
+
+    MEF_ELINE_URL = "http://localhost:8181/api/kytos/mef_eline/v2"
+    url = f"{MEF_ELINE_URL}/evc/{evc_id}/redeploy"
+    try:
+        res = httpx.request("PATCH", url, timeout=30)
+    except httpx.TimeoutException:
+        print(f"Timeout while enabling EVC {evc_id}")
+    if res.is_server_error or res.status_code in {424, 404, 409, 400}:
+        print(f"Error disabling EVC {evc_id}: {res.text}")
+
+
+dry_run_key = "WILL" if not DRY_RUN else "WOULD"
+
+print("Checking EVCs with action_type set_queue...")
+evc_ids = []
+for cookie in list_cookies_with_set_queue(flow_manager):
+    evc_ids.append(get_id_from_cookie(cookie))
+print(f"It {dry_run_key} redeploy {len(evc_ids)} EVCs")
+
+if not DRY_RUN:
+    executor = concurrent.futures.ThreadPoolExecutor(BATCH_SIZE, "script:redeploy_evc")
+    executor.map(redeploy_evc, evc_ids)
+    executor.shutdown()
+
+print("Finished!")

--- a/scripts/console/2025.1.1/README.md
+++ b/scripts/console/2025.1.1/README.md
@@ -10,7 +10,7 @@ This folder contains `mef_eline` related scripts that should be run on kytos con
 
 </summary>
 
-[001_redeploy_set_queue.py](./2025.1.1/001_redeploy_set_queue.py) script will reaploy EVCs which have `set_queue` action (incorrectly) as the last action. `set_queue` is supposed to be set before the `output` action.
+[001_redeploy_set_queue.py](./001_redeploy_set_queue.py) script will reaploy EVCs which have `set_queue` action (incorrectly) as the last action. `set_queue` is supposed to be set before the `output` action.
 
 ### How to use
 

--- a/scripts/console/2025.1.1/README.md
+++ b/scripts/console/2025.1.1/README.md
@@ -1,0 +1,35 @@
+# `mef_eline` scripts for Kytos version 2025.1
+
+This folder contains `mef_eline` related scripts that should be run on kytos console:
+
+<details>
+
+<summary>
+
+## Redeploy EVCs which have set_queue action (incorrectly) as the last action
+
+</summary>
+
+[001_redeploy_set_queue.py](./2025.1.1/001_redeploy_set_queue.py) script will reaploy EVCs which have `set_queue` action (incorrectly) as the last action. `set_queue` is supposed to be set before the `output` action.
+
+### How to use
+
+- Change `DRY_RUN` to `False` for the script to make changes.
+- Copy all the lines and paste them inside kytos console every time you need to run this script.
+
+### Output example
+
+```
+Checking EVCs with action_type set_queue...
+It WILL redeploy 50 EVCs
+...
+Finished!
+```
+
+```
+Checking EVCs with action_type set_queue...
+It WILL redeploy 0 EVCs
+Finished!
+```
+
+</details>

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -204,8 +204,10 @@ class TestEVC():
         evc.sb_priority = 1234
         flow_mod = evc._prepare_flow_mod(interface_a, interface_z, 3)
         assert flow_mod["priority"] == 1234
-        assert flow_mod["actions"][1]["action_type"] == "set_queue"
-        assert flow_mod["actions"][1]["queue_id"] == 3
+        assert flow_mod["actions"][0]["action_type"] == "set_queue"
+        assert flow_mod["actions"][0]["queue_id"] == 3
+        assert flow_mod["actions"][1]["action_type"] == "output"
+        assert flow_mod["actions"][1]["port"] == interface_z.port_number
 
     def test_prepare_pop_flow(self):
         """Test prepare pop flow  method."""


### PR DESCRIPTION
Closes #671 

### Summary

- See updated changelog file 
- Backport of https://github.com/kytos-ng/mef_eline/pull/673/files

### Local Tests

- Local tests ran (and documented) on this issue https://github.com/kytos-ng/mef_eline/issues/671

- I also ran the console scripts with 50 EVCs, redeployed as expected, then no longer did anymore since the `set_queue` now is now placed before `output`:

```
    ...: 
    ...: print("Finished!")
Checking EVCs with action_type set_queue...
It WOULD redeploy 50 EVCs
Finished!





Checking EVCs with action_type set_queue...
It WILL redeploy 50 EVCs
INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request command: delete, force: True, dpids: ['00:00:00:00:00:00:00:01', '00:00:00
:00:00:00:00:03'], flows[0, 1]: [{'cookie': 12253324356661394500, 'cookie_mask': 18446744073709551615, 'owner': 'mef_eline'}]
INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Flows received summary:  switches:['00:00:00:00:00:00:00:01', '00:00:00:00:00:00:00:03'], flows_by_s
witch:1,  total_flows_length: 2



    ...: 
    ...: print("Finished!")
Checking EVCs with action_type set_queue...
It WILL redeploy 0 EVCs
Finished!

kytos $> 
```

- Also ran sdntrace_cp on 50 EVCs:

```
{"length 2, 00:00:00:00:00:00:00:03, 1": 50}
```

### End-to-End Tests

mef_eline e2e tests with this branch:

```
+ python3 scripts/wait_for_mongo.py
Trying to run hello command on MongoDB...
Trying to run 'hello' command on MongoDB...
Ran 'hello' command on MongoDB successfully. It's ready!
+ python3 -m pytest tests/ -k mef_eline --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.6.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 285 items / 168 deselected / 117 selected
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 35%]
.                                                                        [ 35%]
tests/test_e2e_11_mef_eline.py ......                                    [ 41%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 47%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 82%]
.                                                                        [ 83%]
tests/test_e2e_14_mef_eline.py ......                                    [ 88%]
tests/test_e2e_15_mef_eline.py ......                                    [ 94%]
tests/test_e2e_16_mef_eline.py ..                                        [ 95%]
tests/test_e2e_17_mef_eline.py ....                                      [ 99%]
tests/test_e2e_60_of_multi_table.py .                                    [100%]
=============================== warnings summary ===============================
../../../../usr/local/lib/python3.11/dist-packages/kytos/core/config.py:254
```

