### PR TITLE
Use tag_capable links from kytos controller for acquiring tags

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ Changed
 - ``mef_eline`` now listens to ``kytos/topology.interface.(enabled|up|disabled|down)`` events to update affected EVCs.
 - UI: Disabled unused inputs of UNI table.
 - UI: Changed UNI table DPID row to ID.
+- Modified to use ``TAGCapable`` for acquiring and releasing tags.
 
 Added
 =====

--- a/models/evc.py
+++ b/models/evc.py
@@ -162,8 +162,6 @@ class EVCBase(GenericEntity):
         self.old_path = Path([])
         self.max_paths = kwargs.get("max_paths", 2)
 
-        self.lock = Lock()
-
         self.archived = kwargs.get("archived", False)
 
         self.metadata = kwargs.get("metadata", {})

--- a/models/evc.py
+++ b/models/evc.py
@@ -480,7 +480,6 @@ class EVCBase(GenericEntity):
             if not tag:
                 return
         uni.interface.atomic_use_tags(
-            self._controller,
             tag_type,
             tag,
             check_order=False
@@ -503,7 +502,6 @@ class EVCBase(GenericEntity):
                 return
         try:
             conflict = uni.interface.atomic_make_tags_available(
-                self._controller,
                 tag_type,
                 tag,
                 check_order=False

--- a/models/path.py
+++ b/models/path.py
@@ -5,6 +5,7 @@ from tenacity import (retry, retry_if_exception_type, stop_after_attempt,
 
 from kytos.core import log
 from kytos.core.common import EntityStatus, GenericEntity
+from kytos.core.controller import Controller
 from kytos.core.exceptions import KytosNoTagAvailableError
 from kytos.core.interface import TAG
 from kytos.core.link import Link
@@ -37,7 +38,11 @@ class Path(list[Link], GenericEntity):
                 return link
         return None
 
-    def choose_vlans(self, controller, old_path_dict: dict = None):
+    def choose_vlans(
+        self,
+        controller: Controller,
+        old_path_dict: dict = None
+    ):
         """Choose the VLANs to be used for the circuit.
         If any of the links next tag isn't available, it'll release
         all vlans of the path that have been allocated, all or nothing.
@@ -45,32 +50,48 @@ class Path(list[Link], GenericEntity):
         old_path_dict = old_path_dict if old_path_dict else {}
         try:
             for link in self:
-                tag_value = link.get_next_available_tag(
-                    controller, link.id,
-                    try_avoid_value=old_path_dict.get(link.id)
-                )
+                real_link = controller.get_link(link.id)
+                if real_link is None:
+                    raise KytosNoTagAvailableError(link)
+                with real_link.tag_lock:
+                    tag_value = real_link.get_next_available_tag(
+                        "vlan",
+                        try_avoid_value=old_path_dict.get(link.id)
+                    )
+                    real_link.notify_tag_listeners(
+                        controller
+                    )
                 tag = TAG('vlan', tag_value)
                 link.add_metadata("s_vlan", tag)
         except KytosNoTagAvailableError as exc:
             self.make_vlans_available(controller)
             raise exc
 
-    def make_vlans_available(self, controller):
+    def make_vlans_available(
+        self,
+        controller: Controller
+    ):
         """Make the VLANs used in a path available when undeployed."""
         for link in self:
-            tag = link.get_metadata("s_vlan")
+            tag: TAG = link.get_metadata("s_vlan")
             if not tag:
                 continue
-            conflict_a, conflict_b = link.make_tags_available(
-                controller, tag.value, link.id, tag.tag_type,
-                check_order=False
-            )
-            if conflict_a:
-                log.error(f"Tags {conflict_a} was already available in"
-                          f"{link.endpoint_a.id}")
-            if conflict_b:
-                log.error(f"Tags {conflict_b} was already available in"
-                          f"{link.endpoint_b.id}")
+            real_link = controller.get_link(link.id)
+            if real_link is not None:
+                with real_link.tag_lock:
+                    conflict = real_link.make_tags_available(
+                        tag.tag_type,
+                        tag.value,
+                        check_order=False
+                    )
+                    real_link.notify_tag_listeners(
+                        controller
+                    )
+                if conflict:
+                    log.error(
+                        f"Tags {conflict} was already available in "
+                        f"{link.id}"
+                    )
             link.remove_metadata("s_vlan")
 
     def is_valid(self, switch_a, switch_z, is_scheduled=False):

--- a/models/path.py
+++ b/models/path.py
@@ -86,6 +86,10 @@ class Path(list[Link], GenericEntity):
                         f"Tags {conflict} was already available in "
                         f"{link.id}"
                     )
+            else:
+                log.error(
+                    f"Link {link.id} was missing, while vlans were being freed."
+                )
             link.remove_metadata("s_vlan")
 
     def is_valid(self, switch_a, switch_z, is_scheduled=False):

--- a/models/path.py
+++ b/models/path.py
@@ -8,7 +8,8 @@ from tenacity import (retry, retry_if_exception_type, stop_after_attempt,
 from kytos.core import log
 from kytos.core.common import EntityStatus, GenericEntity
 from kytos.core.controller import Controller
-from kytos.core.exceptions import KytosNoTagAvailableError
+from kytos.core.exceptions import (KytosDBWriteException,
+                                   KytosNoTagAvailableError)
 from kytos.core.interface import TAG
 from kytos.core.link import Link
 from kytos.core.retry import before_sleep
@@ -69,7 +70,13 @@ class Path(list[Link], GenericEntity):
                     )
                     tag = TAG("vlan", tag_value)
                     modified_links.append((path_link, real_link, tag))
-            except KytosNoTagAvailableError as exc:
+                Link.bulk_notify_tag_listeners(
+                    [
+                        real_link
+                        for _, real_link, _ in modified_links
+                    ]
+                )
+            except (KytosNoTagAvailableError, KytosDBWriteException) as exc:
                 for path_link, real_link, tag in modified_links:
                     real_link.make_tags_available(
                         tag.tag_type,
@@ -80,7 +87,6 @@ class Path(list[Link], GenericEntity):
 
             for path_link, real_link, tag in modified_links:
                 path_link.add_metadata('s_vlan', tag)
-                real_link.notify_tag_listeners()
 
     def make_vlans_available(
         self,
@@ -112,16 +118,31 @@ class Path(list[Link], GenericEntity):
                             f"Tags {conflict} was already available in "
                             f"{path_link.id}"
                         )
-                    modified_links.append(real_link)
+                    else:
+                        modified_links.append(path_link, real_link, tag)
                 else:
                     log.error(
                         f"Link {path_link.id} was missing,"
                         " while vlans were being freed."
                     )
-                path_link.remove_metadata("s_vlan")
+            try:
+                Link.bulk_notify_tag_listeners(
+                    [
+                        real_link
+                        for _, real_link, _ in modified_links
+                    ]
+                )
+            except KytosDBWriteException as exc:
+                for path_link, real_link, tag in modified_links:
+                    real_link.use_tags(
+                        tag.tag_type,
+                        tag.value,
+                        check_order=False
+                    )
+                raise exc
 
-            for real_link in modified_links:
-                real_link.notify_tag_listeners()
+            for path_link, real_link, tag in modified_links:
+                path_link.remove_metadata("s_vlan")
 
     def is_valid(self, switch_a, switch_z, is_scheduled=False):
         """Check if this is a valid path."""

--- a/models/path.py
+++ b/models/path.py
@@ -1,4 +1,6 @@
 """Classes related to paths"""
+from contextlib import ExitStack
+
 import httpx
 from tenacity import (retry, retry_if_exception_type, stop_after_attempt,
                       wait_combine, wait_fixed, wait_random)
@@ -48,49 +50,78 @@ class Path(list[Link], GenericEntity):
         all vlans of the path that have been allocated, all or nothing.
         """
         old_path_dict = old_path_dict if old_path_dict else {}
-        try:
-            for link in self:
-                real_link = controller.get_link(link.id)
-                if real_link is None:
-                    raise KytosNoTagAvailableError(link)
-                tag_value = real_link.atomic_get_next_available_tag(
-                    controller,
-                    "vlan",
-                    try_avoid_value=old_path_dict.get(link.id)
-                )
-                tag = TAG('vlan', tag_value)
-                link.add_metadata("s_vlan", tag)
-        except KytosNoTagAvailableError as exc:
-            self.make_vlans_available(controller)
-            raise exc
+        with ExitStack() as stack:
+            link_list = []
+            with controller.switches_lock:
+                for path_link in self:
+                    real_link = controller.get_link(path_link.id)
+                    if real_link is None:
+                        raise KytosNoTagAvailableError(path_link)
+                    stack.enter_context(real_link.tag_lock)
+                    link_list.append((path_link, real_link))
+
+            modified_links = []
+            try:
+                for path_link, real_link in link_list:
+                    tag_value = real_link.get_next_available_tag(
+                        "vlan",
+                        try_avoid_value=old_path_dict.get(real_link.id)
+                    )
+                    tag = TAG("vlan", tag_value)
+                    modified_links.append((path_link, real_link, tag))
+            except KytosNoTagAvailableError as exc:
+                for path_link, real_link, tag in modified_links:
+                    real_link.make_tags_available(
+                        tag.tag_type,
+                        tag.value,
+                        check_order=False
+                    )
+                raise exc
+
+            for path_link, real_link, tag in modified_links:
+                path_link.add_metadata('s_vlan', tag)
+                real_link.notify_tag_listeners()
 
     def make_vlans_available(
         self,
         controller: Controller
     ):
         """Make the VLANs used in a path available when undeployed."""
-        for link in self:
-            tag: TAG = link.get_metadata("s_vlan")
-            if not tag:
-                continue
-            real_link = controller.get_link(link.id)
-            if real_link is not None:
-                conflict = real_link.atomic_make_tags_available(
-                    controller,
-                    tag.tag_type,
-                    tag.value,
-                    check_order=False
-                )
-                if conflict:
-                    log.error(
-                        f"Tags {conflict} was already available in "
-                        f"{link.id}"
+        with ExitStack() as stack:
+            link_list = []
+            with controller.switches_lock:
+                for path_link in self:
+                    real_link = controller.get_link(path_link.id)
+                    if real_link is not None:
+                        stack.enter_context(real_link.tag_lock)
+                    link_list.append((path_link, real_link))
+
+            modified_links = []
+            for path_link, real_link in link_list:
+                tag: TAG = path_link.get_metadata("s_vlan")
+                if not tag:
+                    continue
+                if real_link is not None:
+                    conflict = real_link.make_tags_available(
+                        tag.tag_type,
+                        tag.value,
+                        check_order=False
                     )
-            else:
-                log.error(
-                    f"Link {link.id} was missing, while vlans were being freed."
-                )
-            link.remove_metadata("s_vlan")
+                    if conflict:
+                        log.error(
+                            f"Tags {conflict} was already available in "
+                            f"{path_link.id}"
+                        )
+                    modified_links.append(real_link)
+                else:
+                    log.error(
+                        f"Link {path_link.id} was missing,"
+                        " while vlans were being freed."
+                    )
+                path_link.remove_metadata("s_vlan")
+
+            for real_link in modified_links:
+                real_link.notify_tag_listeners()
 
     def is_valid(self, switch_a, switch_z, is_scheduled=False):
         """Check if this is a valid path."""

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -5,5 +5,6 @@
 #    pip-compile --output-file requirements/dev.txt requirements/dev.in
 #
 -e git+https://github.com/kytos-ng/python-openflow.git#egg=python-openflow
--e git+https://github.com/kytos-ng/kytos.git#egg=kytos[dev]
+# TODO: Revert pinned branch
+-e git+https://github.com/kytos-ng/kytos.git@feature/tag_capable#egg=kytos[dev]
 -e .

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,5 +1,5 @@
 """Module to help to create tests."""
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 from kytos.core import Controller
 from kytos.core.common import EntityStatus
@@ -48,7 +48,8 @@ def get_link_mocked(**kwargs):
         switch_b,
     )
     link = Mock(spec=Link, endpoint_a=endpoint_a, endpoint_b=endpoint_b)
-    link.make_tags_available.return_value = True, True
+    link.make_tags_available.return_value = True
+    link.tag_lock = MagicMock()
     link.endpoint_a.link = link
     link.endpoint_b.link = link
     link.as_dict.return_value = kwargs.get(
@@ -102,6 +103,7 @@ def get_uni_mocked(**kwargs):
     switch.id = kwargs.get("switch_id", "custom_switch_id")
     switch.dpid = kwargs.get("switch_dpid", "custom_switch_dpid")
     interface = Interface(interface_name, interface_port, switch)
+    interface.notify_tag_listeners = MagicMock()
     if isinstance(tag_value, list):
         tag = TAGRange(tag_type, tag_value)
     else:

--- a/tests/unit/models/test_evc_base.py
+++ b/tests/unit/models/test_evc_base.py
@@ -596,8 +596,8 @@ class TestEVC():  # pylint: disable=too-many-public-methods, no-member
         uni.interface.use_tags = MagicMock()
         evc._use_uni_vlan(uni)
         args = uni.interface.use_tags.call_args[0]
+        assert args[0] == uni.user_tag.tag_type
         assert args[1] == uni.user_tag.value
-        assert args[2] == uni.user_tag.tag_type
         assert uni.interface.use_tags.call_count == 1
 
         uni.user_tag.value = "any"
@@ -639,8 +639,8 @@ class TestEVC():  # pylint: disable=too-many-public-methods, no-member
 
         evc.make_uni_vlan_available(uni)
         args = uni.interface.make_tags_available.call_args[0]
+        assert args[0] == uni.user_tag.tag_type
         assert args[1] == uni.user_tag.value
-        assert args[2] == uni.user_tag.tag_type
         assert uni.interface.make_tags_available.call_count == 1
 
         uni.user_tag.value = [[1, 10]]

--- a/tests/unit/models/test_evc_base.py
+++ b/tests/unit/models/test_evc_base.py
@@ -593,35 +593,35 @@ class TestEVC():  # pylint: disable=too-many-public-methods, no-member
         }
         evc = EVC(**attributes)
         uni = get_uni_mocked(is_valid=True)
-        uni.interface.use_tags = MagicMock()
+        uni.interface.atomic_use_tags = MagicMock()
         evc._use_uni_vlan(uni)
-        args = uni.interface.use_tags.call_args[0]
-        assert args[0] == uni.user_tag.tag_type
-        assert args[1] == uni.user_tag.value
-        assert uni.interface.use_tags.call_count == 1
+        args = uni.interface.atomic_use_tags.call_args[0]
+        assert args[1] == uni.user_tag.tag_type
+        assert args[2] == uni.user_tag.value
+        assert uni.interface.atomic_use_tags.call_count == 1
 
         uni.user_tag.value = "any"
         evc._use_uni_vlan(uni)
-        assert uni.interface.use_tags.call_count == 2
+        assert uni.interface.atomic_use_tags.call_count == 2
 
         uni.user_tag.value = [[1, 10]]
         uni_dif = get_uni_mocked(tag_value=[[1, 2]])
         mock_difference.return_value = [[3, 10]]
         evc._use_uni_vlan(uni, uni_dif)
-        assert uni.interface.use_tags.call_count == 3
+        assert uni.interface.atomic_use_tags.call_count == 3
 
         mock_difference.return_value = []
         evc._use_uni_vlan(uni, uni_dif)
-        assert uni.interface.use_tags.call_count == 3
+        assert uni.interface.atomic_use_tags.call_count == 3
 
-        uni.interface.use_tags.side_effect = KytosTagError("")
+        uni.interface.atomic_use_tags.side_effect = KytosTagError("")
         with pytest.raises(KytosTagError):
             evc._use_uni_vlan(uni)
-        assert uni.interface.use_tags.call_count == 4
+        assert uni.interface.atomic_use_tags.call_count == 4
 
         uni.user_tag = None
         evc._use_uni_vlan(uni)
-        assert uni.interface.use_tags.call_count == 4
+        assert uni.interface.atomic_use_tags.call_count == 4
 
     @patch("napps.kytos.mef_eline.models.evc.log")
     def test_make_uni_vlan_available(self, mock_log):
@@ -635,26 +635,26 @@ class TestEVC():  # pylint: disable=too-many-public-methods, no-member
         }
         evc = EVC(**attributes)
         uni = get_uni_mocked(is_valid=True)
-        uni.interface.make_tags_available = MagicMock()
+        uni.interface.atomic_make_tags_available = MagicMock()
 
         evc.make_uni_vlan_available(uni)
-        args = uni.interface.make_tags_available.call_args[0]
-        assert args[0] == uni.user_tag.tag_type
-        assert args[1] == uni.user_tag.value
-        assert uni.interface.make_tags_available.call_count == 1
+        args = uni.interface.atomic_make_tags_available.call_args[0]
+        assert args[1] == uni.user_tag.tag_type
+        assert args[2] == uni.user_tag.value
+        assert uni.interface.atomic_make_tags_available.call_count == 1
 
         uni.user_tag.value = [[1, 10]]
         uni_dif = get_uni_mocked(tag_value=[[1, 2]])
         evc.make_uni_vlan_available(uni, uni_dif)
-        assert uni.interface.make_tags_available.call_count == 2
+        assert uni.interface.atomic_make_tags_available.call_count == 2
 
-        uni.interface.make_tags_available.side_effect = KytosTagError("")
+        uni.interface.atomic_make_tags_available.side_effect = KytosTagError("")
         evc.make_uni_vlan_available(uni)
         assert mock_log.error.call_count == 1
 
         uni.user_tag = None
         evc.make_uni_vlan_available(uni)
-        assert uni.interface.make_tags_available.call_count == 3
+        assert uni.interface.atomic_make_tags_available.call_count == 3
 
     def test_remove_uni_tags(self):
         """Test remove_uni_tags"""

--- a/tests/unit/models/test_evc_base.py
+++ b/tests/unit/models/test_evc_base.py
@@ -635,26 +635,27 @@ class TestEVC():  # pylint: disable=too-many-public-methods, no-member
         }
         evc = EVC(**attributes)
         uni = get_uni_mocked(is_valid=True)
-        uni.interface.atomic_make_tags_available = MagicMock()
+        mock_iface = uni.interface
+        mock_iface.atomic_make_tags_available = MagicMock()
 
         evc.make_uni_vlan_available(uni)
-        args = uni.interface.atomic_make_tags_available.call_args[0]
+        args = mock_iface.atomic_make_tags_available.call_args[0]
         assert args[1] == uni.user_tag.tag_type
         assert args[2] == uni.user_tag.value
-        assert uni.interface.atomic_make_tags_available.call_count == 1
+        assert mock_iface.atomic_make_tags_available.call_count == 1
 
         uni.user_tag.value = [[1, 10]]
         uni_dif = get_uni_mocked(tag_value=[[1, 2]])
         evc.make_uni_vlan_available(uni, uni_dif)
-        assert uni.interface.atomic_make_tags_available.call_count == 2
+        assert mock_iface.atomic_make_tags_available.call_count == 2
 
-        uni.interface.atomic_make_tags_available.side_effect = KytosTagError("")
+        mock_iface.atomic_make_tags_available.side_effect = KytosTagError("")
         evc.make_uni_vlan_available(uni)
         assert mock_log.error.call_count == 1
 
         uni.user_tag = None
         evc.make_uni_vlan_available(uni)
-        assert uni.interface.atomic_make_tags_available.call_count == 3
+        assert mock_iface.atomic_make_tags_available.call_count == 3
 
     def test_remove_uni_tags(self):
         """Test remove_uni_tags"""

--- a/tests/unit/models/test_evc_base.py
+++ b/tests/unit/models/test_evc_base.py
@@ -603,8 +603,8 @@ class TestEVC():  # pylint: disable=too-many-public-methods, no-member
         uni.interface.atomic_use_tags = MagicMock()
         evc._use_uni_vlan(uni)
         args = uni.interface.atomic_use_tags.call_args[0]
-        assert args[1] == uni.user_tag.tag_type
-        assert args[2] == uni.user_tag.value
+        assert args[0] == uni.user_tag.tag_type
+        assert args[1] == uni.user_tag.value
         assert uni.interface.atomic_use_tags.call_count == 1
 
         uni.user_tag.value = "any"
@@ -647,8 +647,8 @@ class TestEVC():  # pylint: disable=too-many-public-methods, no-member
 
         evc.make_uni_vlan_available(uni)
         args = mock_iface.atomic_make_tags_available.call_args[0]
-        assert args[1] == uni.user_tag.tag_type
-        assert args[2] == uni.user_tag.value
+        assert args[0] == uni.user_tag.tag_type
+        assert args[1] == uni.user_tag.value
         assert mock_iface.atomic_make_tags_available.call_count == 1
 
         uni.user_tag.value = [[1, 10]]

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -879,8 +879,17 @@ class TestEVC():
             metadata={"s_vlan": Mock(value=6)},
         )
 
+        links_by_id = {
+            link_a_b.id: link_a_b,
+            link_b_c.id: link_b_c,
+        }
+
+        controller = get_controller_mock()
+
+        controller.links = links_by_id
+
         attributes = {
-            "controller": get_controller_mock(),
+            "controller": controller,
             "name": "custom_name",
             "uni_a": uni_a,
             "uni_z": uni_z,
@@ -1004,28 +1013,40 @@ class TestEVC():
         switch_b = Switch("00:00:00:00:00:00:00:02")
         switch_c = Switch("00:00:00:00:00:00:00:03")
 
+        link_a_b = get_link_mocked(
+            switch_a=switch_a,
+            switch_b=switch_b,
+            endpoint_a_port=9,
+            endpoint_b_port=10,
+            metadata={"s_vlan": Mock(value=5)},
+        )
+        link_b_c = get_link_mocked(
+            switch_a=switch_b,
+            switch_b=switch_c,
+            endpoint_a_port=11,
+            endpoint_b_port=12,
+            metadata={"s_vlan": Mock(value=6)},
+        )
+
+        links_by_id = {
+            link_a_b.id: link_a_b,
+            link_b_c.id: link_b_c,
+        }
+
+        controller = get_controller_mock()
+
+        controller.links = links_by_id
+
         attributes = {
-            "controller": get_controller_mock(),
+            "controller": controller,
             "name": "custom_name",
             "uni_a": uni_a,
             "uni_z": uni_z,
             "active": True,
             "enabled": True,
             "failover_path": [
-                get_link_mocked(
-                    switch_a=switch_a,
-                    switch_b=switch_b,
-                    endpoint_a_port=9,
-                    endpoint_b_port=10,
-                    metadata={"s_vlan": 5},
-                ),
-                get_link_mocked(
-                    switch_a=switch_b,
-                    switch_b=switch_c,
-                    endpoint_a_port=11,
-                    endpoint_b_port=12,
-                    metadata={"s_vlan": 6},
-                ),
+                link_a_b,
+                link_b_c,
             ],
         }
 

--- a/tests/unit/models/test_path.py
+++ b/tests/unit/models/test_path.py
@@ -151,9 +151,9 @@ class TestPath():
         path = Path(links)
         path.make_vlans_available = MagicMock()
         path.choose_vlans(controller)
-        assert link1.get_next_available_tag.call_count == 1
+        assert link1.atomic_get_next_available_tag.call_count == 1
         assert link1.add_metadata.call_count == 1
-        assert link2.get_next_available_tag.call_count == 1
+        assert link2.atomic_get_next_available_tag.call_count == 1
         assert link2.add_metadata.call_count == 1
         assert not path.make_vlans_available.call_count
 
@@ -173,12 +173,12 @@ class TestPath():
         path = Path(links)
         path.make_vlans_available = MagicMock()
         exc = KytosNoTagAvailableError(link2)
-        link2.get_next_available_tag.side_effect = exc
+        link2.atomic_get_next_available_tag.side_effect = exc
         with pytest.raises(KytosNoTagAvailableError):
             path.choose_vlans(controller)
-        assert link1.get_next_available_tag.call_count == 1
+        assert link1.atomic_get_next_available_tag.call_count == 1
         assert link1.add_metadata.call_count == 1
-        assert link2.get_next_available_tag.call_count == 1
+        assert link2.atomic_get_next_available_tag.call_count == 1
         assert not link2.add_metadata.call_count
         assert path.make_vlans_available.call_count == 1
 

--- a/tests/unit/models/test_path.py
+++ b/tests/unit/models/test_path.py
@@ -142,6 +142,11 @@ class TestPath():
         link2 = get_link_mocked(status=EntityStatus.UP)
         link1.id = "def"
         link2.id = "abc"
+        links_by_id = {
+            link1.id: link1,
+            link2.id: link2
+        }
+        controller.get_link = links_by_id.get
         links = [link1, link2]
         path = Path(links)
         path.make_vlans_available = MagicMock()
@@ -159,6 +164,11 @@ class TestPath():
         link2 = get_link_mocked(status=EntityStatus.UP)
         link1.id = "def"
         link2.id = "abc"
+        links_by_id = {
+            link1.id: link1,
+            link2.id: link2
+        }
+        controller.get_link = links_by_id.get
         links = [link1, link2]
         path = Path(links)
         path.make_vlans_available = MagicMock()

--- a/tests/unit/models/test_path.py
+++ b/tests/unit/models/test_path.py
@@ -149,13 +149,13 @@ class TestPath():
         controller.get_link = links_by_id.get
         links = [link1, link2]
         path = Path(links)
-        path.make_vlans_available = MagicMock()
         path.choose_vlans(controller)
-        assert link1.atomic_get_next_available_tag.call_count == 1
+        assert link1.get_next_available_tag.call_count == 1
         assert link1.add_metadata.call_count == 1
-        assert link2.atomic_get_next_available_tag.call_count == 1
+        assert link2.get_next_available_tag.call_count == 1
         assert link2.add_metadata.call_count == 1
-        assert not path.make_vlans_available.call_count
+        assert not link1.make_tags_available.call_count
+        assert not link2.make_tags_available.call_count
 
     def test_choose_vlans_tags_not_available(self) -> None:
         """Test choose vlans rollback if tags not available."""
@@ -171,16 +171,16 @@ class TestPath():
         controller.get_link = links_by_id.get
         links = [link1, link2]
         path = Path(links)
-        path.make_vlans_available = MagicMock()
         exc = KytosNoTagAvailableError(link2)
-        link2.atomic_get_next_available_tag.side_effect = exc
+        link2.get_next_available_tag.side_effect = exc
         with pytest.raises(KytosNoTagAvailableError):
             path.choose_vlans(controller)
-        assert link1.atomic_get_next_available_tag.call_count == 1
-        assert link1.add_metadata.call_count == 1
-        assert link2.atomic_get_next_available_tag.call_count == 1
+        assert link1.get_next_available_tag.call_count == 1
+        assert not link1.add_metadata.call_count
+        assert link2.get_next_available_tag.call_count == 1
         assert not link2.add_metadata.call_count
-        assert path.make_vlans_available.call_count == 1
+        assert link1.make_tags_available.call_count == 1
+        assert link2.make_tags_available.call_count == 0
 
     def test_compare_same_paths(self):
         """Test compare paths with same links."""


### PR DESCRIPTION
Part of kytos-ng/kytos#554

### Summary

This makes it so that mef_eline uses tag_capable links from the kytos controller to acquire tags for evcs.

### Local Tests

Ran with a few hundred evcs, all with dynamic paths. Was able to acquire and release vlans from links successfully

### End-to-End Tests

E2E results:

```
kytos-1  | Starting enhanced syslogd: rsyslogd.
kytos-1  | /etc/openvswitch/conf.db does not exist ... (warning).
kytos-1  | Creating empty database /etc/openvswitch/conf.db.
kytos-1  | Starting ovsdb-server.
kytos-1  | rsyslogd: error during config processing: omfile: chown for file '/var/log/syslog' failed: Operation not permitted [v8.2302.0 try https://www.rsyslog.com/e/2207 ]
kytos-1  | Configuring Open vSwitch system IDs.
kytos-1  | Starting ovs-vswitchd.
kytos-1  | Enabling remote OVSDB managers.
kytos-1  | + '[' -z '' ']'
kytos-1  | + '[' -z '' ']'
kytos-1  | + echo 'There is no NAPPS_PATH specified. Default will be used.'
kytos-1  | + NAPPS_PATH=
kytos-1  | + sed -i 's/STATS_INTERVAL = 60/STATS_INTERVAL = 7/g' /var/lib/kytos/napps/kytos/of_core/settings.py
kytos-1  | There is no NAPPS_PATH specified. Default will be used.
kytos-1  | + sed -i 's/CONSISTENCY_MIN_VERDICT_INTERVAL =.*/CONSISTENCY_MIN_VERDICT_INTERVAL = 60/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
kytos-1  | + sed -i 's/LINK_UP_TIMER = 10/LINK_UP_TIMER = 1/g' /var/lib/kytos/napps/kytos/topology/settings.py
kytos-1  | + sed -i 's/DEPLOY_EVCS_INTERVAL = 60/DEPLOY_EVCS_INTERVAL = 5/g' /var/lib/kytos/napps/kytos/mef_eline/settings.py
kytos-1  | + sed -i 's/LLDP_LOOP_ACTIONS = \["log"\]/LLDP_LOOP_ACTIONS = \["disable","log"\]/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos-1  | + sed -i 's/LLDP_IGNORED_LOOPS = {}/LLDP_IGNORED_LOOPS = {"00:00:00:00:00:00:00:01": \[\[4, 5\]\]}/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos-1  | + sed -i 's/CONSISTENCY_COOKIE_IGNORED_RANGE =.*/CONSISTENCY_COOKIE_IGNORED_RANGE = [(0xdd00000000000000, 0xdd00000000000009)]/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
kytos-1  | + sed -i 's/LIVENESS_DEAD_MULTIPLIER =.*/LIVENESS_DEAD_MULTIPLIER = 3/g' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos-1  | + kytosd --help
kytos-1  | + sed -i s/WARNING/DEBUG/g /etc/kytos/logging.ini
kytos-1  | + sed -i s/INFO/DEBUG/g /etc/kytos/logging.ini
kytos-1  | + sed -i 's/keys: root,kytos,api_server,socket/keys: root,kytos,api_server,socket,aiokafka/' /etc/kytos/logging.ini
kytos-1  | + sed -i 's/handlers: syslog,console/handlers: syslog,console,file/g' /etc/kytos/logging.ini
kytos-1  | + echo -e '\n\n[logger_aiokafka]\nlevel: INFO\nhandlers:\nqualname: aiokafka'
kytos-1  | + echo
kytos-1  | + test -z ''
kytos-1  | + TESTS=tests/
kytos-1  | + test -z ''
kytos-1  | + RERUNS=2
kytos-1  | + python3 scripts/wait_for_mongo.py
kytos-1  | Trying to run hello command on MongoDB...
kytos-1  | Trying to run 'hello' command on MongoDB...
kytos-1  | Trying to run 'hello' command on MongoDB...
kytos-1  | Ran 'hello' command on MongoDB successfully. It's ready!
kytos-1  | + python3 scripts/setup_kafka.py
kytos-1  | Starting setup_kafka.py...
kytos-1  | Attempting to create an admin client at ['broker1:19092', 'broker2:19092', 'broker3:19092']...
kytos-1  | Admin client was successful! Attempting to validate cluster...
kytos-1  | Cluster info: {'throttle_time_ms': 0, 'brokers': [{'node_id': 1, 'host': 'broker1', 'port': 19092, 'rack': None}, {'node_id': 2, 'host': 'broker2', 'port': 19092, 'rack': None}, {'node_id': 3, 'host': 'broker3', 'port': 19092, 'rack': None}], 'cluster_id': '5L6g3nShT-eMCtK--X86sw', 'controller_id': 2}
kytos-1  | Cluster was successfully validated! Attempting to create topic 'event_logs'...
kytos-1  | Topic 'event_logs' was created! Attempting to close the admin client...
kytos-1  | Kafka admin client closed.
kytos-1  | + python3 -m pytest tests/ --reruns 2 -r fEr
kytos-1  | ============================= test session starts ==============================
kytos-1  | platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
kytos-1  | rootdir: /
kytos-1  | configfile: pytest.ini
kytos-1  | plugins: rerunfailures-13.0, timeout-2.2.0, asyncio-1.1.0, anyio-4.3.0
kytos-1  | asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
kytos-1  | collected 301 items
kytos-1  | 
kytos-1  | tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
kytos-1  | tests/test_e2e_05_topology.py ...................                        [  6%]
kytos-1  | tests/test_e2e_06_topology.py ....                                       [  8%]
kytos-1  | tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 21%]
kytos-1  | .                                                                        [ 22%]
kytos-1  | tests/test_e2e_11_mef_eline.py ........                                  [ 24%]
kytos-1  | tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
kytos-1  | tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 41%]
kytos-1  | .                                                                        [ 41%]
kytos-1  | tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
kytos-1  | tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
kytos-1  | tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
kytos-1  | tests/test_e2e_17_mef_eline.py .....                                     [ 47%]
kytos-1  | tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
kytos-1  | tests/test_e2e_20_flow_manager.py ............................           [ 58%]
kytos-1  | tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
kytos-1  | tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
kytos-1  | tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
kytos-1  | tests/test_e2e_30_of_lldp.py .R...                                       [ 70%]
kytos-1  | tests/test_e2e_31_of_lldp.py ...RRF                                      [ 72%]
kytos-1  | tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
kytos-1  | tests/test_e2e_40_sdntrace.py ................                           [ 78%]
kytos-1  | tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
kytos-1  | tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
kytos-1  | tests/test_e2e_50_maintenance.py ...............................         [ 92%]
kytos-1  | tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
kytos-1  | tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
kytos-1  | tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
kytos-1  | tests/test_e2e_90_kafka_events.py .                                      [ 99%]
kytos-1  | tests/test_e2e_95_telemtry_int.py s                                      [100%]
kytos-1  | 
kytos-1  | =================================== FAILURES ===================================
kytos-1  | ________________ TestE2EOfLLDP.test_010_liveness_intf_deletion _________________
kytos-1  | 
kytos-1  | self = <tests.test_e2e_31_of_lldp.TestE2EOfLLDP object at 0x7882e3f1ba90>
kytos-1  | 
kytos-1  |     def test_010_liveness_intf_deletion(self) -> None:
kytos-1  |         """Test liveness not loaded after intf deletion."""
kytos-1  |         polling_interval = 1
kytos-1  |         self.set_polling_time(polling_interval)
kytos-1  |         intf_id = "00:00:00:00:00:00:00:01:1"
kytos-1  |         interface_ids = [intf_id]
kytos-1  |         self.enable_link_liveness(interface_ids)
kytos-1  |     
kytos-1  |         time.sleep(polling_interval * 5)
kytos-1  |     
kytos-1  |         # Assert GET liveness/ entries are in init state
kytos-1  |         api_url = f"{KYTOS_API}/of_lldp/v1/liveness/"
kytos-1  |         response = requests.get(api_url)
kytos-1  |         data = response.json()
kytos-1  |         for entry in data["interfaces"]:
kytos-1  |             assert entry["id"] in interface_ids, entry
kytos-1  |             assert entry["status"] == "init", entry
kytos-1  |     
kytos-1  |         # Disable the intf for deletion
kytos-1  |         api_url = f'{KYTOS_API}/topology/v3/interfaces/{intf_id}/disable/'
kytos-1  |         response = requests.post(api_url)
kytos-1  |         assert response.status_code == 200, response.text
kytos-1  |     
kytos-1  |         # Deactivate the interface for deletion
kytos-1  |         self.net.net.configLinkStatus('s1', 'h11', 'down')
kytos-1  |     
kytos-1  |         api_url = f'{KYTOS_API}/topology/v3/interfaces/{intf_id}'
kytos-1  |         response = requests.delete(api_url)
kytos-1  |         assert response.status_code == 200, response.text
kytos-1  |     
kytos-1  |         # Restart the controller maintaining config
kytos-1  | >       self.restart(wait_for=15)
kytos-1  | 
kytos-1  | tests/test_e2e_31_of_lldp.py:298: 
kytos-1  | _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
kytos-1  | tests/test_e2e_31_of_lldp.py:38: in restart
kytos-1  |     self.net.start_controller(clean_config=clean_config, enable_all=enable_all)
kytos-1  | tests/helpers.py:402: in start_controller
kytos-1  |     self.wait_controller_start()
kytos-1  | _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
kytos-1  | 
kytos-1  | self = <tests.helpers.NetworkTest object at 0x7882c02da290>
kytos-1  | 
kytos-1  |     def wait_controller_start(self):
kytos-1  |         """Wait until controller starts according to core/status API."""
kytos-1  |         wait_count = 0
kytos-1  |         last_error = ""
kytos-1  |         while wait_count < 60:
kytos-1  |             try:
kytos-1  |                 response = requests.get('http://127.0.0.1:8181/api/kytos/core/status/', timeout=3)
kytos-1  |                 assert response.json()['response'] == 'running', response.text
kytos-1  |                 break
kytos-1  |             except Exception as exc:
kytos-1  |                 last_error = str(exc)
kytos-1  |                 time.sleep(0.5)
kytos-1  |                 wait_count += 0.5
kytos-1  |         else:
kytos-1  |             msg = f"Timeout while starting Kytos controller. Last error: {last_error}"
kytos-1  | >           raise Exception(msg)
kytos-1  | E           Exception: Timeout while starting Kytos controller. Last error: HTTPConnectionPool(host='127.0.0.1', port=8181): Read timed out. (read timeout=3)
kytos-1  | 
kytos-1  | tests/helpers.py:422: Exception
kytos-1  | ---------------------------- Captured stdout setup -----------------------------
kytos-1  | FAIL to stop kytos after 5 seconds -- Kytos pid still exists.. Force stop!
kytos-1  | ---------------------------- Captured stdout setup -----------------------------
kytos-1  | FAIL to stop kytos after 5 seconds -- Kytos pid still exists.. Force stop!
kytos-1  | =============================== warnings summary ===============================
kytos-1  | usr/local/lib/python3.11/dist-packages/kytos/core/config.py:254
kytos-1  |   /usr/local/lib/python3.11/dist-packages/kytos/core/config.py:254: UserWarning: Unknown arguments: ['tests/', '--reruns', '2', '-r', 'fEr']
kytos-1  |     warnings.warn(f"Unknown arguments: {unknown}")
kytos-1  | 
kytos-1  | tests/test_e2e_01_kytos_startup.py: 17 warnings
kytos-1  | tests/test_e2e_05_topology.py: 17 warnings
kytos-1  | tests/test_e2e_06_topology.py: 37 warnings
kytos-1  | tests/test_e2e_10_mef_eline.py: 17 warnings
kytos-1  | tests/test_e2e_11_mef_eline.py: 25 warnings
kytos-1  | tests/test_e2e_12_mef_eline.py: 17 warnings
kytos-1  | tests/test_e2e_13_mef_eline.py: 17 warnings
kytos-1  | tests/test_e2e_14_mef_eline.py: 76 warnings
kytos-1  | tests/test_e2e_15_mef_eline.py: 17 warnings
kytos-1  | tests/test_e2e_16_mef_eline.py: 17 warnings
kytos-1  | tests/test_e2e_17_mef_eline.py: 37 warnings
kytos-1  | tests/test_e2e_18_mef_eline.py: 17 warnings
kytos-1  | tests/test_e2e_20_flow_manager.py: 17 warnings
kytos-1  | tests/test_e2e_21_flow_manager.py: 17 warnings
kytos-1  | tests/test_e2e_22_flow_manager.py: 17 warnings
kytos-1  | tests/test_e2e_23_flow_manager.py: 17 warnings
kytos-1  | tests/test_e2e_30_of_lldp.py: 16 warnings
kytos-1  | tests/test_e2e_31_of_lldp.py: 16 warnings
kytos-1  | tests/test_e2e_32_of_lldp.py: 11 warnings
kytos-1  | tests/test_e2e_40_sdntrace.py: 49 warnings
kytos-1  | tests/test_e2e_41_kytos_auth.py: 17 warnings
kytos-1  | tests/test_e2e_42_sdntrace.py: 84 warnings
kytos-1  | tests/test_e2e_50_maintenance.py: 17 warnings
kytos-1  | tests/test_e2e_60_of_multi_table.py: 17 warnings
kytos-1  | tests/test_e2e_70_kytos_stats.py: 17 warnings
kytos-1  | tests/test_e2e_80_pathfinder.py: 37 warnings
kytos-1  | tests/test_e2e_90_kafka_events.py: 17 warnings
kytos-1  |   /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
kytos-1  |     return ( StrictVersion( cls.OVSVersion ) <
kytos-1  | 
kytos-1  | tests/test_e2e_01_kytos_startup.py: 17 warnings
kytos-1  | tests/test_e2e_05_topology.py: 17 warnings
kytos-1  | tests/test_e2e_06_topology.py: 37 warnings
kytos-1  | tests/test_e2e_10_mef_eline.py: 17 warnings
kytos-1  | tests/test_e2e_11_mef_eline.py: 25 warnings
kytos-1  | tests/test_e2e_12_mef_eline.py: 17 warnings
kytos-1  | tests/test_e2e_13_mef_eline.py: 17 warnings
kytos-1  | tests/test_e2e_14_mef_eline.py: 76 warnings
kytos-1  | tests/test_e2e_15_mef_eline.py: 17 warnings
kytos-1  | tests/test_e2e_16_mef_eline.py: 17 warnings
kytos-1  | tests/test_e2e_17_mef_eline.py: 37 warnings
kytos-1  | tests/test_e2e_18_mef_eline.py: 17 warnings
kytos-1  | tests/test_e2e_20_flow_manager.py: 17 warnings
kytos-1  | tests/test_e2e_21_flow_manager.py: 17 warnings
kytos-1  | tests/test_e2e_22_flow_manager.py: 17 warnings
kytos-1  | tests/test_e2e_23_flow_manager.py: 17 warnings
kytos-1  | tests/test_e2e_30_of_lldp.py: 16 warnings
kytos-1  | tests/test_e2e_31_of_lldp.py: 16 warnings
kytos-1  | tests/test_e2e_32_of_lldp.py: 11 warnings
kytos-1  | tests/test_e2e_40_sdntrace.py: 49 warnings
kytos-1  | tests/test_e2e_41_kytos_auth.py: 17 warnings
kytos-1  | tests/test_e2e_42_sdntrace.py: 84 warnings
kytos-1  | tests/test_e2e_50_maintenance.py: 17 warnings
kytos-1  | tests/test_e2e_60_of_multi_table.py: 17 warnings
kytos-1  | tests/test_e2e_70_kytos_stats.py: 17 warnings
kytos-1  | tests/test_e2e_80_pathfinder.py: 37 warnings
kytos-1  | tests/test_e2e_90_kafka_events.py: 17 warnings
kytos-1  |   /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
kytos-1  |     StrictVersion( '1.10' ) )
kytos-1  | 
kytos-1  | -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
kytos-1  | ------------------------------- start/stop times -------------------------------
kytos-1  | rerun: 0
kytos-1  | tests/test_e2e_30_of_lldp.py::TestE2EOfLLDP::test_010_disable_of_lldp: 2026-02-13,02:13:41.285613 - 2026-02-13,02:14:06.485583
kytos-1  | self = <tests.test_e2e_30_of_lldp.TestE2EOfLLDP object at 0x7882e3da1350>
kytos-1  | 
kytos-1  |     def test_010_disable_of_lldp(self):
kytos-1  |         """ Test if the disabling OF LLDP in an interface worked properly. """
kytos-1  |         self.net.start_controller(clean_config=True, enable_all=False)
kytos-1  |         self.net.wait_switches_connect()
kytos-1  |         time.sleep(5)
kytos-1  |         self.enable_all_interfaces()
kytos-1  |     
kytos-1  |         # disabling all the UNI interfaces
kytos-1  |         payload = {
kytos-1  |             "interfaces": [
kytos-1  |                 "00:00:00:00:00:00:00:01:1", "00:00:00:00:00:00:00:01:2", "00:00:00:00:00:00:00:01:4294967294",
kytos-1  |                 "00:00:00:00:00:00:00:02:1", "00:00:00:00:00:00:00:02:4294967294",
kytos-1  |                 "00:00:00:00:00:00:00:03:1", "00:00:00:00:00:00:00:03:4294967294"
kytos-1  |             ]
kytos-1  |         }
kytos-1  |         expected_interfaces = [
kytos-1  |                 "00:00:00:00:00:00:00:01:3", "00:00:00:00:00:00:00:01:4",
kytos-1  |                 "00:00:00:00:00:00:00:02:2", "00:00:00:00:00:00:00:02:3",
kytos-1  |                 "00:00:00:00:00:00:00:03:2", "00:00:00:00:00:00:00:03:3"
kytos-1  |         ]
kytos-1  |     
kytos-1  |         api_url = KYTOS_API + '/of_lldp/v1/interfaces/disable/'
kytos-1  |         response = requests.post(api_url, json=payload)
kytos-1  |         assert response.status_code == 200, response.text
kytos-1  |     
kytos-1  |         api_url = KYTOS_API + '/of_lldp/v1/interfaces/'
kytos-1  |         response = requests.get(api_url)
kytos-1  |         data = response.json()
kytos-1  |         assert set(data["interfaces"]) == set(expected_interfaces)
kytos-1  |     
kytos-1  |         h11, h12, h2, h3 = self.net.net.get('h11', 'h12', 'h2', 'h3')
kytos-1  |         rx_stats_h11 = self.get_iface_stats_rx_pkt(h11)
kytos-1  |         rx_stats_h12 = self.get_iface_stats_rx_pkt(h12)
kytos-1  |         rx_stats_h2 = self.get_iface_stats_rx_pkt(h2)
kytos-1  |         rx_stats_h3 = self.get_iface_stats_rx_pkt(h3)
kytos-1  |         time.sleep(10)
kytos-1  |         rx_stats_h11_2 = self.get_iface_stats_rx_pkt(h11)
kytos-1  |         rx_stats_h12_2 = self.get_iface_stats_rx_pkt(h12)
kytos-1  |         rx_stats_h2_2 = self.get_iface_stats_rx_pkt(h2)
kytos-1  |         rx_stats_h3_2 = self.get_iface_stats_rx_pkt(h3)
kytos-1  |     
kytos-1  | >       assert rx_stats_h11_2 == rx_stats_h11 \
kytos-1  |             and rx_stats_h12_2 == rx_stats_h12 \
kytos-1  |             and rx_stats_h2_2 == rx_stats_h2 \
kytos-1  |             and rx_stats_h3_2 == rx_stats_h3
kytos-1  | E       assert (19 == 18)
kytos-1  | 
kytos-1  | tests/test_e2e_30_of_lldp.py:127: AssertionError
kytos-1  | rerun: 0
kytos-1  | tests/test_e2e_31_of_lldp.py::TestE2EOfLLDP::test_010_liveness_intf_deletion: 2026-02-13,02:20:08.025225 - 2026-02-13,02:27:15.923321
kytos-1  | self = <tests.test_e2e_31_of_lldp.TestE2EOfLLDP object at 0x7882e3f1ba90>
kytos-1  | 
kytos-1  |     def test_010_liveness_intf_deletion(self) -> None:
kytos-1  |         """Test liveness not loaded after intf deletion."""
kytos-1  |         polling_interval = 1
kytos-1  |         self.set_polling_time(polling_interval)
kytos-1  |         intf_id = "00:00:00:00:00:00:00:01:1"
kytos-1  |         interface_ids = [intf_id]
kytos-1  |         self.enable_link_liveness(interface_ids)
kytos-1  |     
kytos-1  |         time.sleep(polling_interval * 5)
kytos-1  |     
kytos-1  |         # Assert GET liveness/ entries are in init state
kytos-1  |         api_url = f"{KYTOS_API}/of_lldp/v1/liveness/"
kytos-1  |         response = requests.get(api_url)
kytos-1  |         data = response.json()
kytos-1  |         for entry in data["interfaces"]:
kytos-1  |             assert entry["id"] in interface_ids, entry
kytos-1  |             assert entry["status"] == "init", entry
kytos-1  |     
kytos-1  |         # Disable the intf for deletion
kytos-1  |         api_url = f'{KYTOS_API}/topology/v3/interfaces/{intf_id}/disable/'
kytos-1  |         response = requests.post(api_url)
kytos-1  |         assert response.status_code == 200, response.text
kytos-1  |     
kytos-1  |         # Deactivate the interface for deletion
kytos-1  |         self.net.net.configLinkStatus('s1', 'h11', 'down')
kytos-1  |     
kytos-1  |         api_url = f'{KYTOS_API}/topology/v3/interfaces/{intf_id}'
kytos-1  |         response = requests.delete(api_url)
kytos-1  |         assert response.status_code == 200, response.text
kytos-1  |     
kytos-1  |         # Restart the controller maintaining config
kytos-1  | >       self.restart(wait_for=15)
kytos-1  | 
kytos-1  | tests/test_e2e_31_of_lldp.py:298: 
kytos-1  | _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
kytos-1  | tests/test_e2e_31_of_lldp.py:38: in restart
kytos-1  |     self.net.start_controller(clean_config=clean_config, enable_all=enable_all)
kytos-1  | tests/helpers.py:402: in start_controller
kytos-1  |     self.wait_controller_start()
kytos-1  | _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
kytos-1  | 
kytos-1  | self = <tests.helpers.NetworkTest object at 0x7882c02da290>
kytos-1  | 
kytos-1  |     def wait_controller_start(self):
kytos-1  |         """Wait until controller starts according to core/status API."""
kytos-1  |         wait_count = 0
kytos-1  |         last_error = ""
kytos-1  |         while wait_count < 60:
kytos-1  |             try:
kytos-1  |                 response = requests.get('http://127.0.0.1:8181/api/kytos/core/status/', timeout=3)
kytos-1  |                 assert response.json()['response'] == 'running', response.text
kytos-1  |                 break
kytos-1  |             except Exception as exc:
kytos-1  |                 last_error = str(exc)
kytos-1  |                 time.sleep(0.5)
kytos-1  |                 wait_count += 0.5
kytos-1  |         else:
kytos-1  |             msg = f"Timeout while starting Kytos controller. Last error: {last_error}"
kytos-1  | >           raise Exception(msg)
kytos-1  | E           Exception: Timeout while starting Kytos controller. Last error: HTTPConnectionPool(host='127.0.0.1', port=8181): Read timed out. (read timeout=3)
kytos-1  | 
kytos-1  | tests/helpers.py:422: Exception
kytos-1  | rerun: 1
kytos-1  | tests/test_e2e_31_of_lldp.py::TestE2EOfLLDP::test_010_liveness_intf_deletion: 2026-02-13,02:27:37.065407 - 2026-02-13,02:34:44.996798
kytos-1  | self = <tests.test_e2e_31_of_lldp.TestE2EOfLLDP object at 0x7882e3f1ba90>
kytos-1  | 
kytos-1  |     def test_010_liveness_intf_deletion(self) -> None:
kytos-1  |         """Test liveness not loaded after intf deletion."""
kytos-1  |         polling_interval = 1
kytos-1  |         self.set_polling_time(polling_interval)
kytos-1  |         intf_id = "00:00:00:00:00:00:00:01:1"
kytos-1  |         interface_ids = [intf_id]
kytos-1  |         self.enable_link_liveness(interface_ids)
kytos-1  |     
kytos-1  |         time.sleep(polling_interval * 5)
kytos-1  |     
kytos-1  |         # Assert GET liveness/ entries are in init state
kytos-1  |         api_url = f"{KYTOS_API}/of_lldp/v1/liveness/"
kytos-1  |         response = requests.get(api_url)
kytos-1  |         data = response.json()
kytos-1  |         for entry in data["interfaces"]:
kytos-1  |             assert entry["id"] in interface_ids, entry
kytos-1  |             assert entry["status"] == "init", entry
kytos-1  |     
kytos-1  |         # Disable the intf for deletion
kytos-1  |         api_url = f'{KYTOS_API}/topology/v3/interfaces/{intf_id}/disable/'
kytos-1  |         response = requests.post(api_url)
kytos-1  |         assert response.status_code == 200, response.text
kytos-1  |     
kytos-1  |         # Deactivate the interface for deletion
kytos-1  |         self.net.net.configLinkStatus('s1', 'h11', 'down')
kytos-1  |     
kytos-1  |         api_url = f'{KYTOS_API}/topology/v3/interfaces/{intf_id}'
kytos-1  |         response = requests.delete(api_url)
kytos-1  |         assert response.status_code == 200, response.text
kytos-1  |     
kytos-1  |         # Restart the controller maintaining config
kytos-1  | >       self.restart(wait_for=15)
kytos-1  | 
kytos-1  | tests/test_e2e_31_of_lldp.py:298: 
kytos-1  | _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
kytos-1  | tests/test_e2e_31_of_lldp.py:38: in restart
kytos-1  |     self.net.start_controller(clean_config=clean_config, enable_all=enable_all)
kytos-1  | tests/helpers.py:402: in start_controller
kytos-1  |     self.wait_controller_start()
kytos-1  | _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
kytos-1  | 
kytos-1  | self = <tests.helpers.NetworkTest object at 0x7882c02da290>
kytos-1  | 
kytos-1  |     def wait_controller_start(self):
kytos-1  |         """Wait until controller starts according to core/status API."""
kytos-1  |         wait_count = 0
kytos-1  |         last_error = ""
kytos-1  |         while wait_count < 60:
kytos-1  |             try:
kytos-1  |                 response = requests.get('http://127.0.0.1:8181/api/kytos/core/status/', timeout=3)
kytos-1  |                 assert response.json()['response'] == 'running', response.text
kytos-1  |                 break
kytos-1  |             except Exception as exc:
kytos-1  |                 last_error = str(exc)
kytos-1  |                 time.sleep(0.5)
kytos-1  |                 wait_count += 0.5
kytos-1  |         else:
kytos-1  |             msg = f"Timeout while starting Kytos controller. Last error: {last_error}"
kytos-1  | >           raise Exception(msg)
kytos-1  | E           Exception: Timeout while starting Kytos controller. Last error: HTTPConnectionPool(host='127.0.0.1', port=8181): Read timed out. (read timeout=3)
kytos-1  | 
kytos-1  | tests/helpers.py:422: Exception
kytos-1  | tests/test_e2e_31_of_lldp.py::TestE2EOfLLDP::test_010_liveness_intf_deletion: 2026-02-13,02:35:06.127242 - 2026-02-13,02:42:14.019770
kytos-1  | =========================== rerun test summary info ============================
kytos-1  | RERUN tests/test_e2e_30_of_lldp.py::TestE2EOfLLDP::test_010_disable_of_lldp
kytos-1  | RERUN tests/test_e2e_31_of_lldp.py::TestE2EOfLLDP::test_010_liveness_intf_deletion
kytos-1  | RERUN tests/test_e2e_31_of_lldp.py::TestE2EOfLLDP::test_010_liveness_intf_deletion
kytos-1  | =========================== short test summary info ============================
kytos-1  | FAILED tests/test_e2e_31_of_lldp.py::TestE2EOfLLDP::test_010_liveness_intf_deletion
kytos-1  | = 1 failed, 277 passed, 9 skipped, 7 xfailed, 7 xpassed, 1355 warnings, 3 rerun in 13730.45s (3:48:50) =

�[Kkytos-1 exited with code 1

```