### PR TITLE
Added accordion tables to path tables

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Changed
 - In EVCs flows where VLAN translation (numeric VLAN to untagged and different numeric VLANs) is performed, there is not longer ``qinq`` encapsulation applied. The translation will happen in the egress switch.
 - UI: Table from ``View Connections`` has now sticky property. This means that the title of every column will always be on sight when scrolling vertically.
 - UI: Table columns from ``View Connections`` are resizeable now. The cursor will change when hovering over the title of the column edges.
+- UI: Path tables from ``Circuit Details`` now have accordion tables. At first only shows the links for each path which are collapsible to show details of the clicked link.
 
 Added
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ Changed
 - UI: Table from ``View Connections`` has now sticky property. This means that the title of every column will always be on sight when scrolling vertically.
 - UI: Table columns from ``View Connections`` are resizeable now. The cursor will change when hovering over the title of the column edges.
 - UI: Path tables from ``Circuit Details`` now have accordion tables. At first only shows the links for each path which are collapsible to show details of the clicked link.
+- UI: Changed matching system in the table from ``View Connections``. Now every row will be displayed if it matches any filter entered specified.
+- UI: Added strict matching in the table from ``View Connections``. If a filter is checked, then only the rows that match the checked filters are going to be displayed.
 
 Added
 =====

--- a/ui/k-info-panel/list_connections.kytos
+++ b/ui/k-info-panel/list_connections.kytos
@@ -1,6 +1,10 @@
 <template>
     <div v-if="component_key > 0">
       <div class="mef_container">
+        <div class="mef-table-tip">
+          Hint: If any filter is used, any row that matches any of the filters will be displayed. To strict match a filter, check the box along the input area.
+          This way, only rows that match the checked filters will be displayed.
+        </div>
         <div class="mef-table">
           <div class="mef-table-divisor">
             <table id="mef-table-list-circuit" class="table mef-table-list-circuit">
@@ -21,10 +25,12 @@
                   <template v-for="(header, index) in data_header_id">
                     <th v-if="header == 'mef_dpid_id'"></th>
                     <th v-else>
-                      <input :id="header + '_search'" v-model="search_cols[header]"
-                        tooltip="DPID"
-                        v-if="!(['mef_lst_enabled', 'mef_lst_active'].includes(header))">
-                      </input>
+                      <div v-if="!(['mef_lst_enabled', 'mef_lst_active'].includes(header))">
+                        <k-checkbox :action="toggle_check_column" :checked="false" :value="header"></k-checkbox>
+                        <input :id="header + '_search'" v-model="search_cols[header]"
+                          tooltip="DPID">
+                        </input>
+                      </div>
                     </th>
                   </template>
                 </tr>
@@ -67,7 +73,7 @@ export default {
     return {
       flag_loading: false,
       component_key: 0,
-      search_cols: [], 
+      search_cols: {}, 
       data_header_id:  ['mef_dpid_id', 'mef_lst_name', 
                       'mef_lst_sw_a', 'mef_lst_prt_a', 'mef_lst_int_a', 'mef_lst_tag_a',
                       'mef_lst_sw_z', 'mef_lst_prt_z', 'mef_lst_int_z', 'mef_lst_tag_z', 
@@ -83,6 +89,18 @@ export default {
       interface_names: {}, // DPIDs and interface data and metadata
       thSliding: undefined, // th which was clicked on to be slided
       startOffset: 0, // Initial position to start sliding from
+      strict_filter: {
+        'mef_lst_name': false,
+        'mef_lst_sw_a': false,
+        'mef_lst_prt_a': false,
+        'mef_lst_int_a': false,
+        'mef_lst_tag_a': false,
+        'mef_lst_sw_z': false,
+        'mef_lst_prt_z': false,
+        'mef_lst_int_z': false,
+        'mef_lst_tag_z': false,
+        'path_types': false,
+      }
     }
   },
   methods: {
@@ -284,7 +302,10 @@ export default {
       document.addEventListener('mouseup', function (e) {
         _this.thSliding = undefined;
       })
-    }
+    },
+    toggle_check_column: function(header) {
+      this.strict_filter[header] = !this.strict_filter[header];
+    },
   },
   computed: {
     rowsOfPage: function() {
@@ -293,22 +314,38 @@ export default {
        * selected column
        */
       // list all seach properties
-      let properties = Object.keys(this.search_cols);
+      let filtered = []
+      let values = Object.values(this.search_cols);
 
-      let filtered = this.data_rows.filter((item)=>
-        {
-          // for every property check if search is not empty and item[prop] has search[prop]
-          // Cast to string to search VLAN numbers
-          // Regular Expression searches for comas and spaces
-          let checks = properties.map(i => 
-            !this.search_cols[i] || 
-            this.search_cols[i].toString().toUpperCase().split(/[\s,]+/).some(element => item[i].toString().toUpperCase().includes(element))
-          );
-          
-          // check if no property is false
-          return !checks.includes(false);
-        }
-      );
+      // If there is no filter entered
+      if (values.every(i => Boolean(i) == false)) {
+        filtered = this.data_rows
+      }
+      else {
+        let properties = Object.keys(this.search_cols);
+        filtered = this.data_rows.filter((item)=>
+          {
+            // Flag to indicate if matches with column checked (strict match).
+            let match_strict = true;
+            // for every property check if search is not empty and item[prop] has search[prop]
+            // Cast to string to search VLAN numbers
+            // Regular Expression searches for comas and spaces
+            let checks = properties.map(i => {
+              if (!this.search_cols[i] || !match_strict) {
+                return false;
+              }
+
+              const matches = this.search_cols[i].toString().toUpperCase().split(/[\s,]+/).some(element => item[i].toString().toUpperCase().includes(element))
+              if (this.strict_filter[i]) {
+                match_strict = matches;
+              }
+              return matches
+            });
+            // If a check is true and matches strict column, include it
+            return checks.includes(true) && match_strict;
+          }
+        );
+      };
 
       return filtered.sort((a, b) => {
         let modifier = 1,
@@ -356,6 +393,10 @@ export default {
 <style>
 /* Import icons */
 @import "https://fonts.googleapis.com/icon?family=Material+Icons";
+
+.mef-table-tip {
+  color: #ccc
+}
 
 .mef-k-info-panel {
   width: calc(100% - 300px);
@@ -408,13 +449,16 @@ export default {
   padding: 0 0 0.5em 0;
   background: #554077;
 }
+.mef-table .header-filter .k-checkbox-wrap {
+  min-height: 0px;
+}
 .mef-table .header-filter input {
   background: lightgray;
   border: 1px solid gray;
   border-radius: 3px;
   font-size: 0.9em;
-  margin: 0 0.2em 0 0.2em;
-  width: 80%;
+  margin: 0 0.3em 0 0;
+  width: 78%;
 }
 .mef-table tbody tr:nth-child(even) {
   background: #313131;

--- a/ui/k-info-panel/show_circuit.kytos
+++ b/ui/k-info-panel/show_circuit.kytos
@@ -171,18 +171,23 @@
                   <th>{{pindex}}</th>
                   <td v-if="path && path.length > 0">
                     <template v-for="step in path">
-                      <table class="mef-path-table">
-                        <tr>
-                          <th></th><th>Endpoint A</th><th>Endpoint B</th>
-                        </tr>
-                        <template v-for="(attr, cindex) in step">
+                      <div class="mef-link-name" @click="onLinkClick(step, pindex)">
+                        {{step['Link'][0]}}
+                      </div>
+                      <div :class="`accordion-${pindex}-${step['CSS-ID']}`" style="display: none;">
+                        <table class="mef-path-table">
                           <tr>
-                            <th>{{cindex}}</th><td>{{attr[0]}}</td><td>{{attr[1]}}</td>
+                            <th></th><th>Endpoint A</th><th>Endpoint B</th>
                           </tr>
-                        </template>
-                      </table>
+                          <template v-for="(attr, cindex) in step">
+                            <tr v-if="cindex !== 'CSS-ID'">
+                              <th>{{cindex}}</th><td>{{attr[0]}}</td><td>{{attr[1]}}</td>
+                            </tr>
+                          </template>
+                        </table>
+                      </div>
                     </template>
-                </td>
+                  </td>
                 </tr>
               </tbody>
             </table>
@@ -575,7 +580,6 @@ export default {
                     "Primary path": this.buildPathView(data['primary_path']),
                     "Backup path": this.buildPathView(data['backup_path'])
                    };
-
       this.links = {"Primary links": data['primary_links'],
                     "Backup links": data['backup_links']
                    };
@@ -612,7 +616,8 @@ export default {
             'Interface': [data_a['interface_name'], data_b['interface_name']],
             'Port': [data_a['port_name'], data_b['port_name']],
             'Link': [data_a['link_name'], data_b['link_name']],
-            'S-VLAN': [svlan, svlan]
+            'S-VLAN': [svlan, svlan],
+            'CSS-ID': dpid_a + "-" + dpid_b + "-" + svlan,
           };
           _path.push(_item);
         }
@@ -967,6 +972,18 @@ export default {
           this.$http_helpers.post_error(this, error, 'Could Not Remove Metadata');
         });
     },
+    onLinkClick: function(step, path_type) {
+      let table_div = document.getElementsByClassName("accordion-" + path_type + "-" + step['CSS-ID'])
+      if (table_div.length <= 0) {
+        return
+      };
+      table_div = table_div[0]
+      if (table_div.style.display === "block") {
+        table_div.style.display = "none"
+      } else {
+        table_div.style.display = "block"
+      };
+    }
   },
   mounted() {
     let _this = this;
@@ -1186,5 +1203,12 @@ export default {
   .vertical-scroll {
     overflow-y: auto;
     max-height: 28rem;
+  }
+  .mef-link-name {
+    cursor: pointer;
+    font-size: 1.2em;
+  } 
+  .mef-link-name:hover {
+    background-color: #666;
   }
 </style>

--- a/ui/k-info-panel/show_circuit.kytos
+++ b/ui/k-info-panel/show_circuit.kytos
@@ -174,7 +174,7 @@
                       <div class="mef-link-name" @click="onLinkClick(step, pindex)">
                         {{step['Link'][0]}}
                       </div>
-                      <div :class="`accordion-${pindex}-${step['CSS-ID']}`" style="display: none;">
+                      <div :id="`accordion-${pindex}-${step['CSS-ID']}`" style="display: none;">
                         <table class="mef-path-table">
                           <tr>
                             <th></th><th>Endpoint A</th><th>Endpoint B</th>
@@ -973,11 +973,10 @@ export default {
         });
     },
     onLinkClick: function(step, path_type) {
-      let table_div = document.getElementsByClassName("accordion-" + path_type + "-" + step['CSS-ID'])
-      if (table_div.length <= 0) {
+      let table_div = document.getElementById("accordion-" + path_type + "-" + step['CSS-ID'])
+      if (!table_div) {
         return
       };
-      table_div = table_div[0]
       if (table_div.style.display === "block") {
         table_div.style.display = "none"
       } else {


### PR DESCRIPTION
Closes #699

### Summary

Path tables from `Circuit Details` now have accordion tables. At first only shows the links for each path which are collapsible to show details of the clicked link.

Changed default matching for the table from `View Connections`:
- Every row will be displayed if it matches any of the filters if any filter is used.
- If any filter is checked, only the rows that match the checked filters will be displayed.

### Technical

Each collapsible table (link details) needs a unique class name. I chose to use: `f"accordion-{path_type}-{interface_a}-{interface_b}-{s-vlan}"`. For example `"accordion-Current path-00:00:00:00:00:00:00:01:4-00:00:00:00:00:00:00:03:3-1"`

### Local Tests
Created EVCs with primary paths.

### End-to-End Tests
N/A

### New table accordion

https://github.com/user-attachments/assets/07aac52d-cb99-4837-aa04-181cc76a8cfc

### New matching system for table in `View Connections`

https://github.com/user-attachments/assets/e19f3523-a36e-4577-828f-2a10ef428a29



