### PR TITLE
Multithreaded Setup Failover for 2025.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,9 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2025.1.3] - 2025-10-02
+***********************
+
 Fixed
 =====
 - Consistency check setting up failover paths is now distributed across multiple threads through the event bus.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Fixed
+=====
+- Consistency check setting up failover paths is now distributed across multiple threads through the event bus.
+
 [2025.1.2] - 2025-07-23
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2025.1.2",
+  "version": "2025.1.3",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],

--- a/models/evc.py
+++ b/models/evc.py
@@ -980,21 +980,6 @@ class EVCDeploy(EVCBase):
         log.info(msg)
         return True
 
-    def try_setup_failover_path(
-        self,
-        wait=settings.DEPLOY_EVCS_INTERVAL,
-        warn_if_not_path=True
-    ):
-        """Try setup failover_path whenever possible."""
-        if (
-                self.failover_path or not self.current_path
-                or not self.is_active()
-                ):
-            return
-        if (now() - self.affected_by_link_at).seconds >= wait:
-            with self.lock:
-                self.setup_failover_path(warn_if_not_path)
-
     # pylint: disable=too-many-statements
     def setup_failover_path(self, warn_if_not_path=True):
         """Install flows for the failover path of this EVC.

--- a/models/evc.py
+++ b/models/evc.py
@@ -158,7 +158,6 @@ class EVCBase(GenericEntity):
         self.current_links_cache = set()
         self.primary_links_cache = set()
         self.backup_links_cache = set()
-        self.affected_by_link_at = get_time("0001-01-01T00:00:00")
         self.old_path = Path([])
         self.max_paths = kwargs.get("max_paths", 2)
 

--- a/models/path.py
+++ b/models/path.py
@@ -162,8 +162,10 @@ class DynamicPathManager:
         except httpx.RequestError as err:
             raise PathFinderException(str(err)) from err
 
-        if api_reply.status_code >= 400:
+        if api_reply.status_code >= 500:
             raise PathFinderException(api_reply.text)
+        if api_reply.status_code >= 400:
+            return []
         reply_data = api_reply.json()
         return reply_data.get("paths", [])
 

--- a/models/path.py
+++ b/models/path.py
@@ -242,6 +242,8 @@ class DynamicPathManager:
             Generator of unwanted_path disjoint paths. If unwanted_path is
             not provided or empty, we return an empty list.
         """
+        if cutoff < 1:
+            return None
         unwanted_links = [
             (link.endpoint_a.id, link.endpoint_b.id) for link in unwanted_path
         ]

--- a/models/path.py
+++ b/models/path.py
@@ -165,6 +165,10 @@ class DynamicPathManager:
         if api_reply.status_code >= 500:
             raise PathFinderException(api_reply.text)
         if api_reply.status_code >= 400:
+            log.error(
+                f"{circuit} failed to get paths from pathfinder. "
+                f"Error {api_reply.text}"
+            )
             return []
         reply_data = api_reply.json()
         return reply_data.get("paths", [])

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -2171,21 +2171,6 @@ class TestEVC():
         assert actual == ('No available path was found. 2 paths were'
                           f' rejected with messages: {tag_errors}')
 
-    @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.setup_failover_path")
-    def test_try_setup_failover_path(self, setup_failover_mock):
-        """Test try_setup_failover_path"""
-        self.evc_deploy.failover_path = True
-        self.evc_deploy.current_path = False
-        self.evc_deploy.is_active = MagicMock(return_value=False)
-        self.evc_deploy.try_setup_failover_path()
-        assert setup_failover_mock.call_count == 0
-
-        self.evc_deploy.failover_path = False
-        self.evc_deploy.current_path = True
-        self.evc_deploy.is_active = MagicMock(return_value=True)
-        self.evc_deploy.try_setup_failover_path()
-        assert setup_failover_mock.call_count == 1
-
     @patch("napps.kytos.mef_eline.models.evc.EVCDeploy._send_flow_mods")
     @patch(
         "napps.kytos.mef_eline.models.evc.EVCDeploy._prepare_direct_uni_flows"

--- a/tests/unit/models/test_path.py
+++ b/tests/unit/models/test_path.py
@@ -872,7 +872,13 @@ class TestDynamicPathManager():
 
         mock_response.json.return_value = {"paths": paths2["paths"]}
         mock_httpx_post.return_value = mock_response
-        paths = list(DynamicPathManager.get_disjoint_paths(evc, current_path, 1))
+        paths = list(
+            DynamicPathManager.get_disjoint_paths(
+                evc,
+                current_path,
+                cutoff=1
+            )
+        )
         args = mock_shared.call_args[0]
         assert args[0] == paths2["paths"][-1]
         assert args[1] == path_interfaces
@@ -883,13 +889,15 @@ class TestDynamicPathManager():
             [link.id for link in expected_disjoint_path]
         )
 
-        result = list(DynamicPathManager.get_disjoint_paths(
-            evc,
-            current_path,
-            0
-        ))
+        result = list(
+            DynamicPathManager.get_disjoint_paths(
+                evc,
+                current_path,
+                cutoff=0
+            )
+        )
 
-        assert result == []
+        assert not result
 
     @patch("httpx.post")
     def test_get_disjoint_paths_simple_evc(self, mock_httpx_post):

--- a/tests/unit/models/test_path.py
+++ b/tests/unit/models/test_path.py
@@ -870,6 +870,27 @@ class TestDynamicPathManager():
             [link.id for link in expected_disjoint_path]
         )
 
+        mock_response.json.return_value = {"paths": paths2["paths"]}
+        mock_httpx_post.return_value = mock_response
+        paths = list(DynamicPathManager.get_disjoint_paths(evc, current_path, 1))
+        args = mock_shared.call_args[0]
+        assert args[0] == paths2["paths"][-1]
+        assert args[1] == path_interfaces
+        assert args[2] == path_switches
+        assert len(paths) == 1
+        assert (
+            [link.id for link in paths[0]] ==
+            [link.id for link in expected_disjoint_path]
+        )
+
+        result = list(DynamicPathManager.get_disjoint_paths(
+            evc,
+            current_path,
+            0
+        ))
+
+        assert result == []
+
     @patch("httpx.post")
     def test_get_disjoint_paths_simple_evc(self, mock_httpx_post):
         """Test get_disjoint_paths method for simple EVCs."""

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2839,6 +2839,9 @@ class TestMain:
     def test_handle_evc_deployed(
         self,
     ):
+        """
+        Test setting up failover path with need_failover event.
+        """
         evc1 = MagicMock()
         evc1.is_eligible_for_failover_path.return_value = True
         evc1.is_active.return_value = True

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -105,12 +105,21 @@ class TestMain:
         mock_execute_consistency.assert_not_called()
         mock_log.info.assert_not_called()
 
+    @patch("napps.kytos.mef_eline.main.map_evc_event_content")
+    @patch("napps.kytos.mef_eline.main.emit_event")
     @patch('napps.kytos.mef_eline.main.settings')
     @patch("napps.kytos.mef_eline.controllers.ELineController.upsert_evc")
     @patch("napps.kytos.mef_eline.models.evc.EVCDeploy.check_list_traces")
     def test_execute_consistency(self, mock_check_list_traces, *args):
         """Test execute_consistency."""
-        (mongo_controller_upsert_mock, mock_settings) = args
+        (
+            mongo_controller_upsert_mock,
+            mock_settings,
+            mock_emit_event,
+            mock_map_evc,
+        ) = args
+
+        mock_map_evc.side_effect = lambda x: x
 
         stored_circuits = {'1': {'name': 'circuit_1'},
                            '2': {'name': 'circuit_2'},
@@ -121,6 +130,7 @@ class TestMain:
         }
 
         mock_settings.WAIT_FOR_OLD_PATH = -1
+
         evc1 = MagicMock(id=1, service_level=0, creation_time=1)
         evc1.is_enabled.return_value = True
         evc1.is_active.return_value = False
@@ -128,6 +138,7 @@ class TestMain:
         evc1.has_recent_removed_flow.return_value = False
         evc1.is_recent_updated.return_value = False
         evc1.execution_rounds = 0
+
         evc2 = MagicMock(id=2, service_level=7, creation_time=1)
         evc2.is_enabled.return_value = True
         evc2.is_active.return_value = False
@@ -135,20 +146,44 @@ class TestMain:
         evc2.has_recent_removed_flow.return_value = False
         evc2.is_recent_updated.return_value = False
         evc2.execution_rounds = 0
-        self.napp.circuits = {'1': evc1, '2': evc2}
-        assert self.napp.get_evcs_by_svc_level() == [evc2, evc1]
+
+        evc3 = MagicMock(id=3, service_level=0, creation_time=1)
+        evc3.is_enabled.return_value = True
+        evc3.is_active.return_value = True
+        evc3.lock.locked.return_value = False
+        evc3.has_recent_removed_flow.return_value = False
+        evc3.is_recent_updated.return_value = False
+        evc3.execution_rounds = 0
+        evc3.is_eligible_for_failover_path.return_value = True
+        evc3.failover_path = Path([])
+
+        self.napp.circuits = {
+            '1': evc1,
+            '2': evc2,
+            '3': evc3,
+        }
+        assert self.napp.get_evcs_by_svc_level() == [
+            evc2,
+            evc1,
+            evc3
+        ]
 
         mock_check_list_traces.return_value = {
-                                                1: True,
-                                                2: False
-                                            }
+            1: True,
+            2: False,
+            3: True,
+        }
 
         self.napp.execute_consistency()
         assert evc1.activate.call_count == 1
         assert evc1.sync.call_count == 1
-        evc1.try_setup_failover_path.assert_called_with(warn_if_not_path=False)
         assert evc2.deploy.call_count == 1
-        evc2.try_setup_failover_path.assert_called_with(warn_if_not_path=False)
+
+        mock_emit_event.assert_called_once_with(
+            self.napp.controller,
+            "need_failover",
+            content=evc3
+        )
 
     @patch('napps.kytos.mef_eline.main.settings')
     @patch('napps.kytos.mef_eline.main.Main._load_evc')
@@ -2800,3 +2835,43 @@ class TestMain:
         self.napp.handle_on_interface_link_change(event)
         assert mock_down.call_count == 2
         assert mock_up.call_count == 1
+
+    def test_handle_evc_deployed(
+        self,
+    ):
+        evc1 = MagicMock()
+        evc1.is_eligible_for_failover_path.return_value = True
+        evc1.is_active.return_value = True
+        evc1.failover_path = Path([])
+        evc1.current_path = ["LINK"]
+
+        evc2 = MagicMock()
+        evc2.is_eligible_for_failover_path.return_value = False
+        evc2.is_active.return_value = True
+        evc2.failover_path = Path([])
+        evc2.current_path = ["LINK"]
+
+        self.napp.circuits = {
+            "evc_1": evc1,
+            "evc_2": evc2,
+        }
+
+        event = KytosEvent(
+            name="kytos/mef_eline.need_failover",
+            content={
+                "evc_id": "evc_1",
+            }
+        )
+
+        self.napp.handle_evc_deployed(event)
+        evc1.setup_failover_path.assert_called()
+
+        event = KytosEvent(
+            name="kytos/mef_eline.need_failover",
+            content={
+                "evc_id": "evc_2",
+            }
+        )
+
+        self.napp.handle_evc_deployed(event)
+        evc2.setup_failover_path.assert_not_called()


### PR DESCRIPTION
Partially closes #686

### Summary

Makes it so that the `try_setup_failover` process of consistency check is distributed across multiple threads through the event bus. This should minimize the timespan this process will use to hold multiple evc locks, and prevent resource contention with the `link_down` handler.

### Local Tests

Everything appears to be properly handled. Failover paths continue to be properly setup. Will need to do further testing with link flaps to fully validate.

### End-to-End Tests

Will need to run E2E tests on this.