### PR TITLE
feat: ui: implemented k-dropdown to cover INT proxy_port_enabled options

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Changed
 Added
 =====
 - Filters can now search for multiple values at a time by using commas or spaces. If you type ``Switch1, Switch2, Switch3`` or ``Switch1 Switch2 Switch3`` or ``Switch1, Switch2, Switch3`` into the filter/search-bar, then your search will include all 3 options, Switch1, Switch2, and Switch3.
+- UI: integrated a dropdown to set INT proxy_port_enabled metadata option
 
 Fixed
 =====

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -69,6 +69,8 @@
            <k-checkbox title="Enable INT" v-model:model="enable_int" :value="'enable'"
                        tooltip="Enable In-band Network Telemetry (INT)"
            ></k-checkbox>
+           <k-dropdown v-if="enable_int.includes('enable')" class="compact-dropdown" title="Inter EVC Proxy Port Enabled: " :options="int_proxy_port_options"
+           v-model:value="int_proxy_port_option"></k-dropdown>
           </form>
         </k-accordion-item>
 
@@ -240,6 +242,7 @@ export default {
         max_paths: "",
         queue_id: "",
         enable_int: [],
+        int_proxy_port_option: null,
         dpids: [""],
         hasAutoComplete:false,
         link_options: [],
@@ -308,6 +311,13 @@ export default {
           x => queue_ids.push({value:x?.toString(), description:String(x)})
       )
       return queue_ids;
+    },
+    int_proxy_port_options(){
+      return [
+        {value: null, description: "none", selected: true},
+        {value: true, description: "true"},
+        {value: false, description: "false"}
+      ];
     }
   },
   methods: {
@@ -467,6 +477,7 @@ export default {
       this.sb_priority = "";
       this.queue_id = "";
       this.enable_int = [],
+      this.int_proxy_port_option = null,
       this.link_options = [];
       this.max_paths = "";
 
@@ -519,6 +530,9 @@ export default {
         }
         if (this.enable_int.includes('enable')) {
           request.metadata = {telemetry_request: {}}
+          if (this.int_proxy_port_option !== null) {
+              request.metadata["proxy_port_enabled"] = this.int_proxy_port_option
+          }
         }
 
         ['primary_constraints', 'secondary_constraints'].forEach(_type => {


### PR DESCRIPTION
Closes #691 

Requires and depends on https://github.com/kytos-ng/telemetry_int/pull/163

### Summary

See updated changelog file 

### Local Tests

Tested 3 cases in the UI:

- Inter EVC with proxy_port_enabled: false
- Inter EVC with proxy_port_enabled: true (but without proxy port configured), confirmed that it didn't enabled and logged the error including addting the expected status_reason metadata
- Inter EVC without proxy_port_enabled set

<img width="972" height="684" alt="20250808_163246" src="https://github.com/user-attachments/assets/dbd8aca1-e983-4e09-892b-4dbf6fbdb208" />


<img width="1905" height="845" alt="20250808_163406" src="https://github.com/user-attachments/assets/d88c46bd-d106-40ae-8049-68125edfb6ef" />



```
2025-08-08 16:34:01,546 - INFO [kytos.napps.kytos/telemetry_int] (MainThread) Handling mef_eline.deployed on EVC id: 0f5f78c3670a4c
2025-08-08 16:34:01,546 - ERROR [kytos.napps.kytos/telemetry_int] (MainThread) Failed when handling mef_eline.deployed: EVC 0f5f78c3670a4c with proxy_port_enabled must have both proxy ports set, pp_a: None, pp_z: None. Analyze the error and you'll need to enable or redeploy EVC 0f5f78c3670a4c later
```


### End-to-End Tests

N/A for UI
