### PR TITLE
Remove check_disabled when creating and updating evcs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -279,6 +279,7 @@ Changed
 - ``GET /v2/evc?archived=true`` will only return archived EVCs
 - k-toolbar UI component won't expose UNI tag type anymore, if a tag value is set, it'll assume it's tag type vlan.
 - Consistency check uses the new ``PUT /traces`` endpoint from `sdntrace_cp` for bulk requests.
+- Changed validation of EVCs. Will no longer check for disabled components on intra-switch EVCs.
 
 Removed
 =======
@@ -292,7 +293,7 @@ Fixed
 - Fixed found but unloaded message log attempt for archived EVCs
 - Fixed EVC validation to catch nonexistent links interfaces
 - Allowed ``primary_path`` to be empty on update when ``dynamic_backup_path`` is true and ``backup_path`` to be empty too
-
+- Fixed bug with updates to intra-switch EVCs failing into an inconsistent state due to disabled components.
 
 [2022.2.0] - 2022-08-12
 ***********************

--- a/main.py
+++ b/main.py
@@ -32,8 +32,7 @@ from napps.kytos.mef_eline.models import (EVC, DynamicPathManager, EVCDeploy,
                                           Path)
 from napps.kytos.mef_eline.scheduler import CircuitSchedule, Scheduler
 from napps.kytos.mef_eline.utils import (_does_uni_affect_evc, aemit_event,
-                                         check_disabled_component, emit_event,
-                                         get_vlan_tags_and_masks,
+                                         emit_event, get_vlan_tags_and_masks,
                                          map_evc_event_content,
                                          merge_flow_dicts, prepare_delete_flow,
                                          send_flow_mods_http)
@@ -252,15 +251,6 @@ class Main(KytosNApp):
         except (ValueError, KytosTagError) as exception:
             log.debug("create_circuit result %s %s", exception, 400)
             raise HTTPException(400, detail=str(exception)) from exception
-        try:
-            check_disabled_component(evc.uni_a, evc.uni_z)
-        except DisabledSwitch as exception:
-            log.debug("create_circuit result %s %s", exception, 409)
-            raise HTTPException(
-                    409,
-                    detail=f"Path is not valid: {exception}"
-                ) from exception
-
         if evc.primary_path:
             try:
                 evc.primary_path.is_valid(

--- a/models/evc.py
+++ b/models/evc.py
@@ -27,7 +27,6 @@ from napps.kytos.mef_eline.exceptions import (ActivationError,
                                               EVCPathNotInstalled,
                                               FlowModException, InvalidPath)
 from napps.kytos.mef_eline.utils import (_does_uni_affect_evc,
-                                         check_disabled_component,
                                          compare_endpoint_trace,
                                          compare_uni_out_trace, emit_event,
                                          make_uni_list, map_dl_vlan,
@@ -246,7 +245,6 @@ class EVCBase(GenericEntity):
                 "UNI_A and UNI_Z tag lists should be the same."
             )
         uni_a, uni_z = self._get_unis_use_tags(**kwargs)
-        check_disabled_component(uni_a, uni_z)
         self._validate_has_primary_or_dynamic(
             primary_path=kwargs.get("primary_path"),
             dynamic_backup_path=kwargs.get("dynamic_backup_path"),

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -6,6 +6,7 @@ from unittest.mock import (AsyncMock, MagicMock, Mock, call,
 import pytest
 from kytos.lib.helpers import get_controller_mock, get_test_client
 from kytos.core.helpers import now
+from kytos.core.common import EntityStatus
 from kytos.core.events import KytosEvent
 from kytos.core.exceptions import KytosTagError
 from kytos.core.interface import TAGRange, UNI, Interface
@@ -567,6 +568,109 @@ class TestMain:
         payload["name"] = 1
         response = await self.api_client.post(url, json=payload)
         assert 400 == response.status_code, response.data
+
+    @patch("napps.kytos.mef_eline.main.Main._check_no_tag_duplication")
+    @patch("napps.kytos.mef_eline.models.evc.EVC._tag_lists_equal")
+    @patch("napps.kytos.mef_eline.main.Main._use_uni_tags")
+    @patch("napps.kytos.mef_eline.models.evc.EVC.deploy")
+    @patch("napps.kytos.mef_eline.scheduler.Scheduler.add")
+    @patch("napps.kytos.mef_eline.main.Main._uni_from_dict")
+    @patch("napps.kytos.mef_eline.controllers.ELineController.upsert_evc")
+    @patch("napps.kytos.mef_eline.main.EVC.as_dict")
+    @patch("napps.kytos.mef_eline.models.evc.EVC._validate")
+    async def test_create_a_circuit_case_5(
+        self,
+        validate_mock,
+        evc_as_dict_mock,
+        mongo_controller_upsert_mock,
+        uni_from_dict_mock,
+        sched_add_mock,
+        evc_deploy_mock,
+        mock_use_uni_tags,
+        mock_tags_equal,
+        mock_check_duplicate
+    ):
+        """Test create a new intra circuit with a disabled switch"""
+        # pylint: disable=too-many-locals
+        self.napp.controller.loop = asyncio.get_running_loop()
+        validate_mock.return_value = True
+        mongo_controller_upsert_mock.return_value = True
+        evc_deploy_mock.return_value = True
+        mock_use_uni_tags.return_value = True
+        mock_tags_equal.return_value = True
+        mock_check_duplicate.return_value = True
+        uni1 = create_autospec(UNI)
+        uni2 = create_autospec(UNI)
+        uni1.interface = create_autospec(Interface)
+        uni2.interface = create_autospec(Interface)
+        switch = MagicMock()
+        switch.status = EntityStatus.DISABLED
+        switch.return_value = "00:00:00:00:00:00:00:01"
+        uni1.interface.switch = switch
+        uni2.interface.switch = switch
+        uni_from_dict_mock.side_effect = [uni1, uni2]
+        evc_as_dict_mock.return_value = {}
+        sched_add_mock.return_value = True
+        self.napp.mongo_controller.get_circuits.return_value = {}
+
+        url = f"{self.base_endpoint}/v2/evc/"
+        payload = {
+            "name": "my evc1",
+            "frequency": "* * * * *",
+            "uni_a": {
+                "interface_id": "00:00:00:00:00:00:00:01:1",
+                "tag": {"tag_type": 'vlan', "value": 80},
+            },
+            "uni_z": {
+                "interface_id": "00:00:00:00:00:00:00:01:2",
+                "tag": {"tag_type": 'vlan', "value": 1},
+            },
+            "dynamic_backup_path": True,
+            "primary_constraints": {
+                "spf_max_path_cost": 8,
+                "mandatory_metrics": {
+                    "ownership": "red"
+                }
+            },
+            "secondary_constraints": {
+                "spf_attribute": "priority",
+                "mandatory_metrics": {
+                    "ownership": "blue"
+                }
+            }
+        }
+
+        response = await self.api_client.post(url, json=payload)
+        current_data = response.json()
+
+        # verify expected result from request
+        assert 201 == response.status_code
+        assert "circuit_id" in current_data
+
+        # verify uni called
+        uni_from_dict_mock.called_twice()
+        uni_from_dict_mock.assert_any_call(payload["uni_z"])
+        uni_from_dict_mock.assert_any_call(payload["uni_a"])
+
+        # verify validation called
+        validate_mock.assert_called_once()
+        validate_mock.assert_called_with(
+            table_group={'evpl': 0, 'epl': 0},
+            frequency="* * * * *",
+            name="my evc1",
+            uni_a=uni1,
+            uni_z=uni2,
+            dynamic_backup_path=True,
+            primary_constraints=payload["primary_constraints"],
+            secondary_constraints=payload["secondary_constraints"],
+        )
+        # verify save method is called
+        mongo_controller_upsert_mock.assert_called_once()
+
+        # verify evc as dict is called to save in the box
+        evc_as_dict_mock.assert_called()
+        # verify add circuit in sched
+        sched_add_mock.assert_called_once()
 
     async def test_create_a_circuit_invalid_queue_id(self):
         """Test create a new circuit with invalid queue_id."""

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -3,7 +3,6 @@ from unittest.mock import MagicMock, Mock
 import pytest
 
 from kytos.core.common import EntityStatus
-from napps.kytos.mef_eline.exceptions import DisabledSwitch
 from napps.kytos.mef_eline.utils import (compare_endpoint_trace,
                                          compare_uni_out_trace,
                                          get_vlan_tags_and_masks, map_dl_vlan,

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -4,8 +4,7 @@ import pytest
 
 from kytos.core.common import EntityStatus
 from napps.kytos.mef_eline.exceptions import DisabledSwitch
-from napps.kytos.mef_eline.utils import (check_disabled_component,
-                                         compare_endpoint_trace,
+from napps.kytos.mef_eline.utils import (compare_endpoint_trace,
                                          compare_uni_out_trace,
                                          get_vlan_tags_and_masks, map_dl_vlan,
                                          merge_flow_dicts, prepare_delete_flow,
@@ -111,36 +110,6 @@ class TestUtils:
     def test_get_vlan_tags_and_masks(self, vlan_range, expected):
         """Test get_vlan_tags_and_masks"""
         assert get_vlan_tags_and_masks(vlan_range) == expected
-
-    def test_check_disabled_component(self):
-        """Test check disabled component"""
-        uni_a = MagicMock()
-        switch = MagicMock()
-        switch.status = EntityStatus.DISABLED
-        uni_a.interface.switch = switch
-
-        uni_z = MagicMock()
-        uni_z.interface.switch = switch
-
-        # Switch disabled
-        with pytest.raises(DisabledSwitch):
-            check_disabled_component(uni_a, uni_z)
-
-        # Uni_a interface disabled
-        switch.status = EntityStatus.UP
-        uni_a.interface.status = EntityStatus.DISABLED
-        with pytest.raises(DisabledSwitch):
-            check_disabled_component(uni_a, uni_z)
-
-        # Uni_z interface disabled
-        uni_a.interface.status = EntityStatus.UP
-        uni_z.interface.status = EntityStatus.DISABLED
-        with pytest.raises(DisabledSwitch):
-            check_disabled_component(uni_a, uni_z)
-
-        # There is no disabled component
-        uni_z.interface.status = EntityStatus.UP
-        check_disabled_component(uni_a, uni_z)
 
     @pytest.mark.parametrize(
         "src1,src2,src3,expected",

--- a/utils.py
+++ b/utils.py
@@ -7,10 +7,10 @@ from tenacity import (retry, retry_if_exception_type, stop_after_attempt,
 
 from kytos.core.common import EntityStatus
 from kytos.core.events import KytosEvent
-from kytos.core.interface import UNI, Interface, TAGRange
+from kytos.core.interface import Interface, TAGRange
 from kytos.core.retry import before_sleep
 from napps.kytos.mef_eline import settings
-from napps.kytos.mef_eline.exceptions import DisabledSwitch, FlowModException
+from napps.kytos.mef_eline.exceptions import FlowModException
 
 
 def map_evc_event_content(evc, **kwargs) -> dict:

--- a/utils.py
+++ b/utils.py
@@ -125,21 +125,6 @@ def get_vlan_tags_and_masks(tag_ranges: list[list[int]]) -> list[int, str]:
     return masks_list
 
 
-def check_disabled_component(uni_a: UNI, uni_z: UNI):
-    """Check if a switch or an interface is disabled"""
-    if uni_a.interface.switch != uni_z.interface.switch:
-        return
-    if uni_a.interface.switch.status == EntityStatus.DISABLED:
-        dpid = uni_a.interface.switch.dpid
-        raise DisabledSwitch(f"Switch {dpid} is disabled")
-    if uni_a.interface.status == EntityStatus.DISABLED:
-        id_ = uni_a.interface.id
-        raise DisabledSwitch(f"Interface {id_} is disabled")
-    if uni_z.interface.status == EntityStatus.DISABLED:
-        id_ = uni_z.interface.id
-        raise DisabledSwitch(f"Interface {id_} is disabled")
-
-
 def make_uni_list(list_circuits: list) -> list:
     """Make uni list to be sent to sdntrace"""
     uni_list = []


### PR DESCRIPTION
Closes #618

### Summary

Removes the check_disabled_components check from the process of creating/updating EVCs. This check created inconsistent behaviour between intra and inter switch EVCs. Network state shouldn't dictate whether an EVC definition is valid, except to validate that the required components exist. We have other checks in place for if the network components are enabled to handle what check_disabled is trying to do.

### Local Tests

Seems to work as expected. Intra switch EVCs on disabled interfaces are able to be created/updated without issue.

### End-to-End Tests

This is most of the E2E tests. I'm just waiting on the last few to finish. In terms of relevant tests, they are all passing.

```
kytos-1  | Starting enhanced syslogd: rsyslogd.
kytos-1  | /etc/openvswitch/conf.db does not exist ... (warning).
kytos-1  | Creating empty database /etc/openvswitch/conf.db.
kytos-1  | Starting ovsdb-server.
kytos-1  | rsyslogd: error during config processing: omfile: chown for file '/var/log/syslog' failed: Operation not permitted [v8.2302.0 try https://www.rsyslog.com/e/2207 ]
kytos-1  | Configuring Open vSwitch system IDs.
kytos-1  | Starting ovs-vswitchd.
kytos-1  | Enabling remote OVSDB managers.
kytos-1  | There is no NAPPS_PATH specified. Default will be used.
kytos-1  | + '[' -z '' ']'
kytos-1  | + '[' -z '' ']'
kytos-1  | + echo 'There is no NAPPS_PATH specified. Default will be used.'
kytos-1  | + NAPPS_PATH=
kytos-1  | + sed -i 's/STATS_INTERVAL = 60/STATS_INTERVAL = 7/g' /var/lib/kytos/napps/kytos/of_core/settings.py
kytos-1  | + sed -i 's/CONSISTENCY_MIN_VERDICT_INTERVAL =.*/CONSISTENCY_MIN_VERDICT_INTERVAL = 60/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
kytos-1  | + sed -i 's/LINK_UP_TIMER = 10/LINK_UP_TIMER = 1/g' /var/lib/kytos/napps/kytos/topology/settings.py
kytos-1  | + sed -i 's/DEPLOY_EVCS_INTERVAL = 60/DEPLOY_EVCS_INTERVAL = 5/g' /var/lib/kytos/napps/kytos/mef_eline/settings.py
kytos-1  | + sed -i 's/LLDP_LOOP_ACTIONS = \["log"\]/LLDP_LOOP_ACTIONS = \["disable","log"\]/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos-1  | + sed -i 's/LLDP_IGNORED_LOOPS = {}/LLDP_IGNORED_LOOPS = {"00:00:00:00:00:00:00:01": \[\[4, 5\]\]}/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos-1  | + sed -i 's/CONSISTENCY_COOKIE_IGNORED_RANGE =.*/CONSISTENCY_COOKIE_IGNORED_RANGE = [(0xdd00000000000000, 0xdd00000000000009)]/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
kytos-1  | + sed -i 's/LIVENESS_DEAD_MULTIPLIER =.*/LIVENESS_DEAD_MULTIPLIER = 3/g' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos-1  | + kytosd --help
kytos-1  | + sed -i s/WARNING/INFO/g /etc/kytos/logging.ini
kytos-1  | + test -z ''
kytos-1  | + TESTS=tests/
kytos-1  | + test -z ''
kytos-1  | + RERUNS=2
kytos-1  | + python3 scripts/wait_for_mongo.py
kytos-1  | Trying to run hello command on MongoDB...
kytos-1  | Trying to run 'hello' command on MongoDB...
kytos-1  | Trying to run 'hello' command on MongoDB...
kytos-1  | Ran 'hello' command on MongoDB successfully. It's ready!
kytos-1  | + python3 scripts/setup_kafka.py
kytos-1  | Attempting to create an admin client at ['broker1:19092', 'broker2:19092', 'broker3:19092']...
kytos-1  | Admin client was successful! Attempting to validate cluster...
kytos-1  | Cluster info: {'throttle_time_ms': 0, 'brokers': [{'node_id': 1, 'host': 'broker1', 'port': 19092, 'rack': None}, {'node_id': 2, 'host': 'broker2', 'port': 19092, 'rack': None}, {'node_id': 3, 'host': 'broker3', 'port': 19092, 'rack': None}], 'cluster_id': '5L6g3nShT-eMCtK--X86sw', 'controller_id': 1}
kytos-1  | Cluster was successfully validated! Attempting shutdown...
kytos-1  | Kafka admin client closed.
kytos-1  | + python3 -m pytest tests/ --reruns 2 -r fEr
kytos-1  | ============================= test session starts ==============================
kytos-1  | platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
kytos-1  | rootdir: /
kytos-1  | configfile: pytest.ini
kytos-1  | plugins: asyncio-1.1.0, rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
kytos-1  | asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
kytos-1  | collected 293 items
kytos-1  | 
kytos-1  | tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
kytos-1  | tests/test_e2e_05_topology.py ...................                        [  7%]
kytos-1  | tests/test_e2e_06_topology.py ....                                       [  8%]
kytos-1  | tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
kytos-1  | .                                                                        [ 22%]
kytos-1  | tests/test_e2e_11_mef_eline.py ......                                    [ 24%]
kytos-1  | tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
kytos-1  | tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 41%]
kytos-1  | .                                                                        [ 41%]
kytos-1  | tests/test_e2e_14_mef_eline.py ......                                    [ 44%]
kytos-1  | tests/test_e2e_15_mef_eline.py ......                                    [ 46%]
kytos-1  | tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
kytos-1  | tests/test_e2e_17_mef_eline.py ....                                      [ 48%]
kytos-1  | tests/test_e2e_18_mef_eline.py ..                                        [ 48%]
kytos-1  | tests/test_e2e_20_flow_manager.py ............................           [ 58%]
kytos-1  | tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
kytos-1  | tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
kytos-1  | tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
kytos-1  | tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
kytos-1  | tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
kytos-1  | tests/test_e2e_32_of_lldp.py ...                                         [ 73%]

```
