### PR TITLE
Removed qinq for VLAN translation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Changed
 =======
 - Internal refactoring updating UI components to use ``pinia`` and ``axios``
 - The redeploy button within the Circuit Details Menu was moved to the top of the menu for easier accessibility
+- In EVCs flows where VLAN translation (numeric VLAN to untagged and different numeric VLANs) is performed, there is not longer ``qinq`` encapsulation applied.
 
 Added
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Changed
 =======
 - Internal refactoring updating UI components to use ``pinia`` and ``axios``
 - The redeploy button within the Circuit Details Menu was moved to the top of the menu for easier accessibility
-- In EVCs flows where VLAN translation (numeric VLAN to untagged and different numeric VLANs) is performed, there is not longer ``qinq`` encapsulation applied.
+- In EVCs flows where VLAN translation (numeric VLAN to untagged and different numeric VLANs) is performed, there is not longer ``qinq`` encapsulation applied. The translation will happen in the egress switch.
 
 Added
 =====

--- a/models/evc.py
+++ b/models/evc.py
@@ -1309,6 +1309,8 @@ class EVCDeploy(EVCBase):
                 endpoint_a,
                 self.uni_a.interface,
                 out_vlan_a,
+                in_vlan_a,
+                in_vlan_z,
                 queue_id=self.queue_id,
             )
             flows_a.append(pop_flow)
@@ -1348,6 +1350,8 @@ class EVCDeploy(EVCBase):
                 endpoint_z,
                 self.uni_z.interface,
                 out_vlan_z,
+                in_vlan_z,
+                in_vlan_a,
                 queue_id=self.queue_id,
             )
             flows_z.append(pop_flow)
@@ -1489,27 +1493,23 @@ class EVCDeploy(EVCBase):
         new_action = {"action_type": "set_vlan", "vlan_id": out_vlan}
         flow_mod["actions"].insert(0, new_action)
 
-        new_action = {"action_type": "push_vlan", "tag_type": "s"}
-        flow_mod["actions"].insert(0, new_action)
+        if not(in_vlan != new_c_vlan and isinstance(in_vlan, int) and isinstance(new_c_vlan, int)):
+            # If there is VLAN translation for untagged and a integer VLAN
+            # then there is not need for qinq encapsulation
+            new_action = {"action_type": "push_vlan", "tag_type": "s"}
+            flow_mod["actions"].insert(0, new_action)
 
         if in_vlan is not None:
             # if in_vlan is set, it must be included in the match
             flow_mod["match"]["dl_vlan"] = in_vlan
 
-        if (not isinstance(new_c_vlan, list) and in_vlan != new_c_vlan and
-                new_c_vlan not in self.special_cases):
+        if not isinstance(in_vlan, int) and isinstance(new_c_vlan, int) and new_c_vlan != 0:
             # new_in_vlan is an integer but zero, action to set is required
             new_action = {"action_type": "set_vlan", "vlan_id": new_c_vlan}
             flow_mod["actions"].insert(0, new_action)
 
-        if in_vlan not in self.special_cases and new_c_vlan == 0:
-            # # new_in_vlan is an integer but zero and new_c_vlan does not
-            # a pop action is required
-            new_action = {"action_type": "pop_vlan"}
-            flow_mod["actions"].insert(0, new_action)
-
-        elif in_vlan == "4096/4096" and new_c_vlan == 0:
-            # if in_vlan match with any tags and new_c_vlan does not
+        if in_vlan == "4096/4096" and new_c_vlan == 0:
+            # if in_vlan match with any tags and new_c_vlan does not,
             # a pop action is required
             new_action = {"action_type": "pop_vlan"}
             flow_mod["actions"].insert(0, new_action)
@@ -1517,15 +1517,15 @@ class EVCDeploy(EVCBase):
         elif (not in_vlan and
                 (not isinstance(new_c_vlan, list) and
                  new_c_vlan not in self.special_cases)):
-            # new_in_vlan is an integer but zero and in_vlan is not set
-            # then it is set now
+            # new_in_vlan is an integer but zero and in_vlan is a no-tag or
+            # untagged
             new_action = {"action_type": "push_vlan", "tag_type": "c"}
             flow_mod["actions"].insert(0, new_action)
 
         return flow_mod
 
     def _prepare_pop_flow(
-        self, in_interface, out_interface, out_vlan, queue_id=None
+        self, in_interface, out_interface, out_vlan, in_vlan, new_c_vlan, queue_id=None
     ):
         # pylint: disable=too-many-arguments
         """Prepare pop flow."""
@@ -1533,8 +1533,16 @@ class EVCDeploy(EVCBase):
             in_interface, out_interface, queue_id
         )
         flow_mod["match"]["dl_vlan"] = out_vlan
-        new_action = {"action_type": "pop_vlan"}
-        flow_mod["actions"].insert(0, new_action)
+        if in_vlan == 0:
+            new_action = {"action_type": "pop_vlan"}
+            flow_mod["actions"].insert(0, new_action)
+        elif in_vlan != new_c_vlan and isinstance(in_vlan, int) and isinstance(new_c_vlan, int):
+            # If UNI VLANs are different and in_vlan is not 0
+            new_action = {"action_type": "set_vlan", "vlan_id": in_vlan}
+            flow_mod["actions"].insert(0, new_action)
+        else:
+            new_action = {"action_type": "pop_vlan"}
+            flow_mod["actions"].insert(0, new_action)
         return flow_mod
 
     @staticmethod

--- a/models/evc.py
+++ b/models/evc.py
@@ -1497,8 +1497,8 @@ class EVCDeploy(EVCBase):
             not (in_vlan != new_c_vlan and isinstance(in_vlan, int) and
                  isinstance(new_c_vlan, int))
         ):
-            # If there is VLAN translation for untagged and a integer VLAN
-            # then there is not need for qinq encapsulation
+            # Add service VLAN header when it does NOT fall into this
+            # statement: Both VLANs should be integer and different.
             new_action = {"action_type": "push_vlan", "tag_type": "s"}
             flow_mod["actions"].insert(0, new_action)
 

--- a/models/evc.py
+++ b/models/evc.py
@@ -1473,10 +1473,10 @@ class EVCDeploy(EVCBase):
         """Prepare push flow.
 
         Arguments:
-            in_interface(str): Interface input.
-            out_interface(str): Interface output.
+            in_interface(Interface): Interface input.
+            out_interface(Interface): Interface output.
             in_vlan(int,str,None): Vlan input.
-            out_vlan(str): Vlan output.
+            out_vlan(int): Vlan output.
             new_c_vlan(int,str,list,None): New client vlan.
 
         Return:
@@ -1493,7 +1493,10 @@ class EVCDeploy(EVCBase):
         new_action = {"action_type": "set_vlan", "vlan_id": out_vlan}
         flow_mod["actions"].insert(0, new_action)
 
-        if not(in_vlan != new_c_vlan and isinstance(in_vlan, int) and isinstance(new_c_vlan, int)):
+        if (
+            not (in_vlan != new_c_vlan and isinstance(in_vlan, int) and
+                 isinstance(new_c_vlan, int))
+        ):
             # If there is VLAN translation for untagged and a integer VLAN
             # then there is not need for qinq encapsulation
             new_action = {"action_type": "push_vlan", "tag_type": "s"}
@@ -1503,7 +1506,10 @@ class EVCDeploy(EVCBase):
             # if in_vlan is set, it must be included in the match
             flow_mod["match"]["dl_vlan"] = in_vlan
 
-        if not isinstance(in_vlan, int) and isinstance(new_c_vlan, int) and new_c_vlan != 0:
+        if (
+            not isinstance(in_vlan, int) and isinstance(new_c_vlan, int) and
+            new_c_vlan != 0
+        ):
             # new_in_vlan is an integer but zero, action to set is required
             new_action = {"action_type": "set_vlan", "vlan_id": new_c_vlan}
             flow_mod["actions"].insert(0, new_action)
@@ -1525,7 +1531,13 @@ class EVCDeploy(EVCBase):
         return flow_mod
 
     def _prepare_pop_flow(
-        self, in_interface, out_interface, out_vlan, in_vlan, new_c_vlan, queue_id=None
+        self,
+        in_interface: Interface,
+        out_interface: Interface,
+        out_vlan: int,
+        in_vlan: Union[int, str, list, None],
+        new_c_vlan: Union[int, str, list, None],
+        queue_id=None,
     ):
         # pylint: disable=too-many-arguments
         """Prepare pop flow."""
@@ -1536,7 +1548,10 @@ class EVCDeploy(EVCBase):
         if in_vlan == 0:
             new_action = {"action_type": "pop_vlan"}
             flow_mod["actions"].insert(0, new_action)
-        elif in_vlan != new_c_vlan and isinstance(in_vlan, int) and isinstance(new_c_vlan, int):
+        elif (
+            in_vlan != new_c_vlan and isinstance(in_vlan, int) and
+            isinstance(new_c_vlan, int)
+        ):
             # If UNI VLANs are different and in_vlan is not 0
             new_action = {"action_type": "set_vlan", "vlan_id": in_vlan}
             flow_mod["actions"].insert(0, new_action)

--- a/scripts/db/2025.2.0/000_quinq_evcs.py
+++ b/scripts/db/2025.2.0/000_quinq_evcs.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import sys
+import os
+import httpx
+
+from kytos.core.db import Mongo
+
+
+def number_evcs_affected():
+    mongo = Mongo()
+    evcs_collection = mongo.client[mongo.db_name]["evcs"]
+    n_documents = evcs_collection.count_documents({
+        "$and": [
+            {"$expr": {
+                "$ne": ["$uni_a.tag.value", "$uni_z.tag.value"]
+            }},
+            {"$or":[
+                {"$and":[
+                    {"uni_a.tag.value": {"$type": "number"}},
+                    {"uni_z.tag.value": {"$type": "number"}}
+                ]},
+                {"$and":[
+                    {"uni_a.tag.value": {"$type": "number"}},
+                    {"uni_z.tag.value": {"$eq": "untagged"}}
+                ]},
+                {"$and":[
+                    {"uni_a.tag.value": {"$eq": "untagged"}},
+                    {"uni_z.tag.value": {"$type": "number"}}
+                ]}]
+            },
+            {"archived": {"$eq": False}}
+        ]
+    })
+    print(f"There are {n_documents} that need to be redeploy")
+    return
+
+def redeploy_affected_evcs():
+    mongo = Mongo()
+    evcs_collection = mongo.client[mongo.db_name]["evcs"]
+    documents = evcs_collection.find({
+        "$and": [
+            {"$expr": {
+                "$ne": ["$uni_a.tag.value", "$uni_z.tag.value"]
+            }},
+            {"$or":[
+                {"$and":[
+                    {"uni_a.tag.value": {"$type": "number"}},
+                    {"uni_z.tag.value": {"$type": "number"}}
+                ]},
+                {"$and":[
+                    {"uni_a.tag.value": {"$type": "number"}},
+                    {"uni_z.tag.value": {"$eq": "untagged"}}
+                ]},
+                {"$and":[
+                    {"uni_a.tag.value": {"$eq": "untagged"}},
+                    {"uni_z.tag.value": {"$type": "number"}}
+                ]}]
+            },
+            {"archived": {"$eq": False}}
+        ]
+    })
+
+    evc_count = 0
+    evc_ids: list[str] = []
+    for evc in documents:
+        evc_count += 1
+        evc_ids.append(evc["id"])
+    print(f"{evc_count} EVCs to be redeploy.")
+    print("Redeploying...")
+
+    evc_deleted_count = 0
+    evc_not_deleted: list[str] = []
+    MEF_URL = "http://localhost:8181/api/kytos/mef_eline/v2/evc/"
+    for evc in evc_ids:
+        response = httpx.patch(MEF_URL+evc+"/redeploy", timeout=60)
+        if response.status_code//100 == 2:
+            evc_deleted_count += 1
+
+    if evc_count != evc_deleted_count:
+        print("Not redeployed EVCs: ", evc_not_deleted)
+
+    else:
+        print("All EVCs were redeployed successfully.")
+
+    return 0
+
+if __name__ == "__main__":
+    cmds = {
+        "number_evcs_affected": number_evcs_affected,
+        "redeploy_affected_evcs": redeploy_affected_evcs,
+    }
+    try:
+        cmd = os.environ["CMD"]
+        command = cmds[cmd]
+    except KeyError:
+        print(
+            f"Please set the 'CMD' env var. \nIt has to be one of these: {list(cmds.keys())}"
+        )
+        sys.exit(1)
+        
+    command()
+    

--- a/scripts/db/2025.2.0/README.md
+++ b/scripts/db/2025.2.0/README.md
@@ -5,7 +5,7 @@ This folder contains Mef_eline's related scripts:
 ### Remove Qinq from EVCs flows when VLAN translation is needed
 
 
-[`000_quinq_evcs.py`](./000_quinq_evcs.py) is a script that redeploys EVCs with VLAN translatio so their flows are updated. This script will only cover cases where both UNIs have different numeric VLAN (from 1 to 4094 inclusive) and a numeric and ``untagged`` VLANs
+[`000_quinq_evcs.py`](./000_quinq_evcs.py) is a script that redeploys EVCs with VLAN translation so their flows are updated. This script will only cover cases where both UNIs have different numeric VLAN (from 1 to 4094 inclusive) and a numeric and ``untagged`` VLANs
 
 #### Pre-requisites
 
@@ -28,20 +28,20 @@ number_evcs_affected
 redeploy_affected_evcs
 ```
 
-#### Examples
+#### Commands
 
-Use ``number_evcs_affected`` to get the number of EVCs that will be re-deployed.
-
-```
-❯ CMD=number_evcs_affected python scripts/db/2025.2.0/000_quinq_evcs.py
-There are 3 that need to be redeploy
-```
-
-``redeploy_affected_evcs`` command will redeploy every EVC.
+``redeploy_affected_evcs`` command will redeploy every EVC. This option is not idempotent, meaning each time is used it re-deploy the same amount EVCs.
 
 ```
 ❯ CMD=redeploy_affected_evcs python scripts/db/2025.2.0/000_quinq_evcs.py
 3 EVCs to be redeploy.
 Redeploying...
 All EVCs were redeployed successfully.
+```
+
+Use ``number_evcs_affected`` to get the number of EVCs that will be re-deployed, EVCs with VLAN translation. If they were re-deployed before, the number will not change since this script does not look into QINQ encapsulation from the flows.
+
+```
+❯ CMD=number_evcs_affected python scripts/db/2025.2.0/000_quinq_evcs.py
+There are 3 that need to be redeploy
 ```

--- a/scripts/db/2025.2.0/README.md
+++ b/scripts/db/2025.2.0/README.md
@@ -1,0 +1,47 @@
+## `mef_eline` scripts for Kytos version 2025.2.0
+
+This folder contains Mef_eline's related scripts:
+
+### Remove Qinq from EVCs flows when VLAN translation is needed
+
+
+[`000_quinq_evcs.py`](./000_quinq_evcs.py) is a script that redeploys EVCs with VLAN translatio so their flows are updated. This script will only cover cases where both UNIs have different numeric VLAN (from 1 to 4094 inclusive) and a numeric and ``untagged`` VLANs
+
+#### Pre-requisites
+
+- The ``mef_eline`` NApp needs to be installed
+- ``kytosd`` needs to be running otherwise the API request are not going to work.
+- Make sure MongoDB replica set is up and running.
+- Export the following MongnoDB variables accordingly in case your running outside of a container
+
+```
+export MONGO_USERNAME=
+export MONGO_PASSWORD=
+export MONGO_DBNAME=napps
+export MONGO_HOST_SEEDS="mongo1:27017,mongo2:27018,mongo3:27099"
+```
+
+- The following `CMD` commands are available:
+
+```
+number_evcs_affected
+redeploy_affected_evcs
+```
+
+#### Examples
+
+Use ``number_evcs_affected`` to get the number of EVCs that will be re-deployed.
+
+```
+❯ CMD=number_evcs_affected python scripts/db/2025.2.0/000_quinq_evcs.py
+There are 3 that need to be redeploy
+```
+
+``redeploy_affected_evcs`` command will redeploy every EVC.
+
+```
+❯ CMD=redeploy_affected_evcs python scripts/db/2025.2.0/000_quinq_evcs.py
+3 EVCs to be redeploy.
+Redeploying...
+All EVCs were redeployed successfully.
+```

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -214,6 +214,7 @@ class TestEVC():
         [
             (2, 100, 0),
             (2, 100, 200),
+            (2, 2, 2)
         ]
     )
     def test_prepare_pop_flow_set_vlan(self, out_vlan, in_vlan, new_c_vlan):
@@ -244,7 +245,13 @@ class TestEVC():
             "table_group": "evpl",
             "table_id": 0,
         }
-        assert flow_mod == expected_flow_mod
+        if out_vlan == in_vlan == new_c_vlan:
+            assert flow_mod["actions"] == [
+                {"action_type": "pop_vlan"},
+                {"action_type": "output", "port": interface_z.port_number},
+            ]
+        else:
+            assert flow_mod == expected_flow_mod
 
     @pytest.mark.parametrize(
         "out_vlan, in_vlan, new_c_vlan",

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -209,8 +209,15 @@ class TestEVC():
         assert flow_mod["actions"][1]["action_type"] == "output"
         assert flow_mod["actions"][1]["port"] == interface_z.port_number
 
-    def test_prepare_pop_flow(self):
-        """Test prepare pop flow  method."""
+    @pytest.mark.parametrize(
+        "out_vlan, in_vlan, new_c_vlan",
+        [
+            (2, 100, 0),
+            (2, 100, 200),
+        ]
+    )
+    def test_prepare_pop_flow_set_vlan(self, out_vlan, in_vlan, new_c_vlan):
+        """Test _preprate_pop_flow when it adds set_vlan."""
         attributes = {
             "table_group": {"epl": 0, "evpl": 0},
             "controller": get_controller_mock(),
@@ -221,16 +228,65 @@ class TestEVC():
         evc = EVC(**attributes)
         interface_a = evc.uni_a.interface
         interface_z = evc.uni_z.interface
-        in_vlan = 10
+        flow_mod = evc._prepare_pop_flow(
+            interface_a, interface_z, out_vlan, in_vlan, new_c_vlan
+        )
+        expected_flow_mod = {
+            "match": {"in_port": interface_a.port_number,
+                      "dl_vlan": out_vlan},
+            "cookie": evc.get_cookie(),
+            "owner": "mef_eline",
+            "actions": [
+                {"action_type": "set_vlan", "vlan_id": in_vlan},
+                {"action_type": "output", "port": interface_z.port_number},
+            ],
+            "priority": EVPL_SB_PRIORITY,
+            "table_group": "evpl",
+            "table_id": 0,
+        }
+        assert flow_mod == expected_flow_mod
+
+    @pytest.mark.parametrize(
+        "out_vlan, in_vlan, new_c_vlan",
+        [
+            (2, 100, 100),
+            (2, 0, 100),
+            (2, "4096/4096", 100),
+            (2, None, 100),
+            (2, 0, 0),
+            (2, "4096/4096", 0),
+            (2, None, 0),
+            (2, 100, "4096/4096"),
+            (2, 0, "4096/4096"),
+            (2, "4096/4096", "4096/4096"),
+            (2, None, "4096/4096"),
+            (2, 100, None),
+            (2, 0, None),
+            (2, "4096/4096", None),
+            (2, None, None)
+        ]
+    )
+    def test_prepare_pop_flow_pop_vlan(self, out_vlan, in_vlan, new_c_vlan):
+        """Test _prepare_pop_flow  method with pop_vlan."""
+        attributes = {
+            "table_group": {"epl": 0, "evpl": 0},
+            "controller": get_controller_mock(),
+            "name": "custom_name",
+            "uni_a": get_uni_mocked(interface_port=1, is_valid=True),
+            "uni_z": get_uni_mocked(interface_port=2, is_valid=True),
+        }
+        evc = EVC(**attributes)
+        interface_a = evc.uni_a.interface
+        interface_z = evc.uni_z.interface
 
         # pylint: disable=protected-access
         flow_mod = evc._prepare_pop_flow(
-            interface_a, interface_z, in_vlan
+            interface_a, interface_z, out_vlan, in_vlan, new_c_vlan
         )
 
         expected_flow_mod = {
             "match": {"in_port": interface_a.port_number,
-                      "dl_vlan": in_vlan},
+                      "dl_vlan": out_vlan},
             "cookie": evc.get_cookie(),
             "owner": "mef_eline",
             "actions": [
@@ -301,17 +357,23 @@ class TestEVC():
             "priority": EVPL_SB_PRIORITY,
         }
         expected_flow_mod["priority"] = evc.get_priority(in_vlan_a)
+        if (
+            isinstance(in_vlan_a, int) and
+            isinstance(in_vlan_z, int) and
+            in_vlan_a != in_vlan_z
+        ):
+            expected_flow_mod["actions"].pop(0)
         if in_vlan_a is not None:
             expected_flow_mod['match']['dl_vlan'] = in_vlan_a
-        if in_vlan_z not in evc.special_cases and in_vlan_a != in_vlan_z:
+        if (
+            in_vlan_z not in evc.special_cases and
+            in_vlan_a != in_vlan_z and
+            not isinstance(in_vlan_a, int)
+        ):
             new_action = {"action_type": "set_vlan",
                           "vlan_id": in_vlan_z}
             expected_flow_mod["actions"].insert(0, new_action)
-        if in_vlan_a not in evc.special_cases:
-            if in_vlan_z == 0:
-                new_action = {"action_type": "pop_vlan"}
-                expected_flow_mod["actions"].insert(0, new_action)
-        elif in_vlan_a == "4096/4096":
+        if in_vlan_a == "4096/4096":
             if in_vlan_z == 0:
                 new_action = {"action_type": "pop_vlan"}
                 expected_flow_mod["actions"].insert(0, new_action)
@@ -323,7 +385,7 @@ class TestEVC():
                 new_action = {"action_type": "push_vlan",
                               "tag_type": "c"}
                 expected_flow_mod["actions"].insert(0, new_action)
-        assert expected_flow_mod == flow_mod
+        assert expected_flow_mod == flow_mod, (in_vlan_a, in_vlan_z)
 
     @staticmethod
     def create_evc_inter_switch(tag_value_a=82, tag_value_z=83):


### PR DESCRIPTION
Closes #509
Closes #648
Closes #650
Closes #649

### Summary

Provided script to redeploy affected EVCs.
Modified flows for 2 scenarios when creating EVCs

- Numeric VLAN and Untagged VLAN, current flows:
```
{"00:00:00:00:00:00:00:01": [
{"match": {"in_port": 1, "dl_vlan": 100},
"actions": [
            {"action_type": "set_vlan", "vlan_id": 1},
            {"action_type": "output", "port": 4}],
"table_group": "evpl",
"priority": 20000},
{"match": {"in_port": 4, "dl_vlan": 1},
"actions": [{"action_type": "set_vlan", "vlan_id": 100},
            {"action_type": "output", "port": 1}],
"table_group": "evpl",
"priority": 20000}],
 "00:00:00:00:00:00:00:03": [
{"match": {"in_port": 1, "dl_vlan": 0},
"actions": [{"action_type": "push_vlan", "tag_type": "c"},
            {"action_type": "set_vlan", "vlan_id": 1},
            {"action_type": "output", "port": 3}],
"table_group": "evpl",
"priority": 20000},
{"match": {"in_port": 3, "dl_vlan": 1},
"actions": [{"action_type": "pop_vlan"},
            {"action_type": "output", "port": 1}],
"table_group": "evpl",
"priority": 20000}]}
```

- Different Numeric VLANs
```
{"00:00:00:00:00:00:00:01": [
{"match": {"in_port": 1, "dl_vlan": 222},
"actions": [
    {"action_type": "set_vlan", "vlan_id": 1},
    {"action_type": "output", "port": 4}
],
"table_group": "evpl", "priority": 20000},
{"match": {"in_port": 4, "dl_vlan": 1},
"actions": [
    {"action_type": "set_vlan", "vlan_id": 222},
    {"action_type": "output", "port": 1}
],
"table_group": "evpl", "priority": 20000}],

"00:00:00:00:00:00:00:03": [
{"match": {"in_port": 1, "dl_vlan": 333},
"actions": [
    {"action_type": "set_vlan", "vlan_id": 1},
    {"action_type": "output", "port": 3}
],
"table_group": "evpl", "priority": 20000},
{"match": {"in_port": 3, "dl_vlan": 1},
"actions": [
    {"action_type": "set_vlan", "vlan_id": 333},
    {"action_type": "output", "port": 1}
],
"table_group": "evpl", "priority": 20000}]}
```

### Local Tests
Created the EVCs for every possible scenario ([script](https://github.com/Alopalao/Alopalao_miscellaneous/blob/main/testing/tests_2025_02/every_evc.py)) and compared flows.
Used Mininet to ping the scenarios where changes were made
Used script to redeploy affected EVCs

### End-to-End Tests
[PR](https://github.com/kytos-ng/kytos-end-to-end-tests/pull/375), results from the PR:
```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.6.0
rootdir: /tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 287 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  7%]
tests/test_e2e_06_topology.py ....                                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 28%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 42%]
.                                                                        [ 42%]
tests/test_e2e_14_mef_eline.py ......                                    [ 44%]
tests/test_e2e_15_mef_eline.py ......                                    [ 47%]
tests/test_e2e_16_mef_eline.py ..                                        [ 47%]
tests/test_e2e_17_mef_eline.py ....                                      [ 49%]
tests/test_e2e_20_flow_manager.py ............................           [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 65%]
tests/test_e2e_23_flow_manager.py ..............                         [ 70%]
tests/test_e2e_30_of_lldp.py .R...                                       [ 71%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 79%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 82%]
tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
tests/test_e2e_50_maintenance.py ............................            [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 94%]
tests/test_e2e_70_kytos_stats.py ........                                [ 97%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
```
