### PR TITLE
fix: UI: k-toolbar primary and secondary constraints are now collapsed by default again

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 Fixed
 =====
 - ``set_queue`` action is now set before ``output``
+- UI: k-toolbar primary and secondary constraints are now collapsed again
 
 Changed
 =======

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -73,7 +73,7 @@
         </k-accordion-item>
 
         <span v-for="constraint in ['primary_constraints', 'secondary_constraints']">
-            <k-accordion-item :title="constraint_titles[constraint]" :checked=false>
+            <k-accordion-item :title="constraint_titles[constraint]" :defaultState="false">
 
                 <k-select :title="constraint_titles.undesired_links" :options="get_link_options()"
                 v-model:value ="form_constraints[constraint].undesired_links"


### PR DESCRIPTION

Closes https://github.com/kytos-ng/mef_eline/issues/682

Related to https://github.com/kytos-ng/ui/issues/230

It'll be backported to 2025.1 on the related issue

### Summary

See updated changelog 

### Local Tests

Tested locally, it's now collapsed by default:

<img width="459" height="683" alt="20250721_112028" src="https://github.com/user-attachments/assets/47431977-3331-4694-9c34-b9dfea000426" />


### End-to-End Tests

N/A
