### PR TITLE
chore: mocked httpx.request for evc removals / deploy test

### DIFF
--- a/tests/unit/models/test_evc_deploy.py
+++ b/tests/unit/models/test_evc_deploy.py
@@ -1,5 +1,5 @@
 """Method to thest EVCDeploy class."""
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import sys
 from unittest.mock import MagicMock, Mock, call, patch
 import operator
@@ -439,6 +439,7 @@ class TestEVC():
         }
         return EVC(**attributes)
 
+    @patch("httpx.request")
     @patch("httpx.post")
     @patch("napps.kytos.mef_eline.controllers.ELineController.upsert_evc")
     @patch("napps.kytos.mef_eline.models.evc.log")
@@ -459,12 +460,14 @@ class TestEVC():
             log_mock,
             _,
             httpx_mock,
+            httpx_request_mock,
         ) = args
 
         response = MagicMock()
         response.status_code = 201
         response.is_server_error = False
         httpx_mock.return_value = response
+        httpx_request_mock.return_value = response
 
         should_deploy_mock.return_value = True
         evc = self.create_evc_inter_switch()
@@ -2315,7 +2318,7 @@ class TestEVC():
         assert evc.intra_evc_needs_redeployment() is True
         evc.last_deployed_at = datetime.now(tzone)
         assert evc.intra_evc_needs_redeployment() is False
-        evc.last_removed_at = datetime.now(tzone)
+        evc.last_removed_at = evc.last_deployed_at + timedelta(seconds=1)
         assert evc.intra_evc_needs_redeployment() is True
 
     @patch("napps.kytos.mef_eline.controllers.ELineController.upsert_evc")

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1463,6 +1463,7 @@ class TestMain:
         response = await self.api_client.get(url)
         assert response.status_code == 404
 
+    @patch('httpx.request')
     @patch('httpx.post')
     @patch("napps.kytos.mef_eline.main.Main._use_uni_tags")
     @patch('napps.kytos.mef_eline.scheduler.Scheduler.add')
@@ -1486,7 +1487,8 @@ class TestMain:
         _mongo_controller_update_mock,
         _sched_add_mock,
         mock_use_uni_tags,
-        httpx_mock
+        httpx_mock,
+        httpx_request_mock,
     ):
         """Test update a circuit circuit."""
         self.napp.controller.loop = asyncio.get_running_loop()
@@ -1501,7 +1503,9 @@ class TestMain:
 
         response = MagicMock()
         response.status_code = 201
+        response.is_server_error = False
         httpx_mock.return_value = response
+        httpx_request_mock.return_value = response
 
         payloads = [
             {


### PR DESCRIPTION
### Summary

mocked `httpx.request` for evc removals / deploy test, turns out we had IO going on here. 

### Local Tests

With this PR on average tests are running in ~7s instead of ~23s

```

====================================================================================== 349 passed, 734 warnings in 7.15s ======================================================================================

```
```
===================================================================================== 349 passed, 734 warnings in 23.07s ======================================================================================

```

### End-to-End Tests

N/A
