### PR TITLE
release 2025.1.2: fix: UI: k-toolbar primary and secondary constraints are now collapsed by default again

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 Fixed
 =====
 - ``set_queue`` action is now set before ``output``
+- UI: k-toolbar primary and secondary constraints are now collapsed again
 
 General Information
 ===================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,13 +6,19 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2025.1.2] - 2025-07-23
+***********************
+
+Fixed
+=====
+- UI: k-toolbar primary and secondary constraints are now collapsed again
+
 [2025.1.1] - 2025-06-23
 ***********************
 
 Fixed
 =====
 - ``set_queue`` action is now set before ``output``
-- UI: k-toolbar primary and secondary constraints are now collapsed again
 
 General Information
 ===================

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2025.1.1",
+  "version": "2025.1.2",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -73,7 +73,7 @@
         </k-accordion-item>
 
         <span v-for="constraint in ['primary_constraints', 'secondary_constraints']">
-            <k-accordion-item :title="constraint_titles[constraint]" :checked=false>
+            <k-accordion-item :title="constraint_titles[constraint]" :defaultState="false">
 
                 <k-select :title="constraint_titles.undesired_links" :options="get_link_options()"
                 v-model:value ="form_constraints[constraint].undesired_links"


### PR DESCRIPTION
Closes https://github.com/kytos-ng/ui/issues/230

- Backport of PR #683 
- It depends on https://github.com/kytos-ng/ui/pull/231

### Summary

See updated changelog file 

### Local Tests

- I tested it with a 2025.1 env from scratch:

```

     _   __      _
    | | / /     | |
    | |/ / _   _| |_ ___  ___          _ __   __ _
    |    \| | | | __/ _ \/ __| ______ | '_ \ / _` |
    | |\  \ |_| | || (_) \__ \|______|| | | | (_| |
    \_| \_/\__, |\__\___/|___/        |_| |_|\__, |
            __/ |                             __/ |
           |___/                             |___/
    
    Welcome to Kytos SDN Platform!

    Kytos website.: https://kytos-ng.github.io/about/
    Documentation.: https://github.com/kytos-ng/documentation/tree/master/tutorials/napps
    OF Address....: tcp://0.0.0.0:6653
    WEB UI........: http://0.0.0.0:8181/
    Kytos Version.: 2025.1.0
```

- Before the PR:

<img width="288" height="907" alt="20250721_121142" src="https://github.com/user-attachments/assets/171b03fe-53dd-446e-905c-9a24b146ebac" />

- After this PR:

<img width="416" height="676" alt="20250721_122237" src="https://github.com/user-attachments/assets/b1af5f01-7c80-4494-a6bb-2d431cccd17a" />


### End-to-End Tests

N/A
