### PR TITLE
Intra EVC inactive state and leftover flows solved.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Added
+=====
+- Added new EVC field called ``last_deployed_at`` to help identify if EVC needs deployment based on time.
+
+Fixed
+=====
+- Intra EVC now redeploys when it gets activated because UNI status changed to ``UP``.
+
 [2025.2.0] - 2026-02-02
 ***********************
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,8 @@ Fixed
 =====
 - Intra EVC now redeploys when it gets activated because UNI status changed to ``UP``.
 - Fixed leftover flows when changing from intra-EVC to inter-EVC by detecting the change and removing UNI flows from intra switch.
+- Fixed leftover flow when both EVC UNI were patched and the circuit changed from intra to inter switch.
+- Redeploying intra EVC when when it has not flows and UNI gets activated.
 
 [2025.2.0] - 2026-02-02
 ***********************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,8 @@ All notable changes to the MEF_ELine NApp will be documented in this file.
 
 Added
 =====
-- Added new EVC field called ``last_deployed_at`` to help identify if EVC needs deployment based on time.
+- Added new EVC field called ``last_deployed_at`` to help identify if EVC was ever deployed and install flows.
+- Added new EVC field called ``last_removed_at`` to help identify if EVC did ever remove flows.
 
 Fixed
 =====

--- a/db/models.py
+++ b/db/models.py
@@ -171,7 +171,7 @@ class EVCBaseDoc(DocumentBaseModel):
             "execution_rounds": {"$ifNull": ["$execution_rounds", 0]},
             "owner": {"$ifNull": ["$owner", None]},
             "queue_id": {"$ifNull": ["$queue_id", None]},
-            "leftover_switch": {"$ifNull": ["$leftover_switch", 0]},
+            "leftover_switch": {"$ifNull": ["$leftover_switch", None]},
             "primary_constraints": {"$ifNull": ["$primary_constraints", {}]},
             "secondary_constraints": {"$ifNull": ["$secondary_constraints",
                                       {}]},

--- a/db/models.py
+++ b/db/models.py
@@ -142,6 +142,7 @@ class EVCBaseDoc(DocumentBaseModel):
     active: bool
     enabled: bool
     max_paths: Optional[int] = 2
+    leftover_switch: Optional[str] = None
 
     @staticmethod
     def projection() -> Dict:
@@ -170,6 +171,7 @@ class EVCBaseDoc(DocumentBaseModel):
             "execution_rounds": {"$ifNull": ["$execution_rounds", 0]},
             "owner": {"$ifNull": ["$owner", None]},
             "queue_id": {"$ifNull": ["$queue_id", None]},
+            "leftover_switch": {"$ifNull": ["$leftover_switch", 0]},
             "primary_constraints": {"$ifNull": ["$primary_constraints", {}]},
             "secondary_constraints": {"$ifNull": ["$secondary_constraints",
                                       {}]},

--- a/db/models.py
+++ b/db/models.py
@@ -120,6 +120,7 @@ class EVCBaseDoc(DocumentBaseModel):
     queue_id: Optional[int] = None
     flow_removed_at: Optional[datetime] = None
     last_deployed_at: Optional[datetime] = None
+    last_removed_at: Optional[datetime] = None
     execution_rounds: int = 0
     bandwidth: int = 0
     primary_path: Optional[list] = None
@@ -198,6 +199,11 @@ class EVCBaseDoc(DocumentBaseModel):
             "last_deployed_at": {"$dateToString": {
                 "format": time_fmt, "date": {
                     "$ifNull": ["$last_deployed_at", None]
+                }
+            }},
+            "last_removed_at": {"$dateToString": {
+                "format": time_fmt, "date": {
+                    "$ifNull": ["$last_removed_at", None]
                 }
             }},
             "updated_at": {"$dateToString": {

--- a/db/models.py
+++ b/db/models.py
@@ -119,6 +119,7 @@ class EVCBaseDoc(DocumentBaseModel):
     end_date: Optional[datetime] = None
     queue_id: Optional[int] = None
     flow_removed_at: Optional[datetime] = None
+    last_deployed_at: Optional[datetime] = None
     execution_rounds: int = 0
     bandwidth: int = 0
     primary_path: Optional[list] = None
@@ -192,6 +193,11 @@ class EVCBaseDoc(DocumentBaseModel):
             "flow_removed_at": {"$dateToString": {
                 "format": time_fmt, "date": {
                     "$ifNull": ["$flow_removed_at", None]
+                }
+            }},
+            "last_deployed_at": {"$dateToString": {
+                "format": time_fmt, "date": {
+                    "$ifNull": ["$last_deployed_at", None]
                 }
             }},
             "updated_at": {"$dateToString": {

--- a/main.py
+++ b/main.py
@@ -415,7 +415,7 @@ class Main(KytosNApp):
                     circuit_id, updated_data.get("uni_a"),
                     updated_data.get("uni_z")
                 )
-                enable, redeploy, force_removal = evc.update(**updated_data)
+                enable, redeploy = evc.update(**updated_data)
             except (ValueError, KytosTagError, ValidationError) as exception:
                 log.debug("update result %s %s", exception, 400)
                 raise HTTPException(400, detail=str(exception)) from exception
@@ -431,15 +431,15 @@ class Main(KytosNApp):
             redeployed = False
             if evc.is_active():
                 if enable is False:  # disable if active
-                    evc.remove(force_removal)
+                    evc.remove()
                 elif redeploy is not None:  # redeploy if active
-                    evc.remove(force_removal)
+                    evc.remove()
                     redeployed = evc.deploy()
             else:
                 if enable is True:  # enable if inactive
                     redeployed = evc.deploy()
                 elif evc.is_enabled() and redeploy:
-                    evc.remove(force_removal)
+                    evc.remove()
                     redeployed = evc.deploy()
             result = {evc.id: evc.as_dict(), 'redeployed': redeployed}
             status = 200

--- a/models/evc.py
+++ b/models/evc.py
@@ -163,6 +163,7 @@ class EVCBase(GenericEntity):
         self.backup_links_cache = set()
         self.old_path = Path([])
         self.max_paths = kwargs.get("max_paths", 2)
+        self.leftover_switch = kwargs.get("leftover_switch", None)
 
         self.lock = Lock()
 
@@ -247,7 +248,9 @@ class EVCBase(GenericEntity):
             ValueError: message with error detail.
 
         """
-        prev_intra = self.is_intra_switch()
+        leftover_switch = None
+        if self.is_intra_switch():
+            leftover_switch = self.uni_a.interface.switch.id
         enable, redeploy = (None, None)
         # Verification of the attributes
         if not self._tag_lists_equal(**kwargs):
@@ -294,8 +297,16 @@ class EVCBase(GenericEntity):
                 setattr(self, attribute, value)
                 if attribute in self.attributes_requiring_redeploy:
                     redeploy = True
+        self.save_leftover_switch(leftover_switch)
         self.sync(set(kwargs.keys()))
-        return enable, redeploy, (prev_intra and not self.is_intra_switch())
+        return enable, redeploy
+
+    def save_leftover_switch(self, leftover_switch):
+        """Save the leftover switch if the circuit has changed to inter.
+        The flows from the saved switch will be removed."""
+        if not leftover_switch or self.is_intra_switch():
+            return
+        self.leftover_switch = leftover_switch
 
     def set_flow_removed_at(self):
         """Update flow_removed_at attribute."""
@@ -456,6 +467,7 @@ class EVCBase(GenericEntity):
         evc_dict["last_removed_at"] = self.last_removed_at
         evc_dict["updated_at"] = self.updated_at
         evc_dict["max_paths"] = self.max_paths
+        evc_dict["leftover_switch"] = self.leftover_switch
 
         if keys:
             selected = {}
@@ -680,9 +692,9 @@ class EVCDeploy(EVCBase):
     #    def discover_new_path(self):
     #        # TODO: discover a new path to satisfy this circuit and deploy
 
-    def remove(self, force_removal=False):
+    def remove(self):
         """Remove EVC path and disable it."""
-        self.remove_current_flows(force_removal=force_removal, sync=False)
+        self.remove_current_flows(sync=False)
         self.remove_failover_flows(sync=False)
         self.disable()
         self.sync()
@@ -739,17 +751,19 @@ class EVCDeploy(EVCBase):
         force=True,
         sync=True,
         return_path=False,
-        force_removal=False,
     ) -> dict[str, int]:
         """Remove all flows from current path or path intended for
          current path if exists."""
         switches, old_path_dict = set(), {}
         current_path = self.current_path if not current_path else current_path
 
-        # if force_removal=True, then an intra EVC was changed to inter EVC
-        if (not force_removal and not current_path and
+        if (not self.leftover_switch and not current_path and
                 not self.is_intra_switch()):
             return old_path_dict
+
+        if self.leftover_switch:
+            switches.add(self.leftover_switch)
+            self.leftover_switch = None
 
         if return_path:
             for link in self.current_path:

--- a/models/evc.py
+++ b/models/evc.py
@@ -155,6 +155,7 @@ class EVCBase(GenericEntity):
         self.last_deployed_at = (
             get_time(kwargs.get("last_deployed_at")) or None
         )
+        self.last_removed_at = get_time(kwargs.get("last_removed_at")) or None
         self.updated_at = get_time(kwargs.get("updated_at")) or now()
         self.execution_rounds = kwargs.get("execution_rounds", 0)
         self.current_links_cache = set()
@@ -452,6 +453,7 @@ class EVCBase(GenericEntity):
         evc_dict["secondary_constraints"] = self.secondary_constraints
         evc_dict["flow_removed_at"] = self.flow_removed_at
         evc_dict["last_deployed_at"] = self.last_deployed_at
+        evc_dict["last_removed_at"] = self.last_removed_at
         evc_dict["updated_at"] = self.updated_at
         evc_dict["max_paths"] = self.max_paths
 
@@ -779,6 +781,7 @@ class EVCDeploy(EVCBase):
         except KytosTagError as err:
             log.error(f"Error removing {self} current_path: {err}")
         self.current_path = Path([])
+        self.last_removed_at = now()
         self.deactivate()
         if sync:
             self.sync()
@@ -1757,9 +1760,13 @@ class EVCDeploy(EVCBase):
         """Determine whether an intra-switch EVC needs redeployment."""
         if not self.is_intra_switch():
             return False
-        flows_removed = bool(self.flow_removed_at) and \
-            self.last_deployed_at < self.flow_removed_at
-        return not self.last_deployed_at or flows_removed
+        if not self.last_deployed_at:
+            return True
+
+        return bool(
+            self.last_removed_at
+            and self.last_deployed_at < self.last_removed_at
+        )
 
 
 class LinkProtection(EVCDeploy):

--- a/models/evc.py
+++ b/models/evc.py
@@ -152,7 +152,9 @@ class EVCBase(GenericEntity):
         self.service_level = kwargs.get("service_level", 0)
         self.circuit_scheduler = kwargs.get("circuit_scheduler", [])
         self.flow_removed_at = get_time(kwargs.get("flow_removed_at")) or None
-        self.last_deployed_at = get_time(kwargs.get("last_deployed_at")) or None
+        self.last_deployed_at = (
+            get_time(kwargs.get("last_deployed_at")) or None
+        )
         self.updated_at = get_time(kwargs.get("updated_at")) or now()
         self.execution_rounds = kwargs.get("execution_rounds", 0)
         self.current_links_cache = set()
@@ -448,6 +450,7 @@ class EVCBase(GenericEntity):
         evc_dict["primary_constraints"] = self.primary_constraints
         evc_dict["secondary_constraints"] = self.secondary_constraints
         evc_dict["flow_removed_at"] = self.flow_removed_at
+        evc_dict["last_deployed_at"] = self.last_deployed_at
         evc_dict["updated_at"] = self.updated_at
         evc_dict["max_paths"] = self.max_paths
 
@@ -986,7 +989,7 @@ class EVCDeploy(EVCBase):
 
         self.current_path = use_path
         msg = f"{self} was deployed."
-        self.last_deployed_at = datetime.now()
+        self.last_deployed_at = now()
         try:
             self.try_to_activate()
         except ActivationError as exc:
@@ -1744,6 +1747,14 @@ class EVCDeploy(EVCBase):
             return link.endpoint_a
         return link.endpoint_b
 
+    def intra_evc_needs_redeployment(self) -> bool:
+        """Determine whether an intra-switch EVC needs redeployment."""
+        if not self.is_intra_switch():
+            return False
+        flows_removed = bool(self.flow_removed_at) and \
+            self.last_deployed_at < self.flow_removed_at
+        return not self.last_deployed_at or flows_removed
+
 
 class LinkProtection(EVCDeploy):
     """Class to handle link protection."""
@@ -1949,12 +1960,6 @@ class LinkProtection(EVCDeploy):
         emit_event(self._controller, "uni_active_updated",
                    content=map_evc_event_content(self))
         self.sync()
-
-    def intra_evc_needs_redeployment(self) -> bool:
-        """Determine whether an intra-switch EVC needs redeployment."""
-        if not self.is_intra_switch():
-            return False
-        return not self.last_deployed_at or self.last_deployed_at < self.flow_removed_at
 
 
 class EVC(LinkProtection):

--- a/models/evc.py
+++ b/models/evc.py
@@ -152,6 +152,7 @@ class EVCBase(GenericEntity):
         self.service_level = kwargs.get("service_level", 0)
         self.circuit_scheduler = kwargs.get("circuit_scheduler", [])
         self.flow_removed_at = get_time(kwargs.get("flow_removed_at")) or None
+        self.last_deployed_at = get_time(kwargs.get("last_deployed_at")) or None
         self.updated_at = get_time(kwargs.get("updated_at")) or now()
         self.execution_rounds = kwargs.get("execution_rounds", 0)
         self.current_links_cache = set()
@@ -985,6 +986,7 @@ class EVCDeploy(EVCBase):
 
         self.current_path = use_path
         msg = f"{self} was deployed."
+        self.last_deployed_at = datetime.now()
         try:
             self.try_to_activate()
         except ActivationError as exc:
@@ -1890,6 +1892,9 @@ class LinkProtection(EVCDeploy):
                 )
             log.info(msg)
             return True
+        if self.intra_evc_needs_redeployment():
+            succeeded = self.deploy_to_path()
+            return succeeded
         return False
 
     def handle_interface_link_up(self, interface: Interface):
@@ -1944,6 +1949,12 @@ class LinkProtection(EVCDeploy):
         emit_event(self._controller, "uni_active_updated",
                    content=map_evc_event_content(self))
         self.sync()
+
+    def intra_evc_needs_redeployment(self) -> bool:
+        """Determine whether an intra-switch EVC needs redeployment."""
+        if not self.is_intra_switch():
+            return False
+        return not self.last_deployed_at or self.last_deployed_at < self.flow_removed_at
 
 
 class EVC(LinkProtection):

--- a/openapi.yml
+++ b/openapi.yml
@@ -718,6 +718,34 @@ components:
           default: 2
           minimum: 2
           maximum: 10
+        metadata:
+          type: object
+          description: "Custom metadata in the form of key:value pairs to store information about the circuit."
+        archived:
+          type: boolean
+          description: "True if the circuit is archived."
+        flow_removed_at:
+          type: string
+          format: date-time
+          description: "Time when the flow was removed from the switch by flow_manager."
+        last_deployed_at:
+          type: string
+          format: date-time
+          description: "Time when the circuit was last deployed and flows were sent to be installed."
+        last_removed_at:
+          type: string
+          format: date-time
+          description: "Time when the circuit current path was last removed and flows were sent to be removed."
+        updated_at:
+          type: string
+          format: date-time
+          description: "Time when the circuit was last updated."
+        execution_rounds:
+          type: integer
+          description: ""
+        table_group:
+          type: object
+          description: "Table groups associated with the circuit."
 
     UpdateCircuit: # Can be referenced via '#/components/schemas/UpdateCircuit'
       type: object

--- a/openapi.yml
+++ b/openapi.yml
@@ -703,6 +703,10 @@ components:
           description: "QoS Egress Queue ID. Value -1 can be use to set this field to default."
           minimum: -1
           maximum: 7
+        leftover_switch:
+          type: string
+          nullable: true
+          description: "Switch ID to remove leftover flows in case of a change from intra to inter switch circuit."
 
         circuit_scheduler:
           type: array

--- a/tests/unit/models/test_evc_base.py
+++ b/tests/unit/models/test_evc_base.py
@@ -257,7 +257,7 @@ class TestEVC():  # pylint: disable=too-many-public-methods, no-member
         }
         update_dict = {"queue_id": 3}
         evc = EVC(**attributes)
-        _, redeploy, __ = evc.update(**update_dict)
+        _, redeploy = evc.update(**update_dict)
         assert redeploy
 
     @patch("napps.kytos.mef_eline.models.EVC.sync")
@@ -273,7 +273,7 @@ class TestEVC():  # pylint: disable=too-many-public-methods, no-member
         }
         update_dict = {"queue_id": None}
         evc = EVC(**attributes)
-        _, redeploy, __ = evc.update(**update_dict)
+        _, redeploy = evc.update(**update_dict)
         assert redeploy
 
     def test_update_different_tag_lists(self):
@@ -772,8 +772,8 @@ class TestEVC():  # pylint: disable=too-many-public-methods, no-member
 
     @patch("napps.kytos.mef_eline.models.EVC._get_unis_use_tags")
     @patch("napps.kytos.mef_eline.models.EVC.sync")
-    def test_from_intra_to_inter(self, _mock_sync, mock_use_tags):
-        """Test _tag_lists_equal"""
+    def test_from_intra_to_inter_1_uni(self, _mock_sync, mock_use_tags):
+        """Test change evc from intra to inter by changing only one UNI."""
         mock_use_tags.return_value = False, False
         uni_a = get_uni_mocked(is_valid=True)
         uni_z = get_uni_mocked(is_valid=True)
@@ -789,9 +789,39 @@ class TestEVC():  # pylint: disable=too-many-public-methods, no-member
             "uni_z": uni_z,
         }
         evc = EVC(**attributes)
+        expected_switch = uni_a.interface.switch.id
         update_dict = {"uni_z": get_uni_mocked(is_valid=True)}
-        _, __, force_removal = evc.update(**update_dict)
-        assert force_removal is True
+        evc.update(**update_dict)
+        assert evc.leftover_switch is not None
+        assert evc.leftover_switch == expected_switch
+
+    @patch("napps.kytos.mef_eline.models.EVC._get_unis_use_tags")
+    @patch("napps.kytos.mef_eline.models.EVC.sync")
+    def test_from_intra_to_inter_2_uni(self, _mock_sync, mock_use_tags):
+        """Test change evc from intra to inter by changing only two UNI."""
+        mock_use_tags.return_value = False, False
+        uni_a = get_uni_mocked(is_valid=True)
+        uni_z = get_uni_mocked(is_valid=True)
+        uni_z.interface.switch = uni_a.interface.switch
+        primary_path = Path([])
+        attributes = {
+            "controller": get_controller_mock(),
+            "name": "circuit_name",
+            "dynamic_backup_path": True,
+            "primary_path": primary_path,
+            "enable": True,
+            "uni_a": uni_a,
+            "uni_z": uni_z,
+        }
+        evc = EVC(**attributes)
+        expected_switch = uni_a.interface.switch.id
+        update_dict = {
+            "uni_a": get_uni_mocked(is_valid=True),
+            "uni_z": get_uni_mocked(is_valid=True)
+        }
+        evc.update(**update_dict)
+        assert evc.leftover_switch is not None
+        assert evc.leftover_switch == expected_switch
 
     @patch("napps.kytos.mef_eline.models.EVC._get_unis_use_tags")
     @patch("napps.kytos.mef_eline.models.EVC.sync")
@@ -815,5 +845,5 @@ class TestEVC():  # pylint: disable=too-many-public-methods, no-member
         new_uni_z = get_uni_mocked(is_valid=True)
         new_uni_z.interface.switch = uni_a_switch
         update_dict = {"uni_z": new_uni_z}
-        _, __, force_removal = evc.update(**update_dict)
-        assert force_removal is False
+        evc.update(**update_dict)
+        assert evc.leftover_switch is None

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -1,4 +1,5 @@
 """Method to thest EVCDeploy class."""
+from datetime import datetime, timezone
 import sys
 from unittest.mock import MagicMock, Mock, call, patch
 import operator
@@ -861,6 +862,7 @@ class TestEVC():
 
         deployed = evc.deploy_to_path()
 
+        assert evc.last_deployed_at is not None
         assert should_deploy_mock.call_count == 1
         assert discover_new_paths_mocked.call_count == 1
         assert activate_mock.call_count == 1
@@ -2290,3 +2292,28 @@ class TestEVC():
         send_flow_mock.assert_called_with(
             expected_installed_flows, "install", by_switch=True
         )
+
+    def test_intra_evc_needs_redeployment(self):
+        """Test intra_evc_needs_redeployment"""
+        uni_a = get_uni_mocked()
+        uni_z = get_uni_mocked()
+        uni_z.interface.switch = uni_a.interface.switch
+        attributes = {
+            "controller": get_controller_mock(),
+            "name": "circuit_name",
+            "dynamic_backup_path": False,
+            "primary_path": MagicMock(),
+            "enable": True,
+            "uni_a": uni_a,
+            "uni_z": uni_z,
+            "flow_removed_at": None,
+            "last_deployed_at": None,
+        }
+        tzone = timezone.utc
+        evc = EVC(**attributes)
+
+        assert evc.intra_evc_needs_redeployment() is True
+        evc.last_deployed_at = datetime.now(tzone)
+        assert evc.intra_evc_needs_redeployment() is False
+        evc.flow_removed_at = datetime.now(tzone)
+        assert evc.intra_evc_needs_redeployment() is True

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -2317,6 +2317,7 @@ class TestEVC():
         assert evc.intra_evc_needs_redeployment() is False
         evc.flow_removed_at = datetime.now(tzone)
         assert evc.intra_evc_needs_redeployment() is True
+
     @patch("napps.kytos.mef_eline.controllers.ELineController.upsert_evc")
     @patch("napps.kytos.mef_eline.models.evc.EVC._send_flow_mods")
     def test_remove_current_flows_intra(self, *args):

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -2361,14 +2361,14 @@ class TestEVC():
 
     @patch("napps.kytos.mef_eline.controllers.ELineController.upsert_evc")
     @patch("napps.kytos.mef_eline.models.evc.EVC._send_flow_mods")
-    def test_remove_current_flows_force_removal(self, *args):
+    def test_remove_current_flows_leftover_switch(self, *args):
         """Remove flows from inter EVC without current path
         because it was recently changed from intra EVC."""
         # pylint: disable=too-many-locals
         (send_flow_mods_mocked, _,) = args
         uni_a = get_uni_mocked()
         uni_z = get_uni_mocked()
-
+        leftover_switch = get_uni_mocked().interface.switch.id
         attributes = {
             "controller": get_controller_mock(),
             "name": "custom_name",
@@ -2380,8 +2380,9 @@ class TestEVC():
         }
 
         evc = EVC(**attributes)
+        evc.leftover_switch = leftover_switch
 
-        evc.remove_current_flows(force_removal=True)
+        evc.remove_current_flows()
         assert send_flow_mods_mocked.call_count == 1
         assert evc.last_removed_at is not None
         assert evc.is_active() is False
@@ -2392,7 +2393,8 @@ class TestEVC():
         expected_flows = {
             "switches": [
                 uni_a.interface.switch.id,
-                uni_z.interface.switch.id
+                uni_z.interface.switch.id,
+                leftover_switch
             ],
             "flows": flows
         }
@@ -2400,3 +2402,4 @@ class TestEVC():
         assert set(expected_flows["switches"]) == set(args[0]["switches"])
         assert expected_flows["flows"] == args[0]["flows"]
         assert 'delete' == args[1]
+        assert evc.leftover_switch is None

--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -2306,7 +2306,7 @@ class TestEVC():
             "enable": True,
             "uni_a": uni_a,
             "uni_z": uni_z,
-            "flow_removed_at": None,
+            "last_removed_at": None,
             "last_deployed_at": None,
         }
         tzone = timezone.utc
@@ -2315,7 +2315,7 @@ class TestEVC():
         assert evc.intra_evc_needs_redeployment() is True
         evc.last_deployed_at = datetime.now(tzone)
         assert evc.intra_evc_needs_redeployment() is False
-        evc.flow_removed_at = datetime.now(tzone)
+        evc.last_removed_at = datetime.now(tzone)
         assert evc.intra_evc_needs_redeployment() is True
 
     @patch("napps.kytos.mef_eline.controllers.ELineController.upsert_evc")
@@ -2357,6 +2357,7 @@ class TestEVC():
         assert set(expected_flows["switches"]) == set(args[0]["switches"])
         assert expected_flows["flows"] == args[0]["flows"]
         assert 'delete' == args[1]
+        assert evc.last_removed_at is not None
 
     @patch("napps.kytos.mef_eline.controllers.ELineController.upsert_evc")
     @patch("napps.kytos.mef_eline.models.evc.EVC._send_flow_mods")
@@ -2382,6 +2383,7 @@ class TestEVC():
 
         evc.remove_current_flows(force_removal=True)
         assert send_flow_mods_mocked.call_count == 1
+        assert evc.last_removed_at is not None
         assert evc.is_active() is False
         flows = [
             {"cookie": evc.get_cookie(), "cookie_mask": 18446744073709551615,


### PR DESCRIPTION
Closes #719 

### Summary

See updated changelog file and/or add any other summarized helpful information for reviewers

### Local Tests
Performed 2 tests.
1.
Started kytos without `-E` option
Created an intra EVC
Enabled switch from recently create EVC UNIs
Check if the flows from the intra EVC are installed

2.
Disabled the intra EVC so flows are uninstalled
Disabled switch from UNIs
Enabled intra EVC, check that flows are not installed
Enable switch from UNIs

3.
Also performed the test from this [comment](https://github.com/kytos-ng/mef_eline/pull/721#pullrequestreview-4462864029).

### End-to-End Tests
[In progress](https://github.com/kytos-ng/kytos-end-to-end-tests/pull/457)
```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /
configfile: pytest.ini
plugins: timeout-2.2.0, rerunfailures-13.0, asyncio-1.1.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 309 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py .....                                      [  8%]
tests/test_e2e_08_topology.py .                                          [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 24%]
tests/test_e2e_12_mef_eline.py .....Xx..                                 [ 27%]
tests/test_e2e_13_mef_eline.py .......................ssss.............. [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 45%]
tests/test_e2e_17_mef_eline.py .....                                     [ 47%]
tests/test_e2e_18_mef_eline.py .......                                   [ 49%]
tests/test_e2e_20_flow_manager.py .............................          [ 59%]
tests/test_e2e_21_flow_manager.py ...                                    [ 60%]
tests/test_e2e_22_flow_manager.py ...............                        [ 65%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ......                                      [ 71%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py s                                      [100%]
```