### PR TITLE
Switch dropdown component to choose EVC endpoints by name

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ Changed
 =======
 - Internal refactoring updating UI components to use ``pinia`` and ``axios``
 
+Added
+=====
+- Added a new dropdown to choose EVC endpoints by name
+
 [2025.1.0] - 2025-04-14
 ***********************
 

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -15,6 +15,7 @@
                     :candidates="dpids" 
                     @focus="fetch_dpids"
                     @blur="onblur_dpid"></k-input-auto>
+            <k-dropdown icon="arrow-right" title="Endpoint A Dropdown" :options="switchName_options" v-model:value="endpoint_a"></k-dropdown>
             <div class="k-input mef-field-label" id="endpoint_name_a"
                     >{{endpoint_name_a}}</div> 
             <k-input id="endpoint-a-tag-type" v-model:value="tag_type_a"
@@ -35,6 +36,7 @@
                     :candidates="dpids"
                     @focus="fetch_dpids"
                     @blur="onblur_dpid"></k-input-auto>
+            <k-dropdown icon="arrow-left" title="Endpoint Z Dropdown" :options="switchName_options" v-model:value="endpoint_z"></k-dropdown>
             <div class="k-input mef-field-label" id="endpoint_name_z"
                     >{{endpoint_name_z}}</div> 
            <k-input id="endpoint-z-tag_type" v-model:value="tag_type_z"
@@ -243,6 +245,7 @@ export default {
         dpids: [""],
         hasAutoComplete:false,
         link_options: [],
+        switchName_options: [],
 
         constraint_titles: {},
         constraints: {},
@@ -595,7 +598,9 @@ export default {
       try {
         const response = await this.$http.get(this.$kytos_server_api + "kytos/topology/v3");
         let _link = response.data['topology']['links'];
+        let _switch = response.data['topology']['switches'];
         this.link_options = [];
+        this.switchName_options = [];
         Object.entries(_link).forEach(([key, value], index) => {
           if (value.metadata.link_name !== undefined && value.metadata.link_name.length !== 0){
             this.link_options.push({value:value.id, description: value.metadata.link_name});
@@ -603,6 +608,15 @@ export default {
             this.link_options.push({value:value.id, description: value.id});
           }
         });
+        Object.entries(_switch).forEach(([key, value], index) => {
+          let switchName = value.metadata.node_name;
+          Object.entries(value.interfaces).forEach(([key, value], index) => {
+            let interfaceID = value.id;
+            let interfaceName = value.name;
+            this.switchName_options.push({value: `${switchName} - ${interfaceID}`, description: `${switchName} - ${interfaceID}`})
+          });
+        });
+
       } catch (err) {
         console.error(err);
       }


### PR DESCRIPTION
Closes #667

### Summary

There is a new dropdown which allows users to choose an EVC endpoint by name instead of DPID.

![image](https://github.com/user-attachments/assets/89895099-b161-44cc-b42e-c64ecbc58762)

### Local Tests

The dropdown functioned as should and there were no errors.

### End-to-End Tests
