### PR TITLE
Now listening to interface status events

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Changed
 - In EVCs flows where VLAN translation (numeric VLAN to untagged and different numeric VLANs) is performed, there is not longer ``qinq`` encapsulation applied. The translation will happen in the egress switch.
 - UI: Table from ``View Connections`` has now sticky property. This means that the title of every column will always be on sight when scrolling vertically.
 - UI: Table columns from ``View Connections`` are resizeable now. The cursor will change when hovering over the title of the column edges.
+- This NApp now listens to ``kytos/topology.interface.(enabled|disabled)`` events to update affected EVCs.
 
 Added
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,7 @@ Changed
 - In EVCs flows where VLAN translation (numeric VLAN to untagged and different numeric VLANs) is performed, there is not longer ``qinq`` encapsulation applied. The translation will happen in the egress switch.
 - UI: Table from ``View Connections`` has now sticky property. This means that the title of every column will always be on sight when scrolling vertically.
 - UI: Table columns from ``View Connections`` are resizeable now. The cursor will change when hovering over the title of the column edges.
-- This NApp now listens to ``kytos/topology.interface.(enabled|disabled)`` events to update affected EVCs.
+- ``mef_eline`` now listens to ``kytos/topology.interface.(enabled|UP|disabled|DOWN)`` events to update affected EVCs.
 
 Added
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,7 @@ Changed
 - In EVCs flows where VLAN translation (numeric VLAN to untagged and different numeric VLANs) is performed, there is not longer ``qinq`` encapsulation applied. The translation will happen in the egress switch.
 - UI: Table from ``View Connections`` has now sticky property. This means that the title of every column will always be on sight when scrolling vertically.
 - UI: Table columns from ``View Connections`` are resizeable now. The cursor will change when hovering over the title of the column edges.
-- ``mef_eline`` now listens to ``kytos/topology.interface.(enabled|UP|disabled|DOWN)`` events to update affected EVCs.
+- ``mef_eline`` now listens to ``kytos/topology.interface.(enabled|up|disabled|down)`` events to update affected EVCs.
 
 Added
 =====

--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,8 @@ Subscribed
 - ``kytos/mef_eline.redeployed_link_up``
 - ``kytos/mef_eline.redeployed_link_down``
 - ``kytos/mef_eline.deployed``
+- ``kytos/topology.interface.enabled``
+- ``kytos/topology.interface.disabled``
 
 Published
 ---------

--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,8 @@ Subscribed
 - ``kytos/mef_eline.deployed``
 - ``kytos/topology.interface.enabled``
 - ``kytos/topology.interface.disabled``
+- ``kytos/topology.interface.UP``
+- ``kytos/topology.interface.DOWN``
 
 Published
 ---------

--- a/README.rst
+++ b/README.rst
@@ -66,8 +66,8 @@ Subscribed
 - ``kytos/mef_eline.deployed``
 - ``kytos/topology.interface.enabled``
 - ``kytos/topology.interface.disabled``
-- ``kytos/topology.interface.UP``
-- ``kytos/topology.interface.DOWN``
+- ``kytos/topology.interface.up``
+- ``kytos/topology.interface.down``
 
 Published
 ---------

--- a/main.py
+++ b/main.py
@@ -760,7 +760,7 @@ class Main(KytosNApp):
     # Possibly replace this with interruptions?
     @listen_to(
         '.*.switch.interface.(link_up|link_down|created|deleted)',
-        '.*.interface.(disabled|enabled)'
+        '.*.interface.(disabled|enabled|UP|DOWN)'
     )
     def on_interface_link_change(self, event: KytosEvent):
         """
@@ -796,9 +796,9 @@ class Main(KytosNApp):
             event = self._intf_events[iface.id]["event"]
             self._intf_events[iface.id].pop('last_acquired', None)
             _, _, event_type = event.name.rpartition('.')
-            if event_type in ('link_up', 'created', 'enabled'):
+            if event_type in ('link_up', 'created', 'enabled', 'UP'):
                 self.handle_interface_link_up(iface)
-            elif event_type in ('link_down', 'deleted', 'disabled'):
+            elif event_type in ('link_down', 'deleted', 'disabled', 'DOWN'):
                 self.handle_interface_link_down(iface)
 
     def handle_interface_link_up(self, interface):

--- a/main.py
+++ b/main.py
@@ -759,7 +759,8 @@ class Main(KytosNApp):
 
     # Possibly replace this with interruptions?
     @listen_to(
-        '.*.switch.interface.(link_up|link_down|created|deleted)'
+        '.*.switch.interface.(link_up|link_down|created|deleted)',
+        '.*.interface.(disabled|enabled)'
     )
     def on_interface_link_change(self, event: KytosEvent):
         """
@@ -795,9 +796,9 @@ class Main(KytosNApp):
             event = self._intf_events[iface.id]["event"]
             self._intf_events[iface.id].pop('last_acquired', None)
             _, _, event_type = event.name.rpartition('.')
-            if event_type in ('link_up', 'created'):
+            if event_type in ('link_up', 'created', 'enabled'):
                 self.handle_interface_link_up(iface)
-            elif event_type in ('link_down', 'deleted'):
+            elif event_type in ('link_down', 'deleted', 'disabled'):
                 self.handle_interface_link_down(iface)
 
     def handle_interface_link_up(self, interface):

--- a/main.py
+++ b/main.py
@@ -760,7 +760,7 @@ class Main(KytosNApp):
     # Possibly replace this with interruptions?
     @listen_to(
         '.*.switch.interface.(link_up|link_down|created|deleted)',
-        '.*.interface.(disabled|enabled|UP|DOWN)'
+        '.*.interface.(disabled|enabled|up|down)'
     )
     def on_interface_link_change(self, event: KytosEvent):
         """
@@ -796,9 +796,9 @@ class Main(KytosNApp):
             event = self._intf_events[iface.id]["event"]
             self._intf_events[iface.id].pop('last_acquired', None)
             _, _, event_type = event.name.rpartition('.')
-            if event_type in ('link_up', 'created', 'enabled', 'UP'):
+            if event_type in ('link_up', 'created', 'enabled', 'up'):
                 self.handle_interface_link_up(iface)
-            elif event_type in ('link_down', 'deleted', 'disabled', 'DOWN'):
+            elif event_type in ('link_down', 'deleted', 'disabled', 'down'):
                 self.handle_interface_link_down(iface)
 
     def handle_interface_link_up(self, interface):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2799,7 +2799,7 @@ class TestMain:
         mock_intf = Mock()
         mock_intf.id = "mock_intf"
 
-        # Created/link_up
+        # Created/link_up/enabled
         name = '.*.switch.interface.created'
         content = {"interface": mock_intf}
         event = KytosEvent(name=name, content=content)
@@ -2807,29 +2807,42 @@ class TestMain:
         assert mock_down.call_count == 0
         assert mock_up.call_count == 1
 
-        # Deleted/link_down
+        name = '.*.interface.enabled'
+        content = {"interface": mock_intf}
+        event = KytosEvent(name=name, content=content)
+        self.napp.handle_on_interface_link_change(event)
+        assert mock_down.call_count == 0
+        assert mock_up.call_count == 2
+
+        # Deleted/link_down/disabled
         name = '.*.switch.interface.deleted'
         event = KytosEvent(name=name, content=content)
         self.napp.handle_on_interface_link_change(event)
         assert mock_down.call_count == 1
-        assert mock_up.call_count == 1
+        assert mock_up.call_count == 2
+
+        name = '.*.interface.disabled'
+        event = KytosEvent(name=name, content=content)
+        self.napp.handle_on_interface_link_change(event)
+        assert mock_down.call_count == 2
+        assert mock_up.call_count == 2
 
         # Event delay
         self.napp._intf_events[mock_intf.id]["last_acquired"] = "mock_time"
         for _ in range(1, 6):
             self.napp.handle_on_interface_link_change(event)
-        assert mock_down.call_count == 1
-        assert mock_up.call_count == 1
+        assert mock_down.call_count == 2
+        assert mock_up.call_count == 2
 
         self.napp._intf_events[mock_intf.id].pop("last_acquired")
         self.napp.handle_on_interface_link_change(event)
-        assert mock_down.call_count == 2
-        assert mock_up.call_count == 1
+        assert mock_down.call_count == 3
+        assert mock_up.call_count == 2
 
         # Out of order event
         event = KytosEvent(name=name, content=content)
         self.napp._intf_events[mock_intf.id]["event"] = Mock(timestamp=now())
 
         self.napp.handle_on_interface_link_change(event)
-        assert mock_down.call_count == 2
-        assert mock_up.call_count == 1
+        assert mock_down.call_count == 3
+        assert mock_up.call_count == 2

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2821,7 +2821,7 @@ class TestMain:
         assert mock_down.call_count == 1
         assert mock_up.call_count == 2
 
-        name = '.*.interface.DOWN'
+        name = '.*.interface.down'
         event = KytosEvent(name=name, content=content)
         self.napp.handle_on_interface_link_change(event)
         assert mock_down.call_count == 2

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2821,7 +2821,7 @@ class TestMain:
         assert mock_down.call_count == 1
         assert mock_up.call_count == 2
 
-        name = '.*.interface.disabled'
+        name = '.*.interface.DOWN'
         event = KytosEvent(name=name, content=content)
         self.napp.handle_on_interface_link_change(event)
         assert mock_down.call_count == 2


### PR DESCRIPTION
Closes #698

### Summary

Listening to changes of interface statuses
Needs `topology` [PR](https://github.com/kytos-ng/topology/pull/286)

### Local Tests
Disabled and enabled interfaces to see if intra and inter EVCs would be DOWN or not

### End-to-End Tests
E2E tests from this [PR](https://github.com/kytos-ng/kytos-end-to-end-tests/pull/392) are passing but I am going to run them all just in case.

