### PR TITLE
release: bumped 2025.2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,9 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2025.2.0] - 2026-02-02
+***********************
+
 Fixed
 =====
 - ``set_queue`` action is now set before ``output``

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "mef_eline",
   "description": "NApp to provision circuits from user request",
-  "version": "2025.1.0",
+  "version": "2025.2.0",
   "napp_dependencies": ["kytos/flow_manager", "kytos/pathfinder", "amlight/sndtrace_cp"],
   "license": "MIT",
   "tags": [],


### PR DESCRIPTION
Related to https://github.com/kytos-ng/kytos/issues/603

### Summary

See updated changelog file 

### Local Tests

N/A

### End-to-End Tests

N/A (nightly tests passing)
