### PR TITLE
Fixed the autocomplete spaces bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Fixed
 =====
 - ``set_queue`` action is now set before ``output``
 - UI: k-toolbar primary and secondary constraints are now collapsed again
+- UI: Autocomplete no longer throws an error when typing in spaces
 
 Changed
 =======

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -308,29 +308,25 @@ export default {
           x => queue_ids.push({value:x?.toString(), description:String(x)})
       )
       return queue_ids;
-    },
-    onblur_dpid() {
-        /**
-        * Update dpid values on event onblur triggered in dpids fields.
-        * It split the value selected from autocomplete list.
-        * It is expected the value as "NAME - DPID".
-        **/
-        let dpid_a = this.endpoint_a;
-        if(dpid_a.lastIndexOf(' ') > 0) {
-            let splitted_dpid = dpid_a.split(' ');
-            this.endpoint_name_a = splitted_dpid[0] + ": " + splitted_dpid[2];
-            this.endpoint_a = splitted_dpid[4];
-        }
-        
-        let dpid_z = this.endpoint_z;
-        if(dpid_z.lastIndexOf(' ') > 0) {
-            let splitted_dpid = dpid_z.split(' ');
-            this.endpoint_name_z = splitted_dpid[0] + ": " + splitted_dpid[2];
-            this.endpoint_z = splitted_dpid[4];
-        }
-    },
+    }
   },
   methods: {
+    onblur_dpid() {
+      /**
+      * Update dpid values on event onblur triggered in dpids fields.
+      * It split the value selected from autocomplete list.
+      * It is expected the value as "NAME - DPID".
+      **/
+      let dpid_a = this.endpoint_a;
+      let splitted_dpid_a = dpid_a.split(' ');
+      this.endpoint_name_a = splitted_dpid[0] + ": " + splitted_dpid[2];
+      this.endpoint_a = splitted_dpid[4];
+      
+      let dpid_z = this.endpoint_z;
+      let splitted_dpid_z = dpid_z.split(' ');
+      this.endpoint_name_z = splitted_dpid[0] + ": " + splitted_dpid[2];
+      this.endpoint_z = splitted_dpid[4];
+    },
     set_metrics: function (val, constraint) {
       try { this.form_constraints[constraint].metrics.not_ownership = JSON.parse(val) }
       catch (e) {


### PR DESCRIPTION
Closes #687 

### Summary

When you typed spaces into the `mef_eline` autocomplete, it would throw errors. It no longer does that.

### Local Tests

No errors were thrown after testing.
